### PR TITLE
feat(benchmarks): add the cross-lane reports package

### DIFF
--- a/benchmarks/reports/__init__.py
+++ b/benchmarks/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-lane benchmark reports: artifact-only, offline, no aggregate."""

--- a/benchmarks/reports/adversarial.py
+++ b/benchmarks/reports/adversarial.py
@@ -35,6 +35,7 @@ from protocol.offline import offline_guard
 from pydantic import Field, field_validator
 
 from .fairness import ReportModel, require_relative_path
+from .guards import refuse_aggregate
 
 #: The one accepted shape of a reviewer handle. This is an *allowlist of form*,
 #: not a name detector — nothing in this repository can tell whether a string is
@@ -492,7 +493,7 @@ def render_adversarial_packet(packet: AdversarialPacket) -> str:
             f"- {bound.question} → `{bound.artifact_path}`"
             for bound in packet.challenge_paths
         ]
-        return "\n".join(lines) + "\n"
+        return refuse_aggregate("\n".join(lines) + "\n")
 
 
 __all__ = [

--- a/benchmarks/reports/adversarial.py
+++ b/benchmarks/reports/adversarial.py
@@ -1,0 +1,515 @@
+"""The adversarial packet handed to a reviewer with no stake in the outcome.
+
+Nothing in the packet is a claim the generator makes on its own behalf. The
+pre-registration binding is derived from the ratification and amendment
+receipts, so it is the same identity every run manifest carries. The assumptions
+and confounds are the projector's own field declarations split by whether the
+field is observable at all, plus the two arguments the scenario's fairness packet
+already had to make — why the invariant is product-neutral, and what the public
+suites already cover. The suspicious-win flags are read off a validated cohort
+that the cohort validator has already normalized: a product row keeps its
+five-valued outcome and loses product-signal eligibility whenever a control
+reproduced the same assertion instance, and it is exactly those masked wins that
+a reviewer is asked to attack.
+
+A packet with no recorded review disposition renders as ``internal-diagnostic``.
+That is the whole point of the artifact: a comparative claim is not publishable
+until somebody who did not produce it has tried to break it.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Literal
+
+from epistemic.cohort import CONTROL_PROVIDERS, ValidatedEpistemicCohort
+from epistemic.schema import FairnessPacket
+from epistemic.snapshot import FieldDeclaration
+from protocol.contracts import derive_preregistration_identity
+from protocol.offline import offline_guard
+from pydantic import Field, field_validator
+
+from .fairness import ReportModel, require_relative_path
+
+#: The one accepted shape of a reviewer handle. This is an *allowlist of form*,
+#: not a name detector — nothing in this repository can tell whether a string is
+#: somebody's name. The repository privacy gate
+#: (``src/exomem/public_artifact_privacy.py``) finds absolute paths and Windows
+#: SIDs and nothing else, and the handle renders verbatim into the packet
+#: markdown, so a filter that merely rejected spaces would still pass
+#: ``hugo.kivi`` and ``hugoander@gmail.com``. Requiring the literal
+#: ``independent-reviewer:`` prefix and a lowercase ``[a-z0-9-]`` id after it
+#: leaves no room for a dotted name, an underscore, or an email address.
+_ALLOWED_REVIEWER_ID = re.compile(r"^independent-reviewer:[a-z0-9][a-z0-9-]*$")
+
+#: The label an unreviewed comparative artifact renders under. A document
+#: finalized without a recorded adversarial review disposition is a diagnostic,
+#: not a publication.
+INTERNAL_DIAGNOSTIC = "internal-diagnostic"
+
+
+class AdversarialPacketError(ValueError):
+    """The packet cannot be built as asked."""
+
+
+class ReviewerChallenge(ReportModel):
+    """One reviewer-checklist question, verbatim from the fairness contract."""
+
+    challenge_id: str = Field(min_length=1)
+    question: str = Field(min_length=1)
+
+
+#: The reviewer checklist of ``docs/benchmark-fairness-contract.md``, in document
+#: order and copied verbatim. The ids are stable handles for binding each
+#: question to the artifact a reviewer opens to answer it.
+REVIEWER_CHALLENGES: tuple[ReviewerChallenge, ...] = (
+    ReviewerChallenge(
+        challenge_id="config-provenance",
+        question="Does any competitor knob lack provenance? (automatic disqualification)",
+    ),
+    ReviewerChallenge(
+        challenge_id="equivalence-gate-diffs",
+        question=(
+            "Do the equivalence-gate diffs contain unexplained mismatches or expired "
+            "exceptions?"
+        ),
+    ),
+    ReviewerChallenge(
+        challenge_id="glue-size-asymmetry",
+        question="Are Exomem's projector/driver LOC materially larger than competitors'?",
+    ),
+    ReviewerChallenge(
+        challenge_id="environment-fault-scoring",
+        question="Did any row score a product where the manifest shows an environment fault?",
+    ),
+    ReviewerChallenge(
+        challenge_id="not-applicable-family",
+        question="Does any comparative claim rest on a family containing an N/A?",
+    ),
+    ReviewerChallenge(
+        challenge_id="privileged-call-receipt",
+        question=(
+            "Does every privileged call have an authenticated sandbox receipt and an "
+            "exact matrix entry, with capability gaps excluded rather than scored?"
+        ),
+    ),
+    ReviewerChallenge(
+        challenge_id="cohort-replay",
+        question=(
+            "Does every product/control cell replay from provider-bound evidence, and do "
+            "control passes disappear from every product-signal gate count?"
+        ),
+    ),
+    ReviewerChallenge(
+        challenge_id="judge-blinding",
+        question=(
+            "Is any judged number published without the structural-blinding fix and a "
+            "judge–human agreement measurement?"
+        ),
+    ),
+    ReviewerChallenge(
+        challenge_id="cost-envelope",
+        question="Does any cost claim include unmetered server-side extraction?",
+    ),
+    ReviewerChallenge(
+        challenge_id="latency-host",
+        question="Is any latency comparison rendered from the known-unvalidated host?",
+    ),
+)
+
+
+class AmendmentBinding(ReportModel):
+    """One ordered amendment receipt, as the folded chain records it."""
+
+    sequence: int = Field(ge=1)
+    receipt_path: str = Field(min_length=1)
+    receipt_sha256: str = Field(min_length=1)
+    parent_contract_sha256: str = Field(min_length=1)
+    contract_sha256: str = Field(min_length=1)
+    acknowledgment_status: str = Field(min_length=1)
+
+
+class PreregistrationBinding(ReportModel):
+    """The pre-registration hash and amendment chain the run executed against."""
+
+    contract_revision: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    #: The ratified document, before any amendment.
+    base_sha256: str = Field(min_length=1)
+    #: The effective document the ordered amendment chain culminates in.
+    sha256: str = Field(min_length=1)
+    amendments: tuple[AmendmentBinding, ...]
+
+
+class Assumption(ReportModel):
+    statement: str = Field(min_length=1)
+    status: str = Field(min_length=1)
+    mechanism: str | None = None
+    evidence: str = Field(min_length=1)
+
+
+class Confound(ReportModel):
+    statement: str = Field(min_length=1)
+    status: str = Field(min_length=1)
+    evidence: str = Field(min_length=1)
+
+
+class SuspiciousWinFlag(ReportModel):
+    """A product win on an assertion instance a control also scored."""
+
+    provider: str = Field(min_length=1)
+    variant: str = Field(min_length=1)
+    scenario_id: str = Field(min_length=1)
+    assertion: str = Field(min_length=1)
+    outcome: str = Field(min_length=1)
+    signal_disposition: str = Field(min_length=1)
+    controls_scoring: tuple[str, ...] = Field(min_length=1)
+
+
+class ChallengePath(ReportModel):
+    """One reviewer question bound to the artifact that answers it."""
+
+    challenge_id: str = Field(min_length=1)
+    question: str = Field(min_length=1)
+    artifact_path: str = Field(min_length=1)
+
+
+class Objection(ReportModel):
+    """One material objection, and what became of it.
+
+    The spec allows exactly two outcomes: an objection is either fixed or
+    documented with the publication. There is no third disposition, and no way
+    to record a review that simply ignored one.
+    """
+
+    text: str = Field(min_length=1)
+    status: Literal["fixed", "documented"]
+
+
+class ReviewDisposition(ReportModel):
+    """Evidence that an independent reviewer examined *these* packet bytes.
+
+    ``packet_sha256`` binds the disposition to the content it reviewed, computed
+    over the packet with this disposition removed. A packet whose content moved
+    after the review therefore renders as unreviewed: a stale review is no
+    review, and that is the whole reason the hash is here rather than a bare
+    "reviewed" flag that any later edit would silently inherit.
+    """
+
+    #: An ``independent-reviewer:<lane-or-run-id>`` handle, never a person.
+    reviewer_id: str = Field(min_length=1)
+    reviewed_at: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}$")
+    packet_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    objections: tuple[Objection, ...]
+
+    @field_validator("reviewer_id")
+    @classmethod
+    def _reviewer_id_has_the_allowed_form(cls, value: str) -> str:
+        if _ALLOWED_REVIEWER_ID.fullmatch(value) is None:
+            raise ValueError(
+                "reviewer_id must match the allowed handle form "
+                "'independent-reviewer:<lane-or-run-id>', where the id is "
+                "lowercase [a-z0-9-]; this is an allowlist of form, because "
+                "nothing downstream can recognise a personal name"
+            )
+        return value
+
+    @field_validator("reviewed_at")
+    @classmethod
+    def _reviewed_at_is_a_real_date(cls, value: str) -> str:
+        try:
+            datetime.date.fromisoformat(value)
+        except ValueError as error:
+            raise ValueError(f"reviewed_at must be a real calendar date: {value!r}") from error
+        return value
+
+
+class AdversarialPacket(ReportModel):
+    run_id: str = Field(min_length=1)
+    preregistration: PreregistrationBinding
+    assumptions: tuple[Assumption, ...]
+    confounds: tuple[Confound, ...]
+    suspicious_win_flags: tuple[SuspiciousWinFlag, ...]
+    challenge_paths: tuple[ChallengePath, ...] = Field(min_length=1)
+    review_disposition: ReviewDisposition | None = None
+
+
+def packet_content_sha256(packet: AdversarialPacket) -> str:
+    """The packet's content hash, excluding its own review disposition.
+
+    Excluding the disposition is what makes the binding usable at all: a
+    reviewer hashes what they read, then attaches the disposition carrying that
+    hash, and attaching it must not change the answer.
+    """
+
+    payload = packet.model_dump(mode="json")
+    payload.pop("review_disposition", None)
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _preregistration_binding(repo_root: Path | str) -> PreregistrationBinding:
+    identity = derive_preregistration_identity(repo_root)
+    return PreregistrationBinding(
+        contract_revision=identity.contract_revision,
+        path=identity.original.path,
+        base_sha256=identity.original.sha256,
+        sha256=identity.effective.sha256,
+        amendments=tuple(
+            AmendmentBinding(
+                sequence=amendment.sequence,
+                receipt_path=amendment.receipt.receipt_path,
+                receipt_sha256=amendment.receipt.receipt_sha256,
+                parent_contract_sha256=amendment.parent_contract_sha256,
+                contract_sha256=amendment.contract.sha256,
+                acknowledgment_status=amendment.acknowledgment_status,
+            )
+            for amendment in identity.amendments
+        ),
+    )
+
+
+def _assumptions(
+    declarations: Iterable[FieldDeclaration], packet: FairnessPacket
+) -> tuple[Assumption, ...]:
+    """Every observable field is an assumption the comparison rests on."""
+
+    found = [
+        Assumption(
+            statement=f"{declaration.field!r} is observable for this row",
+            status=declaration.status,
+            mechanism=declaration.mechanism,
+            evidence=declaration.evidence,
+        )
+        for declaration in declarations
+        if declaration.observable
+    ]
+    found.append(
+        Assumption(
+            statement=packet.why_neutral.strip(),
+            status="fairness-packet",
+            evidence="fairness packet: why_neutral",
+        )
+    )
+    return tuple(found)
+
+
+def _confounds(
+    declarations: Iterable[FieldDeclaration], packet: FairnessPacket
+) -> tuple[Confound, ...]:
+    """Every field that cannot be evaluated confounds the comparison."""
+
+    found = [
+        Confound(
+            statement=f"{declaration.field!r} cannot be evaluated ({declaration.status})",
+            status=declaration.status,
+            evidence=declaration.evidence,
+        )
+        for declaration in declarations
+        if not declaration.observable
+    ]
+    found.append(
+        Confound(
+            statement=packet.public_coverage_subtraction.strip(),
+            status="fairness-packet",
+            evidence="fairness packet: public_coverage_subtraction",
+        )
+    )
+    return tuple(found)
+
+
+def _identity_key(cell) -> tuple:
+    return tuple(cell.identity.model_dump(mode="json").items())
+
+
+def _suspicious_win_flags(cohort: ValidatedEpistemicCohort) -> tuple[SuspiciousWinFlag, ...]:
+    """Product passes the controls reproduced, in cohort order."""
+
+    control_passes: dict[tuple, list[str]] = {}
+    for row in cohort.rows:
+        if row.provider not in CONTROL_PROVIDERS:
+            continue
+        for cell in row.assertions:
+            if cell.result.outcome == "pass":
+                control_passes.setdefault(_identity_key(cell), []).append(row.provider)
+
+    flags: list[SuspiciousWinFlag] = []
+    for row in cohort.rows:
+        if row.provider in CONTROL_PROVIDERS:
+            continue
+        for cell in row.assertions:
+            scoring = control_passes.get(_identity_key(cell))
+            if cell.result.outcome != "pass" or not scoring:
+                continue
+            flags.append(
+                SuspiciousWinFlag(
+                    provider=row.provider,
+                    variant=row.variant,
+                    scenario_id=cell.identity.scenario_id,
+                    assertion=cell.identity.assertion,
+                    outcome=cell.result.outcome,
+                    signal_disposition=cell.signal_disposition,
+                    controls_scoring=tuple(
+                        name for name in CONTROL_PROVIDERS if name in scoring
+                    ),
+                )
+            )
+    return tuple(flags)
+
+
+def _challenge_paths(artifacts: Mapping[str, str]) -> tuple[ChallengePath, ...]:
+    missing = [
+        challenge.challenge_id
+        for challenge in REVIEWER_CHALLENGES
+        if not artifacts.get(challenge.challenge_id)
+    ]
+    if missing:
+        raise AdversarialPacketError(
+            "every reviewer challenge needs the artifact that answers it; "
+            f"unbound: {', '.join(missing)}"
+        )
+    bound: list[ChallengePath] = []
+    for challenge in REVIEWER_CHALLENGES:
+        raw = artifacts[challenge.challenge_id]
+        try:
+            path = require_relative_path(
+                raw, label=f"the {challenge.challenge_id} challenge artifact"
+            )
+        except ValueError as error:
+            raise AdversarialPacketError(str(error)) from error
+        bound.append(
+            ChallengePath(
+                challenge_id=challenge.challenge_id,
+                question=challenge.question,
+                artifact_path=path,
+            )
+        )
+    return tuple(bound)
+
+
+def build_adversarial_packet(
+    *,
+    run_id: str,
+    repo_root: Path | str,
+    fairness: FairnessPacket,
+    declarations: Iterable[FieldDeclaration],
+    cohort: ValidatedEpistemicCohort,
+    challenge_artifacts: Mapping[str, str],
+    review_disposition: ReviewDisposition | None = None,
+) -> AdversarialPacket:
+    """Assemble the packet an independent reviewer is given, from artifacts alone."""
+
+    with offline_guard():
+        declared = tuple(declarations)
+        return AdversarialPacket(
+            run_id=run_id,
+            preregistration=_preregistration_binding(repo_root),
+            assumptions=_assumptions(declared, fairness),
+            confounds=_confounds(declared, fairness),
+            suspicious_win_flags=_suspicious_win_flags(cohort),
+            challenge_paths=_challenge_paths(challenge_artifacts),
+            review_disposition=review_disposition,
+        )
+
+
+def render_adversarial_packet(packet: AdversarialPacket) -> str:
+    """Render the packet as markdown, labelled by its review disposition."""
+
+    with offline_guard():
+        lines: list[str] = [f"# Adversarial packet — run {packet.run_id}", ""]
+        disposition = packet.review_disposition
+        if disposition is None:
+            lines.append(
+                f"**{INTERNAL_DIAGNOSTIC}** — no adversarial review disposition is "
+                "recorded, so nothing here is publishable as a comparative claim."
+            )
+        elif disposition.packet_sha256 != packet_content_sha256(packet):
+            lines.append(
+                f"**{INTERNAL_DIAGNOSTIC}** — the recorded review is bound to "
+                f"`{disposition.packet_sha256}`, but this packet hashes to "
+                f"`{packet_content_sha256(packet)}`. A stale review is no review."
+            )
+        else:
+            lines += [
+                f"**Reviewed** by `{disposition.reviewer_id}` on "
+                f"{disposition.reviewed_at}, bound to `{disposition.packet_sha256}`.",
+                "",
+                "### Objections",
+                "",
+            ]
+            if disposition.objections:
+                lines += [
+                    f"- [{objection.status}] {objection.text}"
+                    for objection in disposition.objections
+                ]
+            else:
+                lines.append("- none raised")
+        lines += [
+            "",
+            "## Pre-registration",
+            "",
+            f"- contract revision: `{packet.preregistration.contract_revision}`",
+            f"- document: `{packet.preregistration.path}`",
+            f"- ratified sha256: `{packet.preregistration.base_sha256}`",
+            f"- effective sha256: `{packet.preregistration.sha256}`",
+        ]
+        for amendment in packet.preregistration.amendments:
+            lines.append(
+                f"- amendment {amendment.sequence} ({amendment.acknowledgment_status}): "
+                f"`{amendment.receipt_path}` → `{amendment.contract_sha256}`"
+            )
+
+        lines += ["", "## Assumptions", ""]
+        lines += [
+            f"- [{item.status}] {item.statement} ({item.evidence})"
+            for item in packet.assumptions
+        ]
+        lines += ["", "## Confounds", ""]
+        lines += [
+            f"- [{item.status}] {item.statement} ({item.evidence})"
+            for item in packet.confounds
+        ]
+
+        lines += ["", "## Suspicious wins", ""]
+        if packet.suspicious_win_flags:
+            lines += [
+                f"- {flag.provider}/{flag.variant} {flag.assertion} in "
+                f"{flag.scenario_id}: {flag.outcome} with "
+                f"{flag.signal_disposition}; controls scoring: "
+                f"{', '.join(flag.controls_scoring)}"
+                for flag in packet.suspicious_win_flags
+            ]
+        else:
+            lines.append("- none: no product win was reproduced by a control")
+
+        lines += ["", "## Challenge artifacts", ""]
+        lines += [
+            f"- {bound.question} → `{bound.artifact_path}`"
+            for bound in packet.challenge_paths
+        ]
+        return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "INTERNAL_DIAGNOSTIC",
+    "REVIEWER_CHALLENGES",
+    "AdversarialPacket",
+    "AdversarialPacketError",
+    "AmendmentBinding",
+    "Assumption",
+    "ChallengePath",
+    "Confound",
+    "Objection",
+    "PreregistrationBinding",
+    "ReviewDisposition",
+    "ReviewerChallenge",
+    "SuspiciousWinFlag",
+    "build_adversarial_packet",
+    "packet_content_sha256",
+    "render_adversarial_packet",
+]

--- a/benchmarks/reports/compat.py
+++ b/benchmarks/reports/compat.py
@@ -1,0 +1,307 @@
+"""The compat matrix: what a row declared against what the run observed.
+
+The declared side is the scenario's own fairness packet — the closed
+``driver_surface_id × provider × variant`` matrix and its dispositions, plus the
+projector's field-declaration statuses and the registered variant vocabulary of
+the programme design. The observed side is the run: the variant the runner bound
+and wrote into the manifest, the provider that variant belongs to, the readiness
+the manifest recorded, and the manifest's own terminal status.
+
+Every declared≠observed cell is a first-class :class:`Divergence`. Two kinds are
+*validity* failures rather than findings — presenting a result under a variant
+identity, or under a provider, that differs from the manifest's registered one —
+and so is a run the protocol did not mark VALID: an environment fault invalidates
+the affected rows instead of scoring against the product. A declared-equivalent
+surface whose readiness never verified is a finding a reviewer must read, but it
+does not by itself re-label the run.
+
+Building from a non-VALID manifest stays allowed, because a diagnostic read of a
+failed run is exactly what a reviewer needs; the rendered matrix carries the
+status and its reason so it can never be mistaken for a publishable result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+
+from epistemic.schema import FairnessPacket
+from epistemic.snapshot import FieldDeclaration
+from protocol.models import ManifestStatus, RunManifest
+from protocol.offline import offline_guard
+from pydantic import Field
+
+from .fairness import ReportModel, require_relative_path
+
+#: The registered provider variants of the programme design, grouped by the
+#: provider each belongs to. Hosted and local variants of one product are
+#: separate identities and never collapse into one row; the names are the
+#: design's own and no new one is minted here.
+VARIANTS_BY_PROVIDER: dict[str, frozenset[str]] = {
+    "exomem": frozenset({"exomem-source-only", "exomem-controlled", "exomem-native"}),
+    "basic-memory": frozenset(
+        {"basic-memory-controlled", "basic-memory-native-git", "basic-memory-native-nogit"}
+    ),
+    "supermemory": frozenset(
+        {
+            "supermemory-hosted-memorybench",
+            "supermemory-hosted-native",
+            "supermemory-local-controlled",
+            "supermemory-local-native",
+            "supermemory-local-documents-v3",
+        }
+    ),
+    "hybrid-rag-control": frozenset({"hybrid-rag-control"}),
+    "grep-markdown": frozenset({"grep-markdown"}),
+    "no-memory": frozenset({"no-memory"}),
+}
+
+#: Every registered variant identity, flattened.
+VARIANT_VOCABULARY: frozenset[str] = frozenset(
+    name for names in VARIANTS_BY_PROVIDER.values() for name in names
+)
+
+#: ``(provider, variant, driver_surface_id)`` — one declared audit cell.
+CompatKey = tuple[str, str, str]
+
+DivergenceKind = Literal["variant", "provider", "capability"]
+
+#: Divergences that make a result invalid rather than merely notable.
+INVALIDATING_KINDS: frozenset[str] = frozenset({"variant", "provider"})
+
+#: Rendered when the observed variant is not a registered identity, so the
+#: provider behind it cannot be derived and the comparison cannot be made.
+PROVIDER_COMPARISON_IMPOSSIBLE = "provider comparison not possible"
+
+
+class CompatMatrixError(ValueError):
+    """The run cannot be compared against its declarations as it stands."""
+
+
+def provider_of_variant(variant: str) -> str | None:
+    """The provider a registered variant belongs to, or ``None`` if unregistered."""
+
+    for provider, names in VARIANTS_BY_PROVIDER.items():
+        if variant in names:
+            return provider
+    return None
+
+
+class Divergence(ReportModel):
+    """One declared≠observed cell, with the artifact a reviewer opens."""
+
+    kind: DivergenceKind
+    key: CompatKey
+    declared: str = Field(min_length=1)
+    observed: str = Field(min_length=1)
+    evidence_path: str = Field(min_length=1)
+
+
+class CompatCell(ReportModel):
+    """One declared surface, carrying what the run actually showed."""
+
+    provider: str = Field(min_length=1)
+    variant: str = Field(min_length=1)
+    driver_surface_id: str = Field(min_length=1)
+    declared_disposition: Literal["equivalent", "capability_gap"]
+    #: Whether the declared identity is one of :data:`VARIANT_VOCABULARY`.
+    declared_variant_registered: bool
+    observed_variant: str = Field(min_length=1)
+    #: Whether the *observed* identity is registered — spec :61-66 asks for the
+    #: registered identity in every artifact, which includes this side.
+    observed_variant_registered: bool
+    #: The provider the observed variant belongs to; ``None`` when the observed
+    #: identity is unregistered and the provider therefore cannot be derived.
+    observed_provider: str | None = None
+    observed_readiness_verified: bool
+    evidence_path: str = Field(min_length=1)
+
+    @property
+    def key(self) -> CompatKey:
+        return (self.provider, self.variant, self.driver_surface_id)
+
+
+class CompatMatrix(ReportModel):
+    run_id: str = Field(min_length=1)
+    observed_variant: str = Field(min_length=1)
+    #: The manifest's terminal status. A run the protocol did not mark VALID
+    #: never yields a publishable comparative row (spec :26-30, :37-40).
+    run_status: ManifestStatus
+    invalid_reason: str | None = None
+    #: The projector's declaration statuses, sorted and de-duplicated.
+    declared_field_statuses: tuple[str, ...]
+    cells: tuple[CompatCell, ...] = Field(min_length=1)
+    divergences: tuple[Divergence, ...]
+
+    def invalidates(self) -> bool:
+        """True when this matrix may not be read as a comparable result."""
+
+        if self.run_status != "VALID":
+            return True
+        return any(item.kind in INVALIDATING_KINDS for item in self.divergences)
+
+
+def build_compat_matrix(
+    *,
+    packet: FairnessPacket,
+    manifest: RunManifest,
+    declarations: Iterable[FieldDeclaration],
+    manifest_ref: str = "manifest.json",
+) -> CompatMatrix:
+    """Compare one scenario's declarations against one run's manifest."""
+
+    with offline_guard():
+        observed = manifest.provider_variant
+        if not observed:
+            raise CompatMatrixError(
+                "compat requires the observed variant the runner bound into the manifest; "
+                f"run {manifest.run_id} recorded none"
+            )
+        if not packet.privileged_endpoint_matrix:
+            raise CompatMatrixError(
+                "compat requires a non-empty privileged endpoint matrix; the fairness "
+                f"packet for run {manifest.run_id} declares no audited surface"
+            )
+        evidence_path = require_relative_path(manifest_ref, label="the compat evidence path")
+
+        observed_registered = observed in VARIANT_VOCABULARY
+        observed_provider = provider_of_variant(observed)
+
+        lanes = [lane for lane in manifest.readiness if lane.lane == observed]
+        unverified = [lane for lane in lanes if not lane.verified]
+        readiness_verified = bool(lanes) and not unverified
+        readiness_observed = (
+            "readiness verified"
+            if readiness_verified
+            else "readiness unverified: "
+            + (
+                "; ".join(lane.evidence for lane in unverified)
+                if unverified
+                else f"no readiness lane recorded for {observed}"
+            )
+        )
+
+        cells: list[CompatCell] = []
+        divergences: list[Divergence] = []
+        for entry in packet.privileged_endpoint_matrix:
+            cell = CompatCell(
+                provider=entry.provider,
+                variant=entry.variant,
+                driver_surface_id=entry.driver_surface_id,
+                declared_disposition=entry.disposition,
+                declared_variant_registered=entry.variant in VARIANT_VOCABULARY,
+                observed_variant=observed,
+                observed_variant_registered=observed_registered,
+                observed_provider=observed_provider,
+                observed_readiness_verified=readiness_verified,
+                evidence_path=evidence_path,
+            )
+            cells.append(cell)
+            if entry.variant != observed:
+                divergences.append(
+                    Divergence(
+                        kind="variant",
+                        key=cell.key,
+                        declared=entry.variant,
+                        observed=observed,
+                        evidence_path=evidence_path,
+                    )
+                )
+            if observed_provider is not None and entry.provider != observed_provider:
+                divergences.append(
+                    Divergence(
+                        kind="provider",
+                        key=cell.key,
+                        declared=entry.provider,
+                        observed=observed_provider,
+                        evidence_path=evidence_path,
+                    )
+                )
+            if entry.disposition == "equivalent" and not readiness_verified:
+                divergences.append(
+                    Divergence(
+                        kind="capability",
+                        key=cell.key,
+                        declared="equivalent",
+                        observed=readiness_observed,
+                        evidence_path=evidence_path,
+                    )
+                )
+
+        return CompatMatrix(
+            run_id=manifest.run_id,
+            observed_variant=observed,
+            run_status=manifest.status,
+            invalid_reason=manifest.invalid_reason,
+            declared_field_statuses=tuple(
+                sorted({declaration.status for declaration in declarations})
+            ),
+            cells=tuple(sorted(cells, key=lambda cell: cell.key)),
+            divergences=tuple(sorted(divergences, key=lambda item: (item.kind, item.key))),
+        )
+
+
+def render_compat_matrix(matrix: CompatMatrix) -> str:
+    """Render the matrix as markdown, led by the status that governs its use."""
+
+    with offline_guard():
+        verdict = "INVALID — not a publishable comparative result" if matrix.invalidates() else "comparable"
+        lines = [
+            f"# Compat matrix — run {matrix.run_id}",
+            "",
+            f"- run status: **{matrix.run_status}**",
+            f"- disposition: **{verdict}**",
+        ]
+        if matrix.invalid_reason:
+            lines.append(f"- invalid reason: {matrix.invalid_reason}")
+        lines.append(f"- observed variant: `{matrix.observed_variant}`")
+        if matrix.cells and matrix.cells[0].observed_provider is None:
+            lines.append(
+                f"- observed provider: unregistered variant identity — "
+                f"{PROVIDER_COMPARISON_IMPOSSIBLE}"
+            )
+        else:
+            lines.append(f"- observed provider: `{matrix.cells[0].observed_provider}`")
+        lines.append(f"- declared field statuses: {', '.join(matrix.declared_field_statuses)}")
+
+        lines += [
+            "",
+            "| provider | variant | surface | disposition | declared registered | "
+            "observed registered | readiness |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        for cell in matrix.cells:
+            lines.append(
+                f"| {cell.provider} | {cell.variant} | {cell.driver_surface_id} | "
+                f"{cell.declared_disposition} | {cell.declared_variant_registered} | "
+                f"{cell.observed_variant_registered} | "
+                f"{'verified' if cell.observed_readiness_verified else 'unverified'} |"
+            )
+
+        lines += ["", "## Divergences", ""]
+        if matrix.divergences:
+            lines += [
+                f"- [{item.kind}] {' / '.join(item.key)}: declared {item.declared!r}, "
+                f"observed {item.observed!r} (`{item.evidence_path}`)"
+                for item in matrix.divergences
+            ]
+        else:
+            lines.append("- none")
+        return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "INVALIDATING_KINDS",
+    "PROVIDER_COMPARISON_IMPOSSIBLE",
+    "VARIANTS_BY_PROVIDER",
+    "VARIANT_VOCABULARY",
+    "CompatCell",
+    "CompatKey",
+    "CompatMatrix",
+    "CompatMatrixError",
+    "Divergence",
+    "DivergenceKind",
+    "build_compat_matrix",
+    "provider_of_variant",
+    "render_compat_matrix",
+]

--- a/benchmarks/reports/compat.py
+++ b/benchmarks/reports/compat.py
@@ -18,6 +18,10 @@ does not by itself re-label the run.
 Building from a non-VALID manifest stays allowed, because a diagnostic read of a
 failed run is exactly what a reviewer needs; the rendered matrix carries the
 status and its reason so it can never be mistaken for a publishable result.
+That this accepts a manifest ``consolidate`` refuses at load time is intended and
+not a gap to close: publication is gated by ``consolidate``'s load-time refusal,
+while this layer stays readable for diagnosis and withholds publishability
+through :meth:`CompatMatrix.invalidates` instead.
 """
 
 from __future__ import annotations
@@ -32,6 +36,7 @@ from protocol.offline import offline_guard
 from pydantic import Field
 
 from .fairness import ReportModel, require_relative_path
+from .guards import refuse_aggregate
 
 #: The registered provider variants of the programme design, grouped by the
 #: provider each belongs to. Hosted and local variants of one product are
@@ -287,7 +292,7 @@ def render_compat_matrix(matrix: CompatMatrix) -> str:
             ]
         else:
             lines.append("- none")
-        return "\n".join(lines) + "\n"
+        return refuse_aggregate("\n".join(lines) + "\n")
 
 
 __all__ = [

--- a/benchmarks/reports/consolidate.py
+++ b/benchmarks/reports/consolidate.py
@@ -1,0 +1,162 @@
+"""Artifact-only, offline consolidation of one or more completed runs.
+
+    python -m benchmarks.reports.consolidate --run <dir> [--run <dir>...] --out <dir>
+
+Before rendering anything, re-reads and re-hashes every pre-registration
+receipt through ``protocol.contracts.derive_preregistration_identity`` --
+never trusting a run's own claimed identity -- and writes it (sha256 plus the
+ordered amendment chain) into ``consolidated.json``. Refuses any non-terminal
+manifest or unknown ``schema_version`` (via ``reports.render.render_all``),
+runs entirely under ``offline_guard``, and writes ``consolidated.json`` then
+``report.md`` into ``--out`` on success only: exit 0 (identity first, so a
+failure between the two writes can never leave a report standing without the
+identity it was rendered against). On refusal it prints one line to stderr,
+exits non-zero, and writes nothing. It never mutates a run directory.
+
+Each ``--run`` directory is classified independently for two purposes that
+are not mutually exclusive: its LME manifest or Epistemic cohort (at most
+one of the two -- carrying both is refused as ambiguous) feeds
+``render_all``'s per-ability / per-scenario sections, and a
+``memorybench-export.v1.json`` alongside either of those (or on its own)
+feeds a ``ProviderLatency`` observation into ``render_all``'s ``latency``
+parameter -- the wiring 9.1's cross-provider latency refusal needs to ever
+run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# ``python -m benchmarks.reports.consolidate`` starts with the repository
+# root on sys.path, while the reused lane renderers are intentionally
+# importable as ``protocol``/``lme``/``epistemic`` from the benchmarks
+# directory (tests/conftest.py already installs this same path for pytest;
+# this entrypoint does it explicitly for a standalone run). Mirrors
+# benchmarks/lme/cli.py's identical sys.path insert.
+_BENCHMARKS_ROOT = Path(__file__).resolve().parents[1]
+if str(_BENCHMARKS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCHMARKS_ROOT))
+
+from protocol.contracts import derive_preregistration_identity  # noqa: E402
+from protocol.models import MemoryBenchExport  # noqa: E402
+from protocol.offline import offline_guard  # noqa: E402
+
+from .latency import ProviderLatency  # noqa: E402
+from .render import EpistemicCohort, LmeRun, ReportInput, render_all  # noqa: E402
+
+_REPO_ROOT = _BENCHMARKS_ROOT.parent
+
+#: The stored, validated cohort artifact name persist_validated_cohort writes
+#: (epistemic.report._load_stored_cohort_without_trusting_claims's sole input
+#: shape) -- used only to recognize which lane a --run directory belongs to.
+_EPISTEMIC_COHORT_NAME = "validated-cohort.v1.json"
+
+#: The MemoryBench export artifact name memorybench/export.py's real writer
+#: uses (benchmarks/memorybench/export.py:1693: `write(output_root /
+#: "memorybench-export.v1.json", ...)`).
+_MEMORYBENCH_EXPORT_NAME = "memorybench-export.v1.json"
+
+
+def _classify(run_dir: Path) -> ReportInput | None:
+    """Which lane renders `run_dir`'s own section, or None for a directory
+    that carries no LME/Epistemic artifact of its own -- a MemoryBench
+    export sitting alone, latency-only, handled by `_latency_observation`."""
+
+    has_manifest = (run_dir / "manifest.json").is_file()
+    cohort_path = run_dir / _EPISTEMIC_COHORT_NAME
+    has_cohort = cohort_path.is_file()
+    if has_manifest and has_cohort:
+        raise ValueError(
+            f"{run_dir}: carries both an LME manifest and an epistemic cohort -- ambiguous"
+        )
+    if has_manifest:
+        return LmeRun(run_dir=run_dir)
+    if has_cohort:
+        return EpistemicCohort(cohort_path=cohort_path, run_root=run_dir)
+    if (run_dir / _MEMORYBENCH_EXPORT_NAME).is_file():
+        return None
+    raise ValueError(f"{run_dir}: not a recognized run artifact directory")
+
+
+def _latency_observation(run_dir: Path) -> ProviderLatency | None:
+    """Read `run_dir`'s MemoryBench export latency flag, if it carries one.
+
+    Validates the WHOLE export through the real `MemoryBenchExport` model --
+    not just its `latency` sub-object -- so an export with an unknown
+    `schema_version`, a wrong `artifact_type`, or any other malformed shape
+    is refused exactly like a non-terminal/unknown-schema_version LME
+    manifest is (benchmark-protocol/spec.md:63-90; D3): a pydantic
+    `ValidationError` propagates as a refusal (consolidate() writes nothing,
+    main() exits non-zero), never swallowed into a raw `KeyError` that could
+    let a malformed export render a latency row.
+
+    The export never carries a millisecond figure (protocol.models.
+    MemoryBenchExport has no such field -- membench's own numbers live in a
+    lane this package does not read), so `value_ms` is always None from this
+    source; see reports/latency.py::ProviderLatency's docstring.
+    """
+
+    export_path = run_dir / _MEMORYBENCH_EXPORT_NAME
+    if not export_path.is_file():
+        return None
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+    export = MemoryBenchExport.model_validate(payload)
+    return ProviderLatency(provider=export.provider, latency=export.latency)
+
+
+def consolidate(run_dirs: list[Path], out_dir: Path, *, repo_root: Path | None = None) -> None:
+    """Render `run_dirs` and write consolidated.json + report.md into `out_dir`.
+
+    Raises (writing nothing) on any refusal -- a non-terminal manifest, an
+    unknown schema_version, an unrecognized or ambiguous run directory, or a
+    pre-registration identity that fails to re-derive. `out_dir` is touched
+    only after every input has rendered and the identity has re-derived
+    successfully; consolidated.json is written before report.md.
+    """
+
+    root = repo_root or _REPO_ROOT
+    inputs: list[ReportInput] = []
+    latency: list[ProviderLatency] = []
+    for run_dir in run_dirs:
+        classified = _classify(run_dir)
+        if classified is not None:
+            inputs.append(classified)
+        observation = _latency_observation(run_dir)
+        if observation is not None:
+            latency.append(observation)
+    with offline_guard():
+        report = render_all(inputs, latency=latency)
+        identity = derive_preregistration_identity(root)
+    payload = {
+        "runs": [str(run_dir) for run_dir in run_dirs],
+        "preregistration_identity": identity.model_dump(mode="json"),
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "consolidated.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (out_dir / "report.md").write_text(report, encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument("--run", action="append", dest="runs", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        consolidate(list(args.runs), args.out)
+    except Exception as exc:  # noqa: BLE001 -- CLI boundary: one-line refusal reason
+        print(f"refused: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/reports/fairness.py
+++ b/benchmarks/reports/fairness.py
@@ -1,0 +1,364 @@
+"""The fairness matrix: one disclosed row per lane × provider × variant.
+
+The eight published fields are exactly the table of
+``docs/benchmark-fairness-contract.md`` — :data:`FAIRNESS_MATRIX_FIELDS` pairs
+each published label with the attribute that carries it, and the row model
+declares them in that order and no other. Nothing here is optional: the spec
+sentence is that every lane's entry *SHALL* record what this repository
+authored, who authored each configuration value, the asymmetries with their
+direction, the pins, and the blocked measurements. A field with a default would
+let a row be published while saying nothing, which is the failure this matrix
+exists to prevent.
+
+Emptiness is the same failure wearing a different hat. A row with no pins and no
+asymmetries reads as "nothing to declare" whether that was surveyed or merely
+skipped, so each such field carries a companion in
+:data:`EMPTY_DISCLOSURE_REASONS`: leave the field empty and you must say why, in
+words, and you may not do both. "None declared" is a claim somebody makes.
+
+The glue accounting is not restated either: it is :meth:`Projector.meta`'s own
+published numbers, and the projector's module path must appear among the
+disclosed files, so the LOC number is provably about a file the row discloses
+rather than about something the reader cannot see.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Literal
+
+from epistemic.snapshot import FieldDeclaration, ProjectorMeta, parse_evidence_citation
+from protocol.models import LaneReadiness
+from protocol.offline import offline_guard
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+#: ``(published label, attribute)`` for the fairness-matrix row of
+#: ``docs/benchmark-fairness-contract.md``. The labels are copied from the
+#: document, not paraphrased, and :class:`FairnessRow` declares the attributes in
+#: this order after its ``(lane, provider, variant)`` key.
+FAIRNESS_MATRIX_FIELDS: tuple[tuple[str, str], ...] = (
+    ("config source", "config_source"),
+    ("config authored by", "config_authored_by"),
+    ("exomem-authored glue", "exomem_authored_glue"),
+    ("asymmetries", "asymmetries"),
+    ("capability declarations", "capability_declarations"),
+    ("readiness", "readiness"),
+    ("pins", "pins"),
+    ("blocked measurements", "blocked_measurements"),
+)
+
+#: ``(published field, companion reason)``. A published field that may legitimately
+#: be empty must say so explicitly rather than defaulting into silence.
+EMPTY_DISCLOSURE_REASONS: tuple[tuple[str, str], ...] = (
+    ("config_source", "no_config_source_reason"),
+    ("asymmetries", "no_asymmetries_reason"),
+    ("pins", "no_pins_reason"),
+    ("blocked_measurements", "no_blocked_measurements_reason"),
+)
+
+#: The three authorship values the contract publishes for a configuration value.
+ConfigAuthor = Literal["competitor", "exomem", "shared-harness"]
+
+#: ``(lane, provider, variant)`` — the key every comparative row is rendered at.
+FairnessKey = tuple[str, str, str]
+
+
+class FairnessMatrixError(ValueError):
+    """The matrix cannot be published as it stands."""
+
+
+class ReportModel(BaseModel):
+    """Strict, frozen, ``extra='forbid'`` — a published row never mutates."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+
+def require_relative_path(value: str, *, label: str) -> str:
+    """Return ``value`` when it is a run-root-relative path, else raise.
+
+    An absolute path in a published artifact leaks the machine that produced it,
+    and a traversal escapes the run root a reviewer was handed.
+    """
+
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{label} must be a relative path under the run root")
+    if PurePosixPath(text).is_absolute() or PureWindowsPath(text).is_absolute():
+        raise ValueError(f"{label} must be relative to the run root, not {text!r}")
+    if ".." in PurePosixPath(text).parts:
+        raise ValueError(f"{label} must be relative to the run root without traversal")
+    return text
+
+
+def _require_citation_or_url(value: str, *, label: str) -> str:
+    """A provenance value is a ``path:line`` citation or a documentation URL."""
+
+    text = value.strip()
+    if text.startswith(("http://", "https://")):
+        return text
+    if parse_evidence_citation(text) is None:
+        raise ValueError(f"{label} {value!r} is neither a path:line citation nor a URL")
+    return text
+
+
+class Asymmetry(ReportModel):
+    """One known asymmetry, with the direction it favours.
+
+    Reported, an asymmetry is a result; unreported, it is a defect — so the
+    direction is required rather than inferred.
+    """
+
+    description: str = Field(min_length=1)
+    favours: str = Field(min_length=1)
+    evidence: str = Field(min_length=1)
+
+
+class GlueAccounting(ReportModel):
+    """What this repository authored for the row: files, LOC, endpoints.
+
+    The numbers come from :meth:`Projector.meta`, and ``projector_module`` names
+    the module they were measured over — which must be one of ``files``, so the
+    published LOC is about disclosed code.
+    """
+
+    files: tuple[str, ...] = Field(min_length=1)
+    projector: ProjectorMeta
+    projector_module: str = Field(min_length=1)
+    reviewer_disposition: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _paths_are_relative_and_the_module_is_disclosed(self) -> GlueAccounting:
+        for path in self.files:
+            require_relative_path(path, label="an exomem-authored glue file")
+        require_relative_path(self.projector_module, label="the projector module")
+        if self.projector_module not in self.files:
+            raise ValueError(
+                "the projector module whose LOC is published must appear in the "
+                f"disclosed files: {self.projector_module!r} is not among {list(self.files)}"
+            )
+        return self
+
+    @classmethod
+    def for_projector(
+        cls,
+        projector,
+        *,
+        repo_root: Path | str,
+        reviewer_disposition: str,
+        files: Iterable[str] = (),
+    ) -> GlueAccounting:
+        """Derive the accounting from a real projector, so the two cannot disagree."""
+
+        source = inspect.getsourcefile(type(projector))
+        if source is None:  # pragma: no cover - a projector always has a module
+            raise ValueError("the projector has no source module to account for")
+        module = Path(source).resolve().relative_to(Path(repo_root).resolve()).as_posix()
+        return cls(
+            files=tuple(dict.fromkeys((module, *files))),
+            projector=projector.meta(),
+            projector_module=module,
+            reviewer_disposition=reviewer_disposition,
+        )
+
+
+class CapabilityDeclarationCounts(ReportModel):
+    """N/A, ``absent_by_design`` and ``unavailable`` counts for one row.
+
+    ``not_applicable`` is deliberately not a synonym for ``absent_by_design``:
+    a designed absence the product itself markets scores ``fail`` rather than
+    N/A (``benchmarks/epistemic/assertions.py`` lines 427-441), so a row whose
+    two counts differ is disclosing exactly that claim-conditioned gap.
+    """
+
+    not_applicable: int = Field(ge=0)
+    absent_by_design: int = Field(ge=0)
+    unavailable: int = Field(ge=0)
+
+    @classmethod
+    def from_declarations(
+        cls, declarations: Iterable[FieldDeclaration]
+    ) -> CapabilityDeclarationCounts:
+        declared = tuple(declarations)
+        by_design = [item for item in declared if item.status == "absent_by_design"]
+        unavailable = [item for item in declared if item.status == "unavailable"]
+        return cls(
+            not_applicable=sum(1 for item in by_design if item.marketing_claim is None),
+            absent_by_design=len(by_design),
+            unavailable=len(unavailable),
+        )
+
+
+class BlockedMeasurement(ReportModel):
+    """A measurement this row could not take, and the one command that unblocks it."""
+
+    measurement: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+    unblock_command: str = Field(min_length=1)
+
+
+class FairnessRow(ReportModel):
+    """One fairness-matrix entry, keyed by ``(lane, provider, variant)``."""
+
+    lane: str = Field(min_length=1)
+    provider: str = Field(min_length=1)
+    variant: str = Field(min_length=1)
+
+    #: file:line / URL for every competitor-side setting.
+    config_source: dict[str, str]
+    #: competitor · exomem (disclosed) · shared harness.
+    config_authored_by: dict[str, ConfigAuthor]
+    #: file list + LOC + endpoints + reviewer disposition.
+    exomem_authored_glue: GlueAccounting
+    #: enumerated, each with direction (favours whom).
+    asymmetries: tuple[Asymmetry, ...]
+    #: N/A, absent_by_design, unavailable counts.
+    capability_declarations: CapabilityDeclarationCounts
+    #: verification method + evidence path (or readiness-unverifiable).
+    readiness: tuple[LaneReadiness, ...] = Field(min_length=1)
+    #: product version/commit/binary, dataset sha, model ids.
+    pins: dict[str, str]
+    #: with reasons and one-command unblock paths.
+    blocked_measurements: tuple[BlockedMeasurement, ...]
+
+    #: Companions for the fields above that may legitimately be empty. Exactly
+    #: one of (entries, reason) is present for each.
+    no_config_source_reason: str | None = None
+    no_asymmetries_reason: str | None = None
+    no_pins_reason: str | None = None
+    no_blocked_measurements_reason: str | None = None
+
+    @property
+    def key(self) -> FairnessKey:
+        return (self.lane, self.provider, self.variant)
+
+    def disclosure_for(self, attribute: str) -> object:
+        """The entries, or the stated reason there are none."""
+
+        content = getattr(self, attribute)
+        if content:
+            return content
+        for field, reason_field in EMPTY_DISCLOSURE_REASONS:
+            if field == attribute:
+                return f"none declared: {getattr(self, reason_field)}"
+        return content
+
+    @model_validator(mode="after")
+    def _provenance_is_complete(self) -> FairnessRow:
+        for setting, source in self.config_source.items():
+            _require_citation_or_url(source, label=f"config source for {setting!r}")
+        if set(self.config_source) != set(self.config_authored_by):
+            raise ValueError(
+                "config authorship must name exactly the sourced settings: "
+                f"sourced {sorted(self.config_source)}, "
+                f"authored {sorted(self.config_authored_by)}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _emptiness_is_stated_not_defaulted(self) -> FairnessRow:
+        for field, reason_field in EMPTY_DISCLOSURE_REASONS:
+            content = getattr(self, field)
+            reason = getattr(self, reason_field)
+            if not content and not (reason and reason.strip()):
+                raise ValueError(
+                    f"{field} is empty, so {reason_field} must state why — "
+                    "'none declared' is a claim, not a silence"
+                )
+            if content and reason is not None:
+                raise ValueError(
+                    f"{field} cannot both carry entries and state {reason_field}"
+                )
+        return self
+
+
+def require_complete(
+    rows: Iterable[FairnessRow], expected_keys: Iterable[FairnessKey]
+) -> None:
+    """Refuse publication while any expected ``(lane, provider, variant)`` has no row."""
+
+    present = {row.key for row in rows}
+    missing = sorted(set(expected_keys) - present)
+    if missing:
+        named = "; ".join(" / ".join(key) for key in missing)
+        raise FairnessMatrixError(f"missing fairness entry blocks publication: {named}")
+
+
+def _cell(value: object) -> str:
+    """One matrix cell, flattened to a single pipe-safe line."""
+
+    if isinstance(value, GlueAccounting):
+        meta = value.projector
+        text = (
+            f"{', '.join(value.files)} · {meta.loc} LOC ({meta.loc_code} code) · "
+            f"endpoints {', '.join(meta.endpoints_used) or 'none'} · "
+            f"reviewer: {value.reviewer_disposition}"
+        )
+    elif isinstance(value, CapabilityDeclarationCounts):
+        text = (
+            f"N/A {value.not_applicable}, absent_by_design {value.absent_by_design}, "
+            f"unavailable {value.unavailable}"
+        )
+    elif isinstance(value, dict):
+        text = "; ".join(f"{name}={item}" for name, item in sorted(value.items())) or "none"
+    elif isinstance(value, tuple):
+        text = "; ".join(_item(item) for item in value) or "none"
+    else:
+        text = str(value)
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _item(value: object) -> str:
+    if isinstance(value, Asymmetry):
+        return f"{value.description} (favours {value.favours}; {value.evidence})"
+    if isinstance(value, BlockedMeasurement):
+        return f"{value.measurement}: {value.reason} → {value.unblock_command}"
+    if isinstance(value, LaneReadiness):
+        verdict = "verified" if value.verified else "unverified"
+        return f"{value.lane}: {value.method} {verdict} ({value.evidence})"
+    return str(value)
+
+
+def render_fairness_matrix(
+    rows: Iterable[FairnessRow], *, expected_keys: Iterable[FairnessKey]
+) -> str:
+    """Render the matrix as markdown — no aggregate, one row per key.
+
+    Rendering is where the spec puts the refusal (:22-24): a comparative row
+    without its fairness entry is not marked publishable, so completeness is
+    checked here rather than only in a helper a caller may forget.
+    """
+
+    with offline_guard():
+        ordered = sorted(rows, key=lambda row: row.key)
+        require_complete(ordered, expected_keys)
+        labels = [label for label, _ in FAIRNESS_MATRIX_FIELDS]
+        header = "| " + " | ".join(["lane", "provider", "variant", *labels]) + " |"
+        rule = "|" + "|".join(["---"] * (3 + len(labels))) + "|"
+        lines = [header, rule]
+        for row in ordered:
+            cells = [
+                _cell(row.disclosure_for(attribute))
+                for _, attribute in FAIRNESS_MATRIX_FIELDS
+            ]
+            lines.append("| " + " | ".join([row.lane, row.provider, row.variant, *cells]) + " |")
+        return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "EMPTY_DISCLOSURE_REASONS",
+    "FAIRNESS_MATRIX_FIELDS",
+    "Asymmetry",
+    "BlockedMeasurement",
+    "CapabilityDeclarationCounts",
+    "ConfigAuthor",
+    "FairnessKey",
+    "FairnessMatrixError",
+    "FairnessRow",
+    "GlueAccounting",
+    "ReportModel",
+    "render_fairness_matrix",
+    "require_complete",
+    "require_relative_path",
+]

--- a/benchmarks/reports/fairness.py
+++ b/benchmarks/reports/fairness.py
@@ -34,6 +34,8 @@ from protocol.models import LaneReadiness
 from protocol.offline import offline_guard
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from .guards import refuse_aggregate
+
 #: ``(published label, attribute)`` for the fairness-matrix row of
 #: ``docs/benchmark-fairness-contract.md``. The labels are copied from the
 #: document, not paraphrased, and :class:`FairnessRow` declares the attributes in
@@ -343,7 +345,7 @@ def render_fairness_matrix(
                 for _, attribute in FAIRNESS_MATRIX_FIELDS
             ]
             lines.append("| " + " | ".join([row.lane, row.provider, row.variant, *cells]) + " |")
-        return "\n".join(lines) + "\n"
+        return refuse_aggregate("\n".join(lines) + "\n")
 
 
 __all__ = [

--- a/benchmarks/reports/guards.py
+++ b/benchmarks/reports/guards.py
@@ -1,0 +1,14 @@
+"""Shared refusals every reports renderer applies before returning text."""
+
+from __future__ import annotations
+
+
+class ReportRefused(ValueError):
+    """A renderer refused to publish text that violates a report invariant."""
+
+
+def refuse_aggregate(text: str) -> str:
+    """Return ``text`` unchanged, or refuse it if it carries an aggregate score."""
+    if "aggregate" in text.lower():
+        raise ReportRefused("reports never publish an aggregate; refusing to render")
+    return text

--- a/benchmarks/reports/latency.py
+++ b/benchmarks/reports/latency.py
@@ -1,0 +1,93 @@
+"""Cross-provider latency refusal (design.md #10; 4b.40 standing policy).
+
+No cross-provider latency COMPARISON is publishable from this host: the GPU
+is unusable here, so nothing on it can stand next to another provider's
+measured latency as if the two were on equal footing. That is narrower than
+"hide the numbers": per operational-quality-bench/spec.md's own scenario,
+"latency on such hosts renders per-provider as indicative-only" -- every
+provider's own figure always renders, individually labelled. What refuses is
+a COMPARATIVE construct: two or more providers add the withheld marker
+alongside their (still-rendered) individual rows, never a replacement for
+them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from protocol.models import MemoryBenchLatency
+
+#: Pinned against benchmarks/membench/reporting.py::WITHHELD_LATENCY by
+#: tests/test_reports_latency.py::test_withheld_latency_pins_against_the_real_membench_constant.
+#: reports/ deliberately does not import membench.reporting at module scope:
+#: it transitively reaches `from membench.judge.backends import
+#: parse_judge_verdict`, and backends.py:486 has its own lazily-imported
+#: `import httpx` ("lazy: offline flows must not require the dependency") --
+#: exactly the kind of module tests/test_reports_import_closure.py refuses to
+#: let benchmarks/reports/ reach. Duplicating the literal string here, pinned
+#: by a test, keeps the closure clean without a runtime import edge.
+WITHHELD_LATENCY = "withheld: transport asymmetry (4b.40)"
+
+
+@dataclass(frozen=True)
+class ProviderLatency:
+    """One provider's own latency observation.
+
+    `value_ms` is optional: the one real on-disk source this lane reads today
+    (memorybench-export.v1.json's run-level `latency` object -- see
+    reports/consolidate.py::_latency_observation) carries only the
+    publishable/reason flag, never a millisecond figure -- membench's actual
+    numbers live in its own per-run view (benchmarks/membench/reporting.py's
+    `_RunView.latencies`), a lane this package does not read. `value_ms`
+    exists so a caller that DOES have a number (a future membench-backed
+    source) can supply one; absent, the cell renders `n/a`.
+    """
+
+    provider: str
+    latency: MemoryBenchLatency
+    value_ms: float | None = None
+
+
+def _row(item: ProviderLatency) -> str:
+    value = "n/a" if item.value_ms is None else f"{item.value_ms:g}"
+    # Load-bearing on the flag, not decorative: MemoryBenchLatency.publishable
+    # is pinned Literal[False] today (memorybench/export.py:1220 always emits
+    # `{"publishable": False, "reason": "host_unvalidated"}"), so this branch
+    # is unreached by any artifact this lane can currently read -- but the
+    # code must still ask, not assume, since a future validated host would
+    # flip it and a number should then render bare, not mislabelled.
+    if item.latency.publishable:
+        disposition = str(item.latency.reason)
+    else:
+        disposition = f"indicative ({item.latency.reason})"
+    return f"| {item.provider} | {value} | {disposition} |"
+
+
+def assert_no_cross_provider_latency(observations: Sequence[ProviderLatency]) -> str:
+    """Render one indicative-only row per provider; never a comparative column.
+
+    Zero observations render nothing. Every provider's own number always
+    renders -- refusing to publish it at all would be losing real data 4b.40
+    never asked to hide. Two or more DISTINCT providers additionally append
+    membench's own withheld marker (never replacing the per-provider rows)
+    because nothing on this host may present two providers' numbers as
+    directly comparable.
+    """
+
+    if not observations:
+        return ""
+    lines = [
+        "## Latency",
+        "",
+        "| provider | latency_ms | disposition |",
+        "| --- | --- | --- |",
+        *(_row(item) for item in observations),
+    ]
+    if len({item.provider for item in observations}) > 1:
+        lines.extend(["", WITHHELD_LATENCY])
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = ["ProviderLatency", "WITHHELD_LATENCY", "assert_no_cross_provider_latency"]

--- a/benchmarks/reports/latency.py
+++ b/benchmarks/reports/latency.py
@@ -6,9 +6,11 @@ measured latency as if the two were on equal footing. That is narrower than
 "hide the numbers": per operational-quality-bench/spec.md's own scenario,
 "latency on such hosts renders per-provider as indicative-only" -- every
 provider's own figure always renders, individually labelled. What refuses is
-a COMPARATIVE construct: two or more providers add the withheld marker
-alongside their (still-rendered) individual rows, never a replacement for
-them.
+a COMPARATIVE construct: with two or more distinct providers, no table cell
+or column may ever be shared across providers -- each gets its OWN one-row
+table under its OWN heading, so a reader cannot read two providers' numbers
+down one column even though both remain visible -- plus the withheld marker
+in place of any comparative construct.
 """
 
 from __future__ import annotations
@@ -49,8 +51,7 @@ class ProviderLatency:
     value_ms: float | None = None
 
 
-def _row(item: ProviderLatency) -> str:
-    value = "n/a" if item.value_ms is None else f"{item.value_ms:g}"
+def _disposition(item: ProviderLatency) -> str:
     # Load-bearing on the flag, not decorative: MemoryBenchLatency.publishable
     # is pinned Literal[False] today (memorybench/export.py:1220 always emits
     # `{"publishable": False, "reason": "host_unvalidated"}"), so this branch
@@ -58,36 +59,57 @@ def _row(item: ProviderLatency) -> str:
     # code must still ask, not assume, since a future validated host would
     # flip it and a number should then render bare, not mislabelled.
     if item.latency.publishable:
-        disposition = str(item.latency.reason)
-    else:
-        disposition = f"indicative ({item.latency.reason})"
-    return f"| {item.provider} | {value} | {disposition} |"
+        return str(item.latency.reason)
+    return f"indicative ({item.latency.reason})"
 
 
-def assert_no_cross_provider_latency(observations: Sequence[ProviderLatency]) -> str:
-    """Render one indicative-only row per provider; never a comparative column.
+def _provider_block(provider: str, items: Sequence[ProviderLatency]) -> str:
+    """A single provider's OWN heading and OWN one-row-per-observation table.
+
+    No column here is ever shared with another provider's block: the
+    provider name lives in the heading, not in a row of a table other
+    providers also populate, so nothing can be read down a shared column.
+    """
+
+    lines = [
+        f"### {provider}",
+        "",
+        "| latency_ms | disposition |",
+        "| --- | --- |",
+    ]
+    for item in items:
+        value = "n/a" if item.value_ms is None else f"{item.value_ms:g}"
+        lines.append(f"| {value} | {_disposition(item)} |")
+    return "\n".join(lines)
+
+
+def render_indicative_latency(observations: Sequence[ProviderLatency]) -> str:
+    """Render one single-provider latency block per distinct provider.
 
     Zero observations render nothing. Every provider's own number always
     renders -- refusing to publish it at all would be losing real data 4b.40
-    never asked to hide. Two or more DISTINCT providers additionally append
-    membench's own withheld marker (never replacing the per-provider rows)
-    because nothing on this host may present two providers' numbers as
-    directly comparable.
+    never asked to hide -- but with two or more DISTINCT providers, no value
+    column ever spans providers: each provider gets its own heading and its
+    own one-row(s) table (operational-quality-bench/spec.md's "Latency
+    column refused" scenario, both halves -- no cross-provider column AND
+    each cell individually indicative-only), plus membench's own withheld
+    marker in place of any comparative construct.
     """
 
     if not observations:
         return ""
-    lines = [
-        "## Latency",
-        "",
-        "| provider | latency_ms | disposition |",
-        "| --- | --- | --- |",
-        *(_row(item) for item in observations),
-    ]
-    if len({item.provider for item in observations}) > 1:
-        lines.extend(["", WITHHELD_LATENCY])
-    lines.append("")
-    return "\n".join(lines)
+    by_provider: dict[str, list[ProviderLatency]] = {}
+    for item in observations:
+        by_provider.setdefault(item.provider, []).append(item)
+
+    sections = ["## Latency", ""]
+    sections.append(
+        "\n\n".join(_provider_block(provider, items) for provider, items in by_provider.items())
+    )
+    if len(by_provider) > 1:
+        sections.extend(["", WITHHELD_LATENCY])
+    sections.append("")
+    return "\n".join(sections)
 
 
-__all__ = ["ProviderLatency", "WITHHELD_LATENCY", "assert_no_cross_provider_latency"]
+__all__ = ["ProviderLatency", "WITHHELD_LATENCY", "render_indicative_latency"]

--- a/benchmarks/reports/render.py
+++ b/benchmarks/reports/render.py
@@ -23,7 +23,8 @@ from epistemic.report import render_epistemic_report
 from lme.report import render_run_report
 from protocol.offline import offline_guard
 
-from .latency import ProviderLatency, assert_no_cross_provider_latency
+from .guards import ReportRefused, refuse_aggregate
+from .latency import ProviderLatency, render_indicative_latency
 
 
 @dataclass(frozen=True)
@@ -42,10 +43,6 @@ class EpistemicCohort:
 
 
 ReportInput = LmeRun | EpistemicCohort
-
-
-class ReportRefused(ValueError):
-    """A rendered report would violate the no-aggregate invariant."""
 
 
 def render_all(
@@ -73,13 +70,11 @@ def render_all(
                 )
             else:
                 raise TypeError(f"unsupported report input: {item!r}")
-        latency_section = assert_no_cross_provider_latency(latency)
+        latency_section = render_indicative_latency(latency)
     if latency_section:
         sections.append(latency_section)
     report = "\n".join(sections)
-    if "aggregate" in report.lower():
-        raise ReportRefused("rendered report must never contain the word aggregate")
-    return report
+    return refuse_aggregate(report)
 
 
 __all__ = ["LmeRun", "EpistemicCohort", "ReportInput", "ReportRefused", "render_all"]

--- a/benchmarks/reports/render.py
+++ b/benchmarks/reports/render.py
@@ -1,0 +1,85 @@
+"""Cross-lane comparative rendering: LME + Epistemic State Bench, composed
+under one offline network guard, per-ability x per-variant only, never an
+aggregate.
+
+Each input is rendered by its OWN lane's existing, tested renderer -- this
+module never re-implements verdict, bounds, or contamination logic. A
+non-terminal manifest or an unknown ``schema_version`` refuses (raised by
+``protocol.manifest.load_manifest``, reached through
+``lme.report.render_run_report``) before anything renders. A blocked row
+renders whatever its own lane renderer already renders for that state
+(``blocked: <reason>`` / ``INVALID`` / ``READINESS_UNVERIFIABLE`` -- see
+``lme.report.manifest_banner``) -- never a loss, and this module adds nothing
+on top of it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from epistemic.report import render_epistemic_report
+from lme.report import render_run_report
+from protocol.offline import offline_guard
+
+from .latency import ProviderLatency, assert_no_cross_provider_latency
+
+
+@dataclass(frozen=True)
+class LmeRun:
+    """An LME/MemoryBench run directory, rendered by the LME lane renderer."""
+
+    run_dir: Path
+
+
+@dataclass(frozen=True)
+class EpistemicCohort:
+    """A stored, validated Epistemic State Bench cohort artifact."""
+
+    cohort_path: Path
+    run_root: Path
+
+
+ReportInput = LmeRun | EpistemicCohort
+
+
+class ReportRefused(ValueError):
+    """A rendered report would violate the no-aggregate invariant."""
+
+
+def render_all(
+    inputs: Sequence[ReportInput],
+    *,
+    latency: Sequence[ProviderLatency] = (),
+) -> str:
+    """Compose the LME and Epistemic lane renderers plus a latency section.
+
+    Runs entirely under one ``offline_guard``; a non-terminal manifest or
+    unknown ``schema_version`` anywhere in ``inputs`` raises before this
+    returns -- the same refusal each lane's own report entry point already
+    raises, never reimplemented here. Never emits an aggregate across
+    abilities, variants, or lanes.
+    """
+
+    sections: list[str] = []
+    with offline_guard():
+        for item in inputs:
+            if isinstance(item, LmeRun):
+                sections.append(render_run_report(item.run_dir, offline=False))
+            elif isinstance(item, EpistemicCohort):
+                sections.append(
+                    render_epistemic_report(item.cohort_path, run_root=item.run_root, offline=False)
+                )
+            else:
+                raise TypeError(f"unsupported report input: {item!r}")
+        latency_section = assert_no_cross_provider_latency(latency)
+    if latency_section:
+        sections.append(latency_section)
+    report = "\n".join(sections)
+    if "aggregate" in report.lower():
+        raise ReportRefused("rendered report must never contain the word aggregate")
+    return report
+
+
+__all__ = ["LmeRun", "EpistemicCohort", "ReportInput", "ReportRefused", "render_all"]

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -475,13 +475,37 @@ them. Mission acceptance criteria (§14) close only from this ledger.
 
 ## 9. Reports + CI (W11)
 
-- [ ] 9.1 `reports/` renderer (per-ability × variant; no aggregate; INVALID
+- [x] 9.1 `reports/` renderer (per-ability × variant; no aggregate; INVALID
       renders INVALID; refuses cross-provider latency from this host)
-- [ ] 9.2 Fairness matrix + compat matrix (declared-vs-observed divergence a
+      Landed 2026-09-02 (`benchmarks/reports/render.py`, `latency.py`): composes the
+      LME and epistemic renderers under the shared offline guard; per-ability by
+      per-variant only; non-terminal and unknown-schema manifests refused by
+      inheriting the manifest loader; latency renders one indicative block per
+      provider and never a column spanning providers. Fresh review + integration
+      review APPROVE; reports test set 123 passed, 0 failed.
+- [x] 9.2 Fairness matrix + compat matrix (declared-vs-observed divergence a
       first-class finding)
-- [ ] 9.3 Adversarial packet generator (assumptions, confounds,
+      Landed 2026-09-02 (`benchmarks/reports/fairness.py`, `compat.py`): the eight
+      contract fields read from `docs/benchmark-fairness-contract.md` at assert time;
+      rendering refuses an incomplete matrix; declared-vs-observed variant and
+      provider divergences are first-class findings; non-VALID status invalidates.
+      Residual 2.3c (basic-memory-direct identity vs the design vocabulary) tracked
+      in §2. Reachability from a one-command path is owed by 9.5/9.6.
+- [x] 9.3 Adversarial packet generator (assumptions, confounds,
       suspicious-win flags, challenge paths, pre-registration hash)
-- [ ] 9.4 `consolidate.py` + offline guard (import-closure test)
+      Landed 2026-09-02 (`benchmarks/reports/adversarial.py`): pre-registration
+      binding (ratified + effective sha256, ordered amendment chain with
+      acknowledgment status), assumptions/confounds from projector declarations,
+      suspicious-win flags where a control also passes, the ten reviewer
+      questions bound to artifact paths, and a review disposition bound to the
+      packet hash; unreviewed or stale renders internal-diagnostic.
+- [x] 9.4 `consolidate.py` + offline guard (import-closure test)
+      Landed 2026-09-02 (`benchmarks/reports/consolidate.py`,
+      `tests/test_reports_import_closure.py`): artifact-only, re-derives the
+      pre-registration identity before rendering, validates every MemoryBench
+      export through its model, writes the identity before the report; the
+      import-closure test scans the package at every scope and its transitive
+      imports at load-time scope.
 - [ ] 9.5 Additive `benchmark-protocol` CI job (offline only; guarded
       `retrieval-eval` untouched); README lane map updated
 - [ ] 9.6 One-command smoke / per-lane run / report-regeneration documented

--- a/tests/harness_modules.txt
+++ b/tests/harness_modules.txt
@@ -110,6 +110,9 @@ tests/test_protocol_update_probe_matching.py
 tests/test_protocol_validity.py
 tests/test_records_recall_reconcile.py
 tests/test_report_offline.py
+tests/test_reports_consolidate.py
+tests/test_reports_latency.py
+tests/test_reports_render.py
 tests/test_reviewer_bootstrap_cli.py
 tests/test_service_installers.py
 tests/test_transactional_writes.py

--- a/tests/harness_modules.txt
+++ b/tests/harness_modules.txt
@@ -110,6 +110,9 @@ tests/test_protocol_update_probe_matching.py
 tests/test_protocol_validity.py
 tests/test_records_recall_reconcile.py
 tests/test_report_offline.py
+tests/test_reports_adversarial.py
+tests/test_reports_compat.py
+tests/test_reports_fairness.py
 tests/test_reviewer_bootstrap_cli.py
 tests/test_service_installers.py
 tests/test_transactional_writes.py

--- a/tests/test_reports_adversarial.py
+++ b/tests/test_reports_adversarial.py
@@ -433,3 +433,27 @@ def test_the_rendered_packet_publishes_the_preregistration_hash(tmp_path: Path) 
     assert packet.preregistration.sha256 in rendered
     for bound in packet.challenge_paths:
         assert bound.artifact_path in rendered
+
+
+def test_rendering_refuses_free_text_that_carries_an_aggregate(tmp_path: Path) -> None:
+    """Integration fold: a reviewer's objection text reaches the page verbatim."""
+
+    from benchmarks.reports.adversarial import Objection, render_adversarial_packet
+    from benchmarks.reports.guards import ReportRefused
+
+    packet = _packet(tmp_path)
+    reviewed = packet.model_copy(
+        update={
+            "review_disposition": _disposition(
+                packet,
+                objections=(
+                    Objection(
+                        text="the aggregate MemScore is quoted in the summary",
+                        status="documented",
+                    ),
+                ),
+            )
+        }
+    )
+    with pytest.raises(ReportRefused, match="never publish an aggregate"):
+        render_adversarial_packet(reviewed)

--- a/tests/test_reports_adversarial.py
+++ b/tests/test_reports_adversarial.py
@@ -1,0 +1,435 @@
+"""9.3: the adversarial packet a reviewer with no stake in the outcome is given.
+
+The pre-registration binding is recomputed here from the real receipts, and the
+suspicious-win flags are read off a cohort the real validator normalized, so
+neither can be asserted into existence by the packet builder.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from epistemic.projectors.exomem_vault import VaultProjector
+from epistemic.schema import load_scenario
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "benchmarks" / "epistemic" / "fixtures"
+VAULT = FIXTURES / "vault"
+CONTRACT = REPO_ROOT / "docs" / "benchmark-fairness-contract.md"
+
+CHECKLIST_HEADING = "## Reviewer checklist (what to attack first)"
+
+SCENARIO_ID = "scenario-1"
+SCENARIO_SHA256 = "1" * 64
+
+
+def _doc_reviewer_questions() -> tuple[str, ...]:
+    """The reviewer checklist, unwrapped, straight out of the contract."""
+
+    lines = CONTRACT.read_text(encoding="utf-8").splitlines()
+    start = lines.index(CHECKLIST_HEADING)
+    questions: list[str] = []
+    current: str | None = None
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        if line.startswith("- "):
+            if current is not None:
+                questions.append(current)
+            current = line[2:].strip()
+        elif current is not None and line.startswith("  ") and line.strip():
+            current = f"{current} {line.strip()}"
+    if current is not None:
+        questions.append(current)
+    return tuple(questions)
+
+
+def _replayable_cell(run_root: Path, *, provider: str, variant: str, outcome: str):
+    from epistemic.assertions import AssertionContext, no_retired_state_served_as_current
+    from epistemic.cohort import CohortAssertionResult, CohortExpectationIdentity
+    from epistemic.evidence import persist_assertion_evidence
+    from epistemic.snapshot import (
+        EpistemicStateSnapshot,
+        FieldDeclaration,
+        ProjectorMeta,
+        StateItem,
+    )
+
+    snapshot = EpistemicStateSnapshot(
+        provider=provider,
+        variant=variant,
+        phase="p1",
+        taken_at="2026-08-11T00:00:00Z",
+        items=(
+            StateItem(
+                id="chain",
+                kind="claim",
+                title="chain",
+                current="yes" if outcome == "fail" else "no",
+                retired_reason="superseded",
+            ),
+        ),
+        declarations=(
+            FieldDeclaration(
+                field="current", status="declared", evidence="https://example.invalid/current"
+            ),
+        ),
+        projector=ProjectorMeta(
+            name="fixture",
+            version="1",
+            author="test",
+            endpoints_used=("broker:state.read",),
+            loc=1,
+        ),
+    )
+    context = AssertionContext(snapshot=snapshot, subject="chain")
+    result = no_retired_state_served_as_current(context)
+    assert result.outcome == outcome
+    reference = persist_assertion_evidence(
+        run_root=run_root,
+        scenario_id=SCENARIO_ID,
+        scenario_sha256=SCENARIO_SHA256,
+        family_id="f01",
+        phase_id="p1",
+        expectation_ordinal=1,
+        assertion=result.name,
+        context=context,
+        result=result,
+    )
+    return CohortAssertionResult(
+        identity=CohortExpectationIdentity(
+            scenario_id=SCENARIO_ID,
+            scenario_sha256=SCENARIO_SHA256,
+            phase_id="p1",
+            expectation_ordinal=1,
+            assertion=result.name,
+            subject="chain",
+        ),
+        result=result,
+        evidence_ref=reference,
+    )
+
+
+def _cohort(run_root: Path, *, product_outcome: str, control_outcome: str):
+    from epistemic.cohort import EpistemicCohortRow, validate_epistemic_cohort
+
+    rows = (
+        EpistemicCohortRow(
+            provider="exomem",
+            variant="exomem-native",
+            assertions=(
+                _replayable_cell(
+                    run_root, provider="exomem", variant="exomem-native", outcome=product_outcome
+                ),
+            ),
+        ),
+        EpistemicCohortRow(
+            provider="grep-markdown",
+            variant="grep-markdown",
+            assertions=(
+                _replayable_cell(
+                    run_root,
+                    provider="grep-markdown",
+                    variant="grep-markdown",
+                    outcome=control_outcome,
+                ),
+            ),
+        ),
+        EpistemicCohortRow(
+            provider="no-memory",
+            variant="no-memory",
+            assertions=(
+                _replayable_cell(
+                    run_root, provider="no-memory", variant="no-memory", outcome=control_outcome
+                ),
+            ),
+        ),
+    )
+    return validate_epistemic_cohort(run_id="run-1", rows=rows, run_root=run_root)
+
+
+def _challenge_artifacts() -> dict[str, str]:
+    from benchmarks.reports.adversarial import REVIEWER_CHALLENGES
+
+    return {
+        challenge.challenge_id: f"challenges/{challenge.challenge_id}.md"
+        for challenge in REVIEWER_CHALLENGES
+    }
+
+
+def _packet(tmp_path: Path, *, product_outcome="pass", control_outcome="fail", **changes):
+    from benchmarks.reports.adversarial import build_adversarial_packet
+
+    arguments = {
+        "run_id": "run-1",
+        "repo_root": REPO_ROOT,
+        "fairness": load_scenario(FIXTURES / "scenario-minimal.yaml").fairness,
+        "declarations": VaultProjector(VAULT).declarations(),
+        "cohort": _cohort(
+            tmp_path, product_outcome=product_outcome, control_outcome=control_outcome
+        ),
+        "challenge_artifacts": _challenge_artifacts(),
+    }
+    arguments.update(changes)
+    return build_adversarial_packet(**arguments)
+
+
+def test_preregistration_binding_equals_the_recomputed_identity(tmp_path: Path) -> None:
+    """R4: sha256 and amendment order are the real receipts', not the packet's."""
+
+    from protocol.contracts import (
+        derive_preregistration_identity,
+        fold_amendment_chain,
+        working_amendment_receipts,
+    )
+
+    packet = _packet(tmp_path)
+    identity = derive_preregistration_identity(REPO_ROOT)
+    assert packet.preregistration.sha256 == identity.effective.sha256
+    assert packet.preregistration.base_sha256 == identity.original.sha256
+    assert packet.preregistration.contract_revision == identity.contract_revision
+
+    receipts = working_amendment_receipts(REPO_ROOT)
+    assert receipts
+    folded = fold_amendment_chain(
+        receipts,
+        base_sha256=packet.preregistration.base_sha256,
+        current_sha256=packet.preregistration.sha256,
+    )
+    assert folded == packet.preregistration.sha256
+    assert tuple(item.sequence for item in packet.preregistration.amendments) == tuple(
+        receipt.sequence for receipt in receipts
+    )
+    assert tuple(item.contract_sha256 for item in packet.preregistration.amendments) == tuple(
+        receipt.contract_sha256 for receipt in receipts
+    )
+    assert tuple(item.receipt_path for item in packet.preregistration.amendments) == tuple(
+        amendment.receipt.receipt_path for amendment in identity.amendments
+    )
+
+
+def test_assumptions_and_confounds_come_from_declarations_and_the_packet(
+    tmp_path: Path,
+) -> None:
+    scenario = load_scenario(FIXTURES / "scenario-minimal.yaml")
+    packet = _packet(tmp_path)
+    declarations = VaultProjector(VAULT).declarations()
+
+    observable = tuple(item for item in declarations if item.observable)
+    unobservable = tuple(item for item in declarations if not item.observable)
+    assert len(packet.assumptions) == len(observable) + 1
+    assert len(packet.confounds) == len(unobservable) + 1
+    assert any(
+        assumption.statement == scenario.fairness.why_neutral.strip()
+        for assumption in packet.assumptions
+    )
+    assert any(
+        confound.statement == scenario.fairness.public_coverage_subtraction.strip()
+        for confound in packet.confounds
+    )
+    assert all(assumption.evidence for assumption in packet.assumptions)
+
+
+def test_a_product_win_a_control_also_scores_is_flagged(tmp_path: Path) -> None:
+    """R5, the positive half: the no_product_signal masking rule."""
+
+    packet = _packet(tmp_path, product_outcome="pass", control_outcome="pass")
+    assert packet.suspicious_win_flags
+    flag = packet.suspicious_win_flags[0]
+    assert flag.provider == "exomem"
+    assert flag.variant == "exomem-native"
+    assert flag.outcome == "pass"
+    assert flag.signal_disposition == "no_product_signal"
+    assert flag.controls_scoring == ("grep-markdown", "no-memory")
+
+
+def test_a_product_win_no_control_reproduces_is_not_flagged(tmp_path: Path) -> None:
+    """R5, the negative half."""
+
+    packet = _packet(tmp_path, product_outcome="pass", control_outcome="fail")
+    assert packet.suspicious_win_flags == ()
+
+
+def test_every_reviewer_question_is_bound_to_an_artifact_under_the_run_root(
+    tmp_path: Path,
+) -> None:
+    """R7. The count is the contract document's own, read at assert time."""
+
+    from benchmarks.reports.adversarial import REVIEWER_CHALLENGES
+
+    questions = _doc_reviewer_questions()
+    assert tuple(challenge.question for challenge in REVIEWER_CHALLENGES) == questions
+
+    packet = _packet(tmp_path)
+    assert len(packet.challenge_paths) == len(questions)
+    assert tuple(path.question for path in packet.challenge_paths) == questions
+    for bound in packet.challenge_paths:
+        assert bound.artifact_path
+        assert not Path(bound.artifact_path).is_absolute()
+        assert ".." not in Path(bound.artifact_path).parts
+
+
+def test_a_challenge_without_a_bound_artifact_refuses(tmp_path: Path) -> None:
+    from benchmarks.reports.adversarial import (
+        REVIEWER_CHALLENGES,
+        AdversarialPacketError,
+    )
+
+    artifacts = _challenge_artifacts()
+    dropped = REVIEWER_CHALLENGES[-1].challenge_id
+    artifacts.pop(dropped)
+    with pytest.raises(AdversarialPacketError) as excinfo:
+        _packet(tmp_path, challenge_artifacts=artifacts)
+    assert dropped in str(excinfo.value)
+
+
+def test_a_challenge_bound_outside_the_run_root_refuses(tmp_path: Path) -> None:
+    from benchmarks.reports.adversarial import (
+        REVIEWER_CHALLENGES,
+        AdversarialPacketError,
+    )
+
+    artifacts = _challenge_artifacts()
+    artifacts[REVIEWER_CHALLENGES[0].challenge_id] = "/var/tmp/challenge.md"
+    with pytest.raises(AdversarialPacketError, match="relative"):
+        _packet(tmp_path, challenge_artifacts=artifacts)
+
+
+def _disposition(
+    packet,
+    *,
+    objections=(),
+    reviewer_id: str = "independent-reviewer:lane-l3",
+    reviewed_at: str = "2026-09-02",
+    packet_sha256: str | None = None,
+):
+    from benchmarks.reports.adversarial import ReviewDisposition, packet_content_sha256
+
+    return ReviewDisposition(
+        reviewer_id=reviewer_id,
+        reviewed_at=reviewed_at,
+        packet_sha256=packet_content_sha256(packet) if packet_sha256 is None else packet_sha256,
+        objections=tuple(objections),
+    )
+
+
+def test_an_unreviewed_packet_renders_internal_diagnostic(tmp_path: Path) -> None:
+    """R6 case 1 / spec :56-59 — no recorded disposition is not publishable."""
+
+    from benchmarks.reports.adversarial import INTERNAL_DIAGNOSTIC, render_adversarial_packet
+
+    packet = _packet(tmp_path)
+    assert packet.review_disposition is None
+    # Pinned as a literal, not through the constant: asserting the constant
+    # against a render built from that same constant moves both sides at once
+    # and would survive a rename of the label the spec names.
+    assert INTERNAL_DIAGNOSTIC == "internal-diagnostic"
+    assert "internal-diagnostic" in render_adversarial_packet(packet)
+
+
+def test_a_review_bound_to_other_bytes_is_no_review(tmp_path: Path) -> None:
+    """R6 case 2 — a stale review is not a review of *this* packet."""
+
+    from benchmarks.reports.adversarial import INTERNAL_DIAGNOSTIC, render_adversarial_packet
+
+    packet = _packet(tmp_path)
+    stale = packet.model_copy(
+        update={"review_disposition": _disposition(packet, packet_sha256="0" * 64)}
+    )
+    assert INTERNAL_DIAGNOSTIC == "internal-diagnostic"
+    assert "internal-diagnostic" in render_adversarial_packet(stale)
+
+
+def test_a_matching_disposition_renders_reviewed_with_its_objections(tmp_path: Path) -> None:
+    """R6 case 3 / spec :48-54 — reviewer, date, and every objection's status."""
+
+    from benchmarks.reports.adversarial import (
+        Objection,
+        render_adversarial_packet,
+    )
+
+    packet = _packet(tmp_path)
+    objections = (
+        Objection(text="the glue LOC asymmetry is not disclosed per row", status="fixed"),
+        Objection(text="this host cannot validate a latency comparison", status="documented"),
+    )
+    reviewed = packet.model_copy(
+        update={"review_disposition": _disposition(packet, objections=objections)}
+    )
+    rendered = render_adversarial_packet(reviewed)
+    assert "internal-diagnostic" not in rendered
+    assert "independent-reviewer:lane-l3" in rendered
+    assert "2026-09-02" in rendered
+    for objection in objections:
+        assert objection.text in rendered
+        assert objection.status in rendered
+
+
+def test_the_reviewed_hash_covers_the_packet_without_its_own_disposition(
+    tmp_path: Path,
+) -> None:
+    """Otherwise attaching the review would invalidate the hash it just recorded."""
+
+    from benchmarks.reports.adversarial import packet_content_sha256
+
+    packet = _packet(tmp_path)
+    before = packet_content_sha256(packet)
+    reviewed = packet.model_copy(update={"review_disposition": _disposition(packet)})
+    assert packet_content_sha256(reviewed) == before
+    assert reviewed.review_disposition.packet_sha256 == before
+
+
+@pytest.mark.parametrize(
+    "reviewer_id",
+    [
+        "Some Reviewer",
+        "hugo.kivi",
+        "hugo_kivi",
+        "hugo",
+        "a@b.com",
+        "reviewer:l3",
+        "independent-reviewer:",
+        "independent-reviewer:Some-Lane",
+    ],
+)
+def test_only_the_allowed_reviewer_handle_form_is_accepted(
+    tmp_path: Path, reviewer_id: str
+) -> None:
+    """D4: an allowlisted FORM, because there is no personal-name detector.
+
+    The repository privacy gate looks for absolute paths and Windows SIDs only
+    (``src/exomem/public_artifact_privacy.py``), and the handle renders verbatim
+    into the packet markdown — so a character-shape filter that merely rejects
+    spaces would pass ``hugo.kivi`` and ``a@b.com`` straight through.
+    """
+
+    packet = _packet(tmp_path)
+    with pytest.raises(ValidationError, match="independent-reviewer:"):
+        _disposition(packet, reviewer_id=reviewer_id)
+
+
+def test_the_allowed_reviewer_handle_form_is_accepted(tmp_path: Path) -> None:
+    packet = _packet(tmp_path)
+    disposition = _disposition(packet, reviewer_id="independent-reviewer:l3-fairness")
+    assert disposition.reviewer_id == "independent-reviewer:l3-fairness"
+
+
+@pytest.mark.parametrize("reviewed_at", ["2026-13-45", "2026-02-30", "2026-00-10"])
+def test_an_impossible_review_date_refuses(tmp_path: Path, reviewed_at: str) -> None:
+    """A well-shaped string is not a date; the calendar has to accept it."""
+
+    packet = _packet(tmp_path)
+    with pytest.raises(ValidationError, match="calendar date"):
+        _disposition(packet, reviewed_at=reviewed_at)
+
+
+def test_the_rendered_packet_publishes_the_preregistration_hash(tmp_path: Path) -> None:
+    from benchmarks.reports.adversarial import render_adversarial_packet
+
+    packet = _packet(tmp_path)
+    rendered = render_adversarial_packet(packet)
+    assert packet.preregistration.sha256 in rendered
+    for bound in packet.challenge_paths:
+        assert bound.artifact_path in rendered

--- a/tests/test_reports_compat.py
+++ b/tests/test_reports_compat.py
@@ -1,0 +1,295 @@
+"""9.2: the compat matrix — declared capability versus observed behaviour.
+
+The manifest under test is written by the real runner and read back by the real
+``load_manifest``; only the *declared* side varies between cases, because the
+declared-versus-observed variant identity is the axis the spec makes a validity
+question (benchmark-fairness-contract spec :61-71).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from epistemic.projectors.exomem_vault import VaultProjector
+from epistemic.schema import load_scenario
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "benchmarks" / "epistemic" / "fixtures"
+VAULT = FIXTURES / "vault"
+DATASET = Path("benchmarks/lme/fixtures/mini.json")
+
+
+@pytest.fixture(scope="module")
+def run_dir(tmp_path_factory) -> Path:
+    """One real protocol run: manifest, readiness and lifecycle evidence."""
+
+    from lme.reader import StubReader
+    from lme.runner import RunConfig, execute_run
+
+    out = tmp_path_factory.mktemp("compat-run")
+    with mock.patch.dict(
+        os.environ, {"PROTOCOL_FIXTURE_EMBEDDER": "1", "EXOMEM_DISABLE_EMBEDDINGS": "1"}
+    ):
+        execute_run(
+            RunConfig(
+                dataset=DATASET,
+                out=out,
+                reader_name="stub",
+                run_id="compat",
+                provider="hybrid-rag-control",
+            ),
+            reader=StubReader(),
+        )
+    return out / "compat"
+
+
+@pytest.fixture(scope="module")
+def manifest(run_dir: Path):
+    from protocol.manifest import load_manifest
+
+    return load_manifest(run_dir)
+
+
+@pytest.fixture(scope="module")
+def packet():
+    return load_scenario(FIXTURES / "scenario-minimal.yaml").fairness
+
+
+def _redeclare_variant(fairness_packet, variant: str):
+    """The same loader-produced packet, re-keyed onto one variant identity."""
+
+    return fairness_packet.model_copy(
+        update={
+            "privileged_endpoint_matrix": tuple(
+                entry.model_copy(update={"variant": variant})
+                for entry in fairness_packet.privileged_endpoint_matrix
+            )
+        }
+    )
+
+
+def _build(fairness_packet, run_manifest):
+    from benchmarks.reports.compat import build_compat_matrix
+
+    return build_compat_matrix(
+        packet=fairness_packet,
+        manifest=run_manifest,
+        declarations=VaultProjector(VAULT).declarations(),
+    )
+
+
+def test_declared_variant_equal_to_the_manifest_yields_no_finding(manifest, packet) -> None:
+    """R3, the negative half."""
+
+    matrix = _build(_redeclare_variant(packet, manifest.provider_variant), manifest)
+    assert manifest.provider_variant
+    assert matrix.cells
+    assert matrix.divergences == ()
+    assert matrix.run_status == "VALID"
+    assert matrix.invalidates() is False
+
+
+def test_declared_variant_differing_from_the_manifest_is_a_divergence(manifest, packet) -> None:
+    """R3 / spec :68-71 — variant conflation is INVALID until corrected."""
+
+    matrix = _build(packet, manifest)
+    variant_findings = [item for item in matrix.divergences if item.kind == "variant"]
+    assert matrix.invalidates() is True
+    assert [item.key for item in variant_findings] == [
+        ("fixture", "native", "corpus.ingest"),
+        ("fixture", "native", "state.read"),
+    ]
+    for finding in variant_findings:
+        assert finding.declared == "native"
+        assert finding.observed == manifest.provider_variant
+        assert finding.evidence_path == "manifest.json"
+
+
+def test_every_declared_surface_becomes_a_cell(manifest, packet) -> None:
+    matrix = _build(packet, manifest)
+    assert tuple(cell.driver_surface_id for cell in matrix.cells) == (
+        "corpus.ingest",
+        "state.read",
+    )
+    for cell in matrix.cells:
+        assert cell.observed_variant == manifest.provider_variant
+        assert cell.declared_disposition == "equivalent"
+        assert cell.observed_readiness_verified is True
+    assert matrix.declared_field_statuses == tuple(
+        sorted({item.status for item in VaultProjector(VAULT).declarations()})
+    )
+
+
+def test_an_equivalent_surface_without_verified_readiness_is_a_capability_finding(
+    run_dir: Path, manifest, packet, tmp_path: Path
+) -> None:
+    from protocol.manifest import finalize_manifest, load_manifest
+    from protocol.models import LaneReadiness
+
+    unverified_dir = tmp_path / "unverified"
+    shutil.copytree(run_dir, unverified_dir)
+    finalize_manifest(
+        unverified_dir,
+        status="VALID",
+        finalized_at="2026-01-02T00:00:00Z",
+        readiness=[
+            LaneReadiness(
+                lane=manifest.provider_variant,
+                requested=True,
+                verified=False,
+                method="config-state",
+                evidence="readiness-unverifiable: dynamic extraction never terminalizes",
+            )
+        ],
+    )
+    unverified = load_manifest(unverified_dir)
+
+    matrix = _build(_redeclare_variant(packet, unverified.provider_variant), unverified)
+    capability_findings = [item for item in matrix.divergences if item.kind == "capability"]
+    assert capability_findings
+    assert "readiness-unverifiable" in capability_findings[0].observed
+    # A capability finding is a finding, not a validity failure: only a variant
+    # or provider identity mismatch makes the run INVALID (spec :61-71).
+    assert matrix.invalidates() is False
+
+
+def test_a_non_valid_run_carries_its_status_and_can_never_read_as_publishable(
+    run_dir: Path, packet, tmp_path: Path
+) -> None:
+    """H2 / spec :26-30, :37-40 — a harness fault is not a comparable result."""
+
+    from protocol.manifest import finalize_manifest, load_manifest
+
+    from benchmarks.reports.compat import render_compat_matrix
+
+    invalid_dir = tmp_path / "invalid"
+    shutil.copytree(run_dir, invalid_dir)
+    finalize_manifest(
+        invalid_dir,
+        status="INVALID",
+        finalized_at="2026-01-03T00:00:00Z",
+        invalid_reason="near-zero retrieval across the run's cases",
+    )
+    invalid = load_manifest(invalid_dir)
+    assert invalid.status == "INVALID"
+
+    matrix = _build(_redeclare_variant(packet, invalid.provider_variant), invalid)
+    # The declared identity matches, so no divergence at all — and the matrix is
+    # still not publishable, because the run itself is not VALID.
+    assert matrix.divergences == ()
+    assert matrix.run_status == "INVALID"
+    assert matrix.invalid_reason == "near-zero retrieval across the run's cases"
+    assert matrix.invalidates() is True
+
+    rendered = render_compat_matrix(matrix)
+    assert "INVALID" in rendered
+    assert "near-zero retrieval across the run's cases" in rendered
+
+
+def test_a_manifest_without_a_bound_observed_variant_refuses(manifest, packet) -> None:
+    from benchmarks.reports.compat import CompatMatrixError
+
+    with pytest.raises(CompatMatrixError, match="observed variant"):
+        _build(packet, manifest.model_copy(update={"provider_variant": None}))
+
+
+def test_an_empty_privileged_endpoint_matrix_refuses_by_name(manifest, packet) -> None:
+    """F7: a named refusal, not a raw pydantic tuple-length error."""
+
+    from benchmarks.reports.compat import CompatMatrixError
+
+    empty = packet.model_copy(update={"privileged_endpoint_matrix": ()})
+    with pytest.raises(CompatMatrixError, match="privileged endpoint matrix"):
+        _build(empty, manifest)
+
+
+def _design_variant_vocabulary() -> tuple[str, ...]:
+    """Expand the registry list of design.md:43-52 out of the document itself."""
+
+    design = (
+        REPO_ROOT
+        / "openspec"
+        / "changes"
+        / "add-competitive-benchmark-programme"
+        / "design.md"
+    ).read_text(encoding="utf-8")
+    block = design.split("**Variants never collapse**", 1)[1]
+    block = block.split("`no-memory`", 1)[0] + "`no-memory`"
+    names: list[str] = []
+    for token in re.findall(r"`([^`]+)`", block):
+        braced = re.fullmatch(r"([a-z0-9-]+)-\{([^}]+)\}", token)
+        if braced is not None:
+            prefix, leaves = braced.groups()
+            names.extend(f"{prefix}-{leaf.strip()}" for leaf in leaves.split(","))
+        elif re.fullmatch(r"[a-z0-9-]+", token):
+            names.append(token)
+    return tuple(names)
+
+
+def test_the_registered_variant_vocabulary_is_the_design_document_s_own() -> None:
+    """I2: no new variant names are minted here."""
+
+    from benchmarks.reports.compat import VARIANT_VOCABULARY, VARIANTS_BY_PROVIDER
+
+    expected = _design_variant_vocabulary()
+    assert len(expected) == 14
+    assert VARIANT_VOCABULARY == frozenset(expected)
+    # Every registered variant belongs to exactly one provider.
+    flattened = [name for names in VARIANTS_BY_PROVIDER.values() for name in names]
+    assert sorted(flattened) == sorted(expected)
+    assert len(flattened) == len(set(flattened))
+
+
+def test_both_variant_identities_are_disclosed_on_the_cell(manifest, packet) -> None:
+    """F1 / spec :61-66 — 'in every artifact' covers the observed identity too."""
+
+    from benchmarks.reports.compat import VARIANT_VOCABULARY
+
+    # The real runner binds `hybrid-rag-fixture`, which is not registered.
+    assert manifest.provider_variant not in VARIANT_VOCABULARY
+
+    unregistered = _build(packet, manifest)
+    assert all(cell.declared_variant_registered is False for cell in unregistered.cells)
+    assert all(cell.observed_variant_registered is False for cell in unregistered.cells)
+
+    registered = _build(_redeclare_variant(packet, "exomem-native"), manifest)
+    assert all(cell.declared_variant_registered is True for cell in registered.cells)
+    assert all(cell.observed_variant_registered is False for cell in registered.cells)
+
+    observed_registered = manifest.model_copy(update={"provider_variant": "exomem-native"})
+    both = _build(_redeclare_variant(packet, "exomem-native"), observed_registered)
+    assert all(cell.observed_variant_registered is True for cell in both.cells)
+
+
+def test_a_provider_differing_from_the_observed_variant_s_provider_is_a_divergence(
+    manifest, packet
+) -> None:
+    """F2: the vocabulary names are provider-prefixed, so the provider compares."""
+
+    observed = manifest.model_copy(update={"provider_variant": "exomem-native"})
+    matrix = _build(_redeclare_variant(packet, "exomem-native"), observed)
+    provider_findings = [item for item in matrix.divergences if item.kind == "provider"]
+    assert provider_findings
+    for finding in provider_findings:
+        assert finding.declared == "fixture"
+        assert finding.observed == "exomem"
+    assert all(cell.observed_provider == "exomem" for cell in matrix.cells)
+    assert matrix.invalidates() is True
+
+
+def test_an_unregistered_observed_variant_discloses_that_provider_comparison_failed(
+    manifest, packet
+) -> None:
+    """F2, the other half: say so rather than silently skipping the check."""
+
+    from benchmarks.reports.compat import render_compat_matrix
+
+    matrix = _build(packet, manifest)
+    assert all(cell.observed_provider is None for cell in matrix.cells)
+    assert [item for item in matrix.divergences if item.kind == "provider"] == []
+    assert "provider comparison not possible" in render_compat_matrix(matrix)

--- a/tests/test_reports_compat.py
+++ b/tests/test_reports_compat.py
@@ -293,3 +293,28 @@ def test_an_unregistered_observed_variant_discloses_that_provider_comparison_fai
     assert all(cell.observed_provider is None for cell in matrix.cells)
     assert [item for item in matrix.divergences if item.kind == "provider"] == []
     assert "provider comparison not possible" in render_compat_matrix(matrix)
+
+
+def test_rendering_refuses_free_text_that_carries_an_aggregate(
+    run_dir: Path, packet, tmp_path: Path
+) -> None:
+    """Integration fold: an invalid_reason is free text on its way to the page."""
+
+    from protocol.manifest import finalize_manifest, load_manifest
+
+    from benchmarks.reports.compat import render_compat_matrix
+    from benchmarks.reports.guards import ReportRefused
+
+    aggregate_dir = tmp_path / "aggregate"
+    shutil.copytree(run_dir, aggregate_dir)
+    finalize_manifest(
+        aggregate_dir,
+        status="INVALID",
+        finalized_at="2026-01-04T00:00:00Z",
+        invalid_reason="the aggregate MemScore was consumed as a result",
+    )
+    invalid = load_manifest(aggregate_dir)
+
+    matrix = _build(_redeclare_variant(packet, invalid.provider_variant), invalid)
+    with pytest.raises(ReportRefused, match="never publish an aggregate"):
+        render_compat_matrix(matrix)

--- a/tests/test_reports_consolidate.py
+++ b/tests/test_reports_consolidate.py
@@ -382,7 +382,7 @@ def test_h3_two_providers_carrying_host_unvalidated_latency_end_to_end(tmp_path:
     memorybench-export.v1.json with host_unvalidated latency -> no
     comparative column, but neither provider's own indicative row is
     dropped (F1's correction to the original, wrong, "no numbers at all"
-    pin)."""
+    pin); H1: the two never share a `latency_ms` column/table."""
 
     from reports.consolidate import consolidate
 
@@ -394,12 +394,17 @@ def test_h3_two_providers_carrying_host_unvalidated_latency_end_to_end(tmp_path:
 
     report = (out_dir / "report.md").read_text(encoding="utf-8")
     assert "## Latency" in report
-    assert "| exomem | n/a | indicative (host_unvalidated) |" in report
-    assert "| basic-memory | n/a | indicative (host_unvalidated) |" in report
+    assert "### exomem" in report
+    assert "### basic-memory" in report
+    assert "| n/a | indicative (host_unvalidated) |" in report
     assert "withheld: transport asymmetry (4b.40)" in report
-    # No comparative construct: neither provider's row is ever juxtaposed
-    # against the other inside a single cell.
-    assert "exomem | basic-memory" not in report
+    # H1: no shared column -- each provider's own table/header appears
+    # exactly once, never one table both providers' rows land in.
+    assert report.count("| latency_ms | disposition |") == 2
+    exomem_block = report.split("### exomem", 1)[1].split("### basic-memory", 1)[0]
+    basic_memory_block = report.split("### basic-memory", 1)[1]
+    assert "| latency_ms | disposition |" in exomem_block
+    assert "| latency_ms | disposition |" in basic_memory_block
     assert "aggregate" not in report.lower()
 
 
@@ -412,7 +417,8 @@ def test_h3_a_single_provider_export_renders_without_the_withheld_marker(tmp_pat
     consolidate([export_dir], out_dir, repo_root=REPO_ROOT)
 
     report = (out_dir / "report.md").read_text(encoding="utf-8")
-    assert "| exomem | n/a | indicative (host_unvalidated) |" in report
+    assert "### exomem" in report
+    assert "| n/a | indicative (host_unvalidated) |" in report
     assert "withheld: transport asymmetry (4b.40)" not in report
 
 

--- a/tests/test_reports_consolidate.py
+++ b/tests/test_reports_consolidate.py
@@ -1,0 +1,517 @@
+"""D3 reports/consolidate.py + D4: artifact-only, offline consolidation.
+
+    python -m benchmarks.reports.consolidate --run <dir> [--run <dir>...] --out <dir>
+
+Re-derives the pre-registration identity from the checked-in receipts (never
+trusts a run's own claim), refuses non-terminal manifests and unknown
+schema_versions, runs under offline_guard, writes consolidated.json then
+report.md on success only, and never mutates a run directory. Also wires
+9.1's cross-provider latency refusal end-to-end: a --run directory carrying
+a memorybench-export.v1.json feeds a ProviderLatency observation into
+render_all.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+FIXTURE = Path("benchmarks/lme/fixtures/mini.json")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _lme_run(out: Path, run_id: str, provider: str = "hybrid-rag-control"):
+    from lme.reader import StubReader
+    from lme.runner import RunConfig, execute_run
+
+    with mock.patch.dict(os.environ, {"PROTOCOL_FIXTURE_EMBEDDER": "1", "EXOMEM_DISABLE_EMBEDDINGS": "1"}):
+        return execute_run(
+            RunConfig(dataset=FIXTURE, out=out, reader_name="stub", run_id=run_id, provider=provider),
+            reader=StubReader(),
+        )
+
+
+def _started_manifest(run_dir: Path) -> None:
+    from protocol.manifest import start_manifest
+
+    start_manifest(
+        run_dir, run_id="started",
+        dataset={"id": "fixture", "variant": "mini", "source": "local", "revision": "1", "sha256": "a" * 64, "case_count": 0},
+        started_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _memorybench_export_dir(base: Path, *, provider: str, run_id: str) -> Path:
+    """A directory carrying memorybench-export.v1.json, serialized exactly
+    the way the real writer does it (memorybench/export.py:1675-1694:
+    `_json_bytes` -> `json.dumps(payload, sort_keys=True,
+    separators=(",", ":"), allow_nan=False) + "\\n"`, written to
+    `<output_root>/memorybench-export.v1.json`).
+
+    Built from the real `protocol.models.MemoryBenchExport` pydantic model
+    rather than the full `_build_export` pipeline: that pipeline needs a live
+    provider run under a real memorybench checkout (checkpoint.json,
+    dataset rows, a `MemoryBenchRunPlan` pointing at an on-disk
+    `memorybench_home`) -- heavier than a report-rendering fixture warrants.
+    The case/harness/dataset shape below mirrors the codebase's own two
+    existing fixtures for this exact model: tests/test_protocol_schema_
+    conformance.py::_memorybench_payloads (the full export dict, validated
+    against the committed JSON Schema) and tests/test_memorybench_export_
+    observations.py::_case (the self-consistent case shape, both
+    observations present, nothing declared missing) -- so this is the real
+    pydantic model, serialized the way export.py serializes it, not an
+    invented convenience shape.
+    """
+
+    from protocol.models import (
+        MEMORYBENCH_BUN_LOCK_SHA256,
+        MEMORYBENCH_COMMIT,
+        MEMORYBENCH_REPOSITORY,
+        MEMORYBENCH_TREE,
+        MemoryBenchExport,
+    )
+
+    harness = {
+        "repository": MEMORYBENCH_REPOSITORY, "commit": MEMORYBENCH_COMMIT,
+        "tree": MEMORYBENCH_TREE, "bun_lock_sha256": MEMORYBENCH_BUN_LOCK_SHA256,
+    }
+    dataset = {
+        "id": "longmemeval", "variant": "s", "source": "local", "revision": "pin",
+        "sha256": "a" * 64, "case_count": 1,
+    }
+    phases = {
+        "ingest": {"status": "completed", "failure_code": None},
+        "indexing": {"status": "completed", "failure_code": None},
+        "search": {"status": "completed", "failure_code": None},
+    }
+    case = {
+        "case_ordinal": 1, "case_id_hmac_sha256": "a" * 64,
+        "question": {"text": "which lantern?", "type": "knowledge-update", "date": None},
+        "container_tag_hmac_sha256": "a" * 64,
+        # Evidence references left null (never scored/compared here), which
+        # is why `status` below is "partial" -- the model refuses "complete"
+        # without them ("export status contradicts evidence completeness").
+        "checkpoint": None, "canonical_result": None, "private_gold": None,
+        "phases": phases, "hits": [{"content": "a hit", "score": 0.0}],
+        "failure_codes": [], "missing_fields": [],
+        "search": {
+            "transmitted_query": "which lantern?", "options": {"limit": 10},
+            "normalized_hit_ids": ["Knowledge Base/Notes/a.md"],
+        },
+        "ingest": {"transmitted_payload_sha256": ["a" * 64]},
+    }
+    export = {
+        "protocol_version": "1.0.0", "schema_version": 1, "artifact_type": "memorybench-export.v1",
+        "status": "partial", "run_id": run_id, "provider": provider,
+        "provider_variant": f"{provider}-default", "benchmark": "longmemeval",
+        "harness": harness, "dataset": dataset,
+        "executed_stages": ["ingest", "indexing", "search"],
+        "excluded_stages": ["answer", "evaluate", "report"],
+        "privacy": {
+            "classification": "provider_safe_reader_input", "contains_ground_truth": False,
+            "source_results_contain_ground_truth": True,
+        },
+        "latency": {"publishable": False, "reason": "host_unvalidated"},
+        "failure_codes": [], "cases": [case], "session_normalization": None, "readiness": None,
+    }
+    validated = MemoryBenchExport.model_validate(export).model_dump(mode="json")
+    export_dir = base / f"export-{provider}"
+    export_dir.mkdir(parents=True)
+    payload = json.dumps(validated, sort_keys=True, separators=(",", ":"), allow_nan=False) + "\n"
+    (export_dir / "memorybench-export.v1.json").write_text(payload, encoding="utf-8")
+    return export_dir
+
+
+def _bogus_memorybench_export_dir(base: Path, *, mutate) -> Path:
+    """A directory carrying a corrupted memorybench-export.v1.json: the same
+    real, valid export dict `_memorybench_export_dir` builds and validates,
+    but with `mutate` applied to the dict AFTER validation would have caught
+    it and written WITHOUT re-validating -- a bogus artifact on disk, the
+    same shape a real one could be corrupted into (mirrors
+    test_r2_unknown_schema_version_exits_non_zero_and_writes_nothing's own
+    technique of mutating a real writer's output), never a hand-invented
+    shape.
+    """
+
+    from protocol.models import (
+        MEMORYBENCH_BUN_LOCK_SHA256,
+        MEMORYBENCH_COMMIT,
+        MEMORYBENCH_REPOSITORY,
+        MEMORYBENCH_TREE,
+        MemoryBenchExport,
+    )
+
+    harness = {
+        "repository": MEMORYBENCH_REPOSITORY, "commit": MEMORYBENCH_COMMIT,
+        "tree": MEMORYBENCH_TREE, "bun_lock_sha256": MEMORYBENCH_BUN_LOCK_SHA256,
+    }
+    dataset = {
+        "id": "longmemeval", "variant": "s", "source": "local", "revision": "pin",
+        "sha256": "a" * 64, "case_count": 1,
+    }
+    phases = {
+        "ingest": {"status": "completed", "failure_code": None},
+        "indexing": {"status": "completed", "failure_code": None},
+        "search": {"status": "completed", "failure_code": None},
+    }
+    case = {
+        "case_ordinal": 1, "case_id_hmac_sha256": "a" * 64,
+        "question": {"text": "which lantern?", "type": "knowledge-update", "date": None},
+        "container_tag_hmac_sha256": "a" * 64,
+        "checkpoint": None, "canonical_result": None, "private_gold": None,
+        "phases": phases, "hits": [{"content": "a hit", "score": 0.0}],
+        "failure_codes": [], "missing_fields": [],
+        "search": {
+            "transmitted_query": "which lantern?", "options": {"limit": 10},
+            "normalized_hit_ids": ["Knowledge Base/Notes/a.md"],
+        },
+        "ingest": {"transmitted_payload_sha256": ["a" * 64]},
+    }
+    export = {
+        "protocol_version": "1.0.0", "schema_version": 1, "artifact_type": "memorybench-export.v1",
+        "status": "partial", "run_id": "bogus-run", "provider": "exomem",
+        "provider_variant": "exomem-default", "benchmark": "longmemeval",
+        "harness": harness, "dataset": dataset,
+        "executed_stages": ["ingest", "indexing", "search"],
+        "excluded_stages": ["answer", "evaluate", "report"],
+        "privacy": {
+            "classification": "provider_safe_reader_input", "contains_ground_truth": False,
+            "source_results_contain_ground_truth": True,
+        },
+        "latency": {"publishable": False, "reason": "host_unvalidated"},
+        "failure_codes": [], "cases": [case], "session_normalization": None, "readiness": None,
+    }
+    # Sanity: the dict is genuinely valid BEFORE the caller's mutation --
+    # every red case below is a targeted corruption, not an accidentally
+    # malformed baseline.
+    MemoryBenchExport.model_validate(export)
+    mutate(export)
+    export_dir = base / "export-bogus"
+    export_dir.mkdir(parents=True)
+    payload = json.dumps(export, sort_keys=True, separators=(",", ":"), allow_nan=False) + "\n"
+    (export_dir / "memorybench-export.v1.json").write_text(payload, encoding="utf-8")
+    return export_dir
+
+
+def test_consolidate_writes_report_and_identity(tmp_path: Path) -> None:
+    from reports.consolidate import consolidate
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-happy")
+    out_dir = tmp_path / "out"
+
+    consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+
+    report = (out_dir / "report.md").read_text(encoding="utf-8")
+    assert "| Ability | Variant | Questions |" in report
+    assert "aggregate" not in report.lower()
+    payload = json.loads((out_dir / "consolidated.json").read_text(encoding="utf-8"))
+    assert payload["preregistration_identity"]["original"]["sha256"]
+    assert payload["preregistration_identity"]["amendments"] == [] or isinstance(
+        payload["preregistration_identity"]["amendments"], list
+    )
+
+
+def test_r4_identity_matches_derive_preregistration_identity_directly(tmp_path: Path) -> None:
+    from protocol.contracts import derive_preregistration_identity
+    from reports.consolidate import consolidate
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-r4")
+    out_dir = tmp_path / "out"
+
+    consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+    payload = json.loads((out_dir / "consolidated.json").read_text(encoding="utf-8"))
+
+    expected = derive_preregistration_identity(REPO_ROOT)
+    assert payload["preregistration_identity"] == expected.model_dump(mode="json")
+    assert payload["preregistration_identity"]["original"]["sha256"] == expected.original.sha256
+    assert [a["sequence"] for a in payload["preregistration_identity"]["amendments"]] == [
+        a.sequence for a in expected.amendments
+    ]
+
+
+def test_r1_non_terminal_manifest_exits_non_zero_and_writes_nothing(tmp_path: Path) -> None:
+    from reports.consolidate import main
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _started_manifest(run_dir)
+    out_dir = tmp_path / "out"
+
+    exit_code = main(["--run", str(run_dir), "--out", str(out_dir)])
+
+    assert exit_code != 0
+    assert not out_dir.exists()
+
+
+def test_r2_unknown_schema_version_exits_non_zero_and_writes_nothing(tmp_path: Path) -> None:
+    from reports.consolidate import main
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-schema-drift")
+    manifest_path = result.run_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    original_bytes = manifest_path.read_bytes()
+    manifest["schema_version"] = 99
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    exit_code = main(["--run", str(result.run_dir), "--out", str(out_dir)])
+
+    assert exit_code != 0
+    assert not out_dir.exists()
+    assert manifest_path.read_bytes() != original_bytes, "sanity: the mutation itself took"
+
+
+def test_never_mutates_a_run_directory(tmp_path: Path) -> None:
+    from reports.consolidate import consolidate
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-no-mutate")
+    before = {
+        path.relative_to(result.run_dir): path.read_bytes()
+        for path in sorted(result.run_dir.rglob("*")) if path.is_file()
+    }
+    out_dir = tmp_path / "out"
+
+    consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+
+    after = {
+        path.relative_to(result.run_dir): path.read_bytes()
+        for path in sorted(result.run_dir.rglob("*")) if path.is_file()
+    }
+    assert before == after
+
+
+def test_r7_consolidated_report_never_contains_aggregate(tmp_path: Path) -> None:
+    from reports.consolidate import consolidate
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-no-aggregate")
+    out_dir = tmp_path / "out"
+
+    consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+
+    report = (out_dir / "report.md").read_text(encoding="utf-8")
+    assert "Aggregate" not in report
+    assert "aggregate" not in report
+
+
+def test_f4_a_manifest_and_a_cohort_in_the_same_directory_is_refused(tmp_path: Path) -> None:
+    """F4: `_classify` must not silently pick one lane when a directory
+    carries both an LME manifest and an epistemic cohort."""
+
+    from reports.consolidate import consolidate
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-ambiguous")
+    (result.run_dir / "validated-cohort.v1.json").write_text("{}", encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+    assert not out_dir.exists()
+
+
+def test_f5_identity_is_written_before_the_report(tmp_path: Path) -> None:
+    """F5: if a failure lands between the two writes, consolidated.json (the
+    identity) must already be on disk -- never a report standing without it."""
+
+    import reports.consolidate as consolidate_module
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-write-order")
+    out_dir = tmp_path / "out"
+
+    real_write_text = Path.write_text
+
+    def _fail_on_report(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self.name == "report.md":
+            raise OSError("simulated failure writing report.md")
+        return real_write_text(self, *args, **kwargs)
+
+    with mock.patch.object(Path, "write_text", _fail_on_report):
+        with pytest.raises(OSError, match="simulated failure writing report.md"):
+            consolidate_module.consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+
+    assert (out_dir / "consolidated.json").is_file(), "identity must survive a later write failure"
+    assert not (out_dir / "report.md").is_file()
+
+
+def test_f6_a_blocked_row_renders_its_own_status_never_a_fabricated_score(tmp_path: Path) -> None:
+    """F6/D3: "a blocked row renders `blocked: <reason>`, never a loss".
+
+    Produced from the real writer's own output: `lme.runner.execute_run`
+    writes one gold-evidence-ceiling.jsonl line per question; removing one
+    line (rather than hand-writing a manifest) is the same minimal-mutation
+    technique tests/test_report_offline.py already uses on `contamination`/
+    `status` -- the row for that question's ability is then genuinely
+    "blocked: missing gold-evidence ceiling" per lme/report.py:108, the one
+    place in the reused renderers that emits the literal word "blocked".
+    """
+
+    from reports.consolidate import consolidate
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-blocked-row")
+    ceiling_path = result.run_dir / "bounds" / "gold-evidence-ceiling.jsonl"
+    kept = [
+        line for line in ceiling_path.read_text(encoding="utf-8").splitlines()
+        if json.loads(line)["question_id"] != "mini-single-user"
+    ]
+    ceiling_path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    consolidate([result.run_dir], out_dir, repo_root=REPO_ROOT)
+
+    report = (out_dir / "report.md").read_text(encoding="utf-8")
+    row = next(line for line in report.splitlines() if line.startswith("| single-session-user"))
+    assert row.strip().endswith("| blocked: missing gold-evidence ceiling |"), row
+    assert not re.search(r"\d+/\d+", row), f"a blocked row must never carry a fabricated score: {row}"
+
+
+def test_h3_two_providers_carrying_host_unvalidated_latency_end_to_end(tmp_path: Path) -> None:
+    """H3 end-to-end: two --run directories each carrying a real
+    memorybench-export.v1.json with host_unvalidated latency -> no
+    comparative column, but neither provider's own indicative row is
+    dropped (F1's correction to the original, wrong, "no numbers at all"
+    pin)."""
+
+    from reports.consolidate import consolidate
+
+    export_a = _memorybench_export_dir(tmp_path, provider="exomem", run_id="run-a")
+    export_b = _memorybench_export_dir(tmp_path, provider="basic-memory", run_id="run-b")
+    out_dir = tmp_path / "out"
+
+    consolidate([export_a, export_b], out_dir, repo_root=REPO_ROOT)
+
+    report = (out_dir / "report.md").read_text(encoding="utf-8")
+    assert "## Latency" in report
+    assert "| exomem | n/a | indicative (host_unvalidated) |" in report
+    assert "| basic-memory | n/a | indicative (host_unvalidated) |" in report
+    assert "withheld: transport asymmetry (4b.40)" in report
+    # No comparative construct: neither provider's row is ever juxtaposed
+    # against the other inside a single cell.
+    assert "exomem | basic-memory" not in report
+    assert "aggregate" not in report.lower()
+
+
+def test_h3_a_single_provider_export_renders_without_the_withheld_marker(tmp_path: Path) -> None:
+    from reports.consolidate import consolidate
+
+    export_dir = _memorybench_export_dir(tmp_path, provider="exomem", run_id="run-solo")
+    out_dir = tmp_path / "out"
+
+    consolidate([export_dir], out_dir, repo_root=REPO_ROOT)
+
+    report = (out_dir / "report.md").read_text(encoding="utf-8")
+    assert "| exomem | n/a | indicative (host_unvalidated) |" in report
+    assert "withheld: transport asymmetry (4b.40)" not in report
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda export: export.__setitem__("schema_version", 99), "schema_version"),
+        (lambda export: export.__setitem__("artifact_type", "not-an-export"), "artifact_type|literal|Input should be"),
+        (lambda export: export.__delitem__("provider"), "provider|Field required"),
+    ],
+    ids=["bogus-schema-version", "bogus-artifact-type", "truncated-missing-provider"],
+)
+def test_a_malformed_memorybench_export_is_refused_not_consumed(
+    tmp_path: Path, mutate, match: str
+) -> None:
+    """The HIGH finding this micro-round fixes: `_latency_observation` used
+    to validate only the `latency` sub-object, so a corrupted export
+    (unknown schema_version, wrong artifact_type, or missing `provider`)
+    was consumed anyway and rendered a latency row. It must refuse exactly
+    like an unknown-schema_version LME manifest does -- exit non-zero,
+    nothing written -- never a raw KeyError."""
+
+    from reports.consolidate import main
+
+    export_dir = _bogus_memorybench_export_dir(tmp_path, mutate=mutate)
+    out_dir = tmp_path / "out"
+
+    exit_code = main(["--run", str(export_dir), "--out", str(out_dir)])
+
+    assert exit_code != 0
+    assert not out_dir.exists()
+
+
+def test_a_malformed_memorybench_export_raises_a_validation_error_not_a_keyerror(
+    tmp_path: Path,
+) -> None:
+    """Calling `consolidate()` directly (below the CLI's broad except)
+    proves the refusal is a real pydantic ValidationError, not a KeyError
+    that a differently-shaped corruption could slip past."""
+
+    from pydantic import ValidationError
+    from reports.consolidate import consolidate
+
+    export_dir = _bogus_memorybench_export_dir(
+        tmp_path, mutate=lambda export: export.__delitem__("provider")
+    )
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(ValidationError):
+        consolidate([export_dir], out_dir, repo_root=REPO_ROOT)
+    assert not out_dir.exists()
+
+
+def test_r5_consolidate_runs_under_its_own_offline_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """H2: the injected render_all must actually be reached -- a real run
+    directory (built by the real writer), not an empty one _classify would
+    refuse before offline_guard is ever entered."""
+
+    import reports.consolidate as consolidate_module
+
+    def _sneaky(inputs, *, latency=()):  # type: ignore[no-untyped-def]
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.settimeout(1.0)
+        with probe:
+            probe.connect(("127.0.0.1", 9))
+        return "unreachable"
+
+    monkeypatch.setattr(consolidate_module, "render_all", _sneaky)
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-offline-guard")
+    out_dir = tmp_path / "out"
+
+    exit_code = consolidate_module.main(["--run", str(result.run_dir), "--out", str(out_dir)])
+
+    assert exit_code != 0
+    assert not out_dir.exists()
+    stderr = capsys.readouterr().err
+    assert "offline report generation forbids socket.connect" in stderr, stderr
+
+
+def test_the_cli_module_is_runnable_as_python_dash_m(tmp_path: Path) -> None:
+    import subprocess
+    import sys
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "consolidate-cli")
+    out_dir = tmp_path / "out"
+
+    completed = subprocess.run(
+        [
+            sys.executable, "-m", "benchmarks.reports.consolidate",
+            "--run", str(result.run_dir), "--out", str(out_dir),
+        ],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert (out_dir / "report.md").is_file()
+    assert (out_dir / "consolidated.json").is_file()

--- a/tests/test_reports_fairness.py
+++ b/tests/test_reports_fairness.py
@@ -1,0 +1,338 @@
+"""9.2: the fairness matrix — the eight published fields, and the refusal.
+
+Every field name here is read out of ``docs/benchmark-fairness-contract.md`` at
+assert time rather than restated, so the row model cannot drift away from the
+published contract without this file going red.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from epistemic.projectors.exomem_vault import VaultProjector
+from epistemic.snapshot import FieldDeclaration
+from protocol.models import LaneReadiness
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = REPO_ROOT / "docs" / "benchmark-fairness-contract.md"
+VAULT = REPO_ROOT / "benchmarks" / "epistemic" / "fixtures" / "vault"
+
+MATRIX_HEADING = "## Fairness-matrix row (rendered per lane × provider × variant)"
+
+
+def _doc_field_labels() -> tuple[str, ...]:
+    """The row labels of the contract's fairness-matrix table, in file order."""
+
+    lines = CONTRACT.read_text(encoding="utf-8").splitlines()
+    start = lines.index(MATRIX_HEADING)
+    labels: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        match = re.match(r"^\|\s*([^|]+?)\s*\|", line)
+        if match is None:
+            continue
+        label = match.group(1)
+        if label == "Field" or set(label) <= {"-", ":"}:
+            continue
+        labels.append(label)
+    return tuple(labels)
+
+
+def _glue():
+    from benchmarks.reports.fairness import GlueAccounting
+
+    return GlueAccounting.for_projector(
+        VaultProjector(VAULT), repo_root=REPO_ROOT, reviewer_disposition="unreviewed"
+    )
+
+
+def _readiness() -> tuple[LaneReadiness, ...]:
+    return (
+        LaneReadiness(
+            lane="exomem",
+            requested=True,
+            verified=True,
+            method="config-state",
+            evidence="evidence/readiness/exomem.json",
+        ),
+    )
+
+
+def _payload(**changes):
+    from benchmarks.reports.fairness import (
+        Asymmetry,
+        BlockedMeasurement,
+        CapabilityDeclarationCounts,
+    )
+
+    payload = {
+        "lane": "epistemic",
+        "provider": "exomem",
+        "variant": "exomem-native",
+        "config_source": {"vault_root": "benchmarks/epistemic/PREREGISTRATION.md:16"},
+        "config_authored_by": {"vault_root": "exomem"},
+        "exomem_authored_glue": _glue(),
+        "asymmetries": (
+            Asymmetry(
+                description="the vault projector reads the filesystem directly",
+                favours="exomem",
+                evidence="benchmarks/epistemic/projectors/exomem_vault.py:405",
+            ),
+        ),
+        "capability_declarations": CapabilityDeclarationCounts.from_declarations(
+            VaultProjector(VAULT).declarations()
+        ),
+        "readiness": _readiness(),
+        "pins": {"exomem": "0f239f0317df83ac77b65f734812bf41f4967251"},
+        "blocked_measurements": (
+            BlockedMeasurement(
+                measurement="cross-provider latency",
+                reason="host is known-unvalidated for latency",
+                unblock_command="uv run python benchmarks/run.py latency --host-validated",
+            ),
+        ),
+    }
+    payload.update(changes)
+    return payload
+
+
+def _row(**changes):
+    from benchmarks.reports.fairness import FairnessRow
+
+    return FairnessRow(**_payload(**changes))
+
+
+def test_the_eight_published_fields_are_the_contract_document_s_own() -> None:
+    """I1: the field names are copied from the doc, never paraphrased."""
+
+    from benchmarks.reports.fairness import (
+        EMPTY_DISCLOSURE_REASONS,
+        FAIRNESS_MATRIX_FIELDS,
+        FairnessRow,
+    )
+
+    labels = _doc_field_labels()
+    assert len(labels) == 8
+    assert tuple(label for label, _ in FAIRNESS_MATRIX_FIELDS) == labels
+
+    attributes = tuple(attribute for _, attribute in FAIRNESS_MATRIX_FIELDS)
+    fields = tuple(FairnessRow.model_fields)
+    assert fields[:3] == ("lane", "provider", "variant")
+    assert fields[3:11] == attributes
+    # The disclosure companions come after the eight and never displace them: an
+    # empty published field still has to state a claim rather than say nothing.
+    assert fields[11:] == tuple(reason for _, reason in EMPTY_DISCLOSURE_REASONS)
+
+
+def test_a_complete_row_carries_the_glue_accounting_the_projector_published() -> None:
+    row = _row()
+    meta = VaultProjector(VAULT).meta()
+    assert row.key == ("epistemic", "exomem", "exomem-native")
+    assert row.exomem_authored_glue.projector.loc == meta.loc
+    assert row.exomem_authored_glue.projector.endpoints_used == meta.endpoints_used
+    assert meta.loc > 0
+
+
+def test_glue_accounting_binds_its_loc_to_the_disclosed_files() -> None:
+    """F4: the LOC number must be about a file the row actually discloses."""
+
+    from benchmarks.reports.fairness import GlueAccounting
+
+    projector = VaultProjector(VAULT)
+    glue = _glue()
+    assert glue.projector_module == "benchmarks/epistemic/projectors/exomem_vault.py"
+    assert glue.projector_module in glue.files
+    assert glue.projector.loc == projector.meta().loc
+
+    with pytest.raises(ValidationError, match="projector module"):
+        GlueAccounting(
+            files=("benchmarks/reports/fairness.py",),
+            projector=projector.meta(),
+            projector_module="benchmarks/epistemic/projectors/exomem_vault.py",
+            reviewer_disposition="unreviewed",
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "config_source",
+        "config_authored_by",
+        "exomem_authored_glue",
+        "asymmetries",
+        "capability_declarations",
+        "readiness",
+        "pins",
+        "blocked_measurements",
+    ],
+)
+def test_a_row_missing_any_published_field_is_a_validation_error(field: str) -> None:
+    """R2: all eight are required; none of them has a silent default."""
+
+    from benchmarks.reports.fairness import FairnessRow
+
+    payload = _payload()
+    payload.pop(field)
+    with pytest.raises(ValidationError) as excinfo:
+        FairnessRow(**payload)
+    assert field in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("field", "reason", "empty"),
+    [
+        ("config_source", "no_config_source_reason", {}),
+        ("asymmetries", "no_asymmetries_reason", ()),
+        ("pins", "no_pins_reason", {}),
+        ("blocked_measurements", "no_blocked_measurements_reason", ()),
+    ],
+)
+def test_an_empty_published_field_must_state_why(field: str, reason: str, empty) -> None:
+    """F3: 'none declared' is a claim someone makes, never a silent default."""
+
+    from benchmarks.reports.fairness import FairnessRow
+
+    emptied = {field: empty}
+    if field == "config_source":
+        emptied["config_authored_by"] = {}
+
+    with pytest.raises(ValidationError, match=reason):
+        FairnessRow(**_payload(**emptied))
+
+    stated = _row(**{**emptied, reason: "this control row applies no competitor-side setting"})
+    assert getattr(stated, reason)
+
+    with pytest.raises(ValidationError, match="cannot both"):
+        FairnessRow(**_payload(**{reason: "this control row applies no setting"}))
+
+
+def test_capability_declaration_counts_come_from_real_declarations() -> None:
+    from benchmarks.reports.fairness import CapabilityDeclarationCounts
+
+    declarations = (
+        FieldDeclaration(field="a", status="declared", evidence="https://example.invalid/a"),
+        FieldDeclaration(
+            field="b", status="absent_by_design", evidence="https://example.invalid/b"
+        ),
+        FieldDeclaration(
+            field="c",
+            status="absent_by_design",
+            evidence="https://example.invalid/c",
+            marketing_claim="the product markets this",
+        ),
+        FieldDeclaration(field="d", status="unavailable", evidence="https://example.invalid/d"),
+    )
+    counts = CapabilityDeclarationCounts.from_declarations(declarations)
+    # `not_applicable` comes only from an unclaimed `absent_by_design`
+    # declaration — a claimed one scores `fail` (benchmarks/epistemic/
+    # assertions.py:427-441), so the two counts are deliberately not equal.
+    assert counts.absent_by_design == 2
+    assert counts.not_applicable == 1
+    assert counts.unavailable == 1
+
+
+def test_a_config_source_that_is_neither_a_citation_nor_a_url_refuses() -> None:
+    from benchmarks.reports.fairness import FairnessRow
+
+    with pytest.raises(ValidationError, match="path:line"):
+        FairnessRow(**_payload(config_source={"vault_root": "we asked them"}))
+
+
+def test_config_authorship_must_cover_exactly_the_sourced_settings() -> None:
+    from benchmarks.reports.fairness import FairnessRow
+
+    with pytest.raises(ValidationError, match="authorship"):
+        FairnessRow(**_payload(config_authored_by={"other_knob": "competitor"}))
+
+
+def test_a_row_may_not_carry_an_absolute_local_path(tmp_path: Path) -> None:
+    """D4: rendered artifacts carry paths relative to the run root.
+
+    The absolute path is produced at runtime rather than written as a literal:
+    an absolute local path spelled out in a committed test is itself what
+    ``scripts/validate-public-artifacts.py`` refuses.
+    """
+
+    from benchmarks.reports.fairness import GlueAccounting
+
+    absolute = str(tmp_path / "benchmarks" / "epistemic" / "projectors" / "exomem_vault.py")
+    assert Path(absolute).is_absolute()
+    with pytest.raises(ValidationError, match="relative"):
+        GlueAccounting(
+            files=(absolute,),
+            projector=VaultProjector(VAULT).meta(),
+            projector_module=absolute,
+            reviewer_disposition="unreviewed",
+        )
+
+
+def test_a_row_may_not_escape_the_run_root_by_traversal() -> None:
+    """F6: the `..` half of the path guard, which no earlier mutant reached."""
+
+    from benchmarks.reports.fairness import GlueAccounting
+
+    escape = "../escape.md"
+    with pytest.raises(ValidationError, match="traversal"):
+        GlueAccounting(
+            files=(escape,),
+            projector=VaultProjector(VAULT).meta(),
+            projector_module=escape,
+            reviewer_disposition="unreviewed",
+        )
+
+
+def test_missing_fairness_entry_blocks_publication() -> None:
+    """R1 / spec :22-24 — the named key is in the refusal."""
+
+    from benchmarks.reports.fairness import FairnessMatrixError, require_complete
+
+    rows = (_row(),)
+    expected = (
+        ("epistemic", "exomem", "exomem-native"),
+        ("epistemic", "basic-memory", "basic-memory-native-git"),
+    )
+    with pytest.raises(FairnessMatrixError) as excinfo:
+        require_complete(rows, expected)
+    message = str(excinfo.value)
+    assert "missing fairness entry blocks publication" in message
+    assert "basic-memory-native-git" in message
+
+
+def test_require_complete_passes_when_every_expected_key_has_a_row() -> None:
+    from benchmarks.reports.fairness import require_complete
+
+    rows = (_row(),)
+    require_complete(rows, (("epistemic", "exomem", "exomem-native"),))
+
+
+def test_rendering_itself_refuses_an_incomplete_matrix() -> None:
+    """F5 / spec :22-24 — it is *rendering* that refuses, not only a helper."""
+
+    from benchmarks.reports.fairness import FairnessMatrixError, render_fairness_matrix
+
+    with pytest.raises(FairnessMatrixError, match="missing fairness entry blocks publication"):
+        render_fairness_matrix(
+            (_row(),),
+            expected_keys=(
+                ("epistemic", "exomem", "exomem-native"),
+                ("epistemic", "basic-memory", "basic-memory-native-git"),
+            ),
+        )
+
+
+def test_rendered_matrix_publishes_every_contract_field_and_one_row_per_key() -> None:
+    from benchmarks.reports.fairness import render_fairness_matrix
+
+    rows = (_row(), _row(provider="basic-memory", variant="basic-memory-native-git"))
+    rendered = render_fairness_matrix(rows, expected_keys=tuple(row.key for row in rows))
+    header = rendered.splitlines()[0]
+    for label in _doc_field_labels():
+        assert f"| {label} |" in header
+    body = [line for line in rendered.splitlines() if line.startswith("| epistemic |")]
+    assert len(body) == 2
+    assert "exomem-native" in rendered
+    assert "basic-memory-native-git" in rendered

--- a/tests/test_reports_fairness.py
+++ b/tests/test_reports_fairness.py
@@ -336,3 +336,30 @@ def test_rendered_matrix_publishes_every_contract_field_and_one_row_per_key() ->
     assert len(body) == 2
     assert "exomem-native" in rendered
     assert "basic-memory-native-git" in rendered
+
+
+@pytest.mark.parametrize("word", ["aggregate", "Aggregate", "AGGREGATE"])
+def test_rendering_refuses_free_text_that_carries_an_aggregate(word: str) -> None:
+    """Integration fold: the no-aggregate rule is a property of every renderer.
+
+    Lane 2's ``render_all`` refuses an aggregate at the consolidation layer, but
+    a row's own free text reaches the page through this renderer without passing
+    through it — so the refusal belongs here too. Capitalisation is covered
+    because the shared guard lowercases before matching, and a refusal that only
+    caught one casing would be trivially evaded by a sentence-initial word.
+    """
+
+    from benchmarks.reports.fairness import Asymmetry, render_fairness_matrix
+    from benchmarks.reports.guards import ReportRefused
+
+    row = _row(
+        asymmetries=(
+            Asymmetry(
+                description=f"the {word} MemScore favours the incumbent harness",
+                favours="basic-memory",
+                evidence="benchmarks/epistemic/PREREGISTRATION.md:16",
+            ),
+        )
+    )
+    with pytest.raises(ReportRefused, match="never publish an aggregate"):
+        render_fairness_matrix((row,), expected_keys=(row.key,))

--- a/tests/test_reports_import_closure.py
+++ b/tests/test_reports_import_closure.py
@@ -1,0 +1,237 @@
+"""D4: benchmarks/reports/ must never transitively reach a network-capable or
+provider-execution module.
+
+Mirrors the AST-walking technique of scripts/generate_harness_modules.py:29-60
+(`_imported_top_level_names`: parse a file, collect every import name at any
+nesting depth) but answers a different question: not "does this test file
+touch the harness at all", but "does the reports/ package's *own* module-level
+import graph ever reach one of a fixed set of forbidden modules".
+
+Two different rules for two different trust levels. Files INSIDE
+benchmarks/reports/ are OUR code: every scope is scanned -- module, class,
+function, async function, arbitrarily nested -- because a function-scoped
+forbidden import in reports/ itself (even one no code path calls yet) is
+exactly the kind of latent dependency this test exists to catch; a
+module-level-only scan would let `def render_all(): import httpx` inside
+render.py itself pass clean. Modules reached transitively OUTSIDE the
+package (lme/report.py, protocol/offline.py, and whatever they import in
+turn) keep the narrower, load-time-only rule: only imports that actually
+execute when a module is *loaded* -- module- and class-scope statements --
+are followed as graph edges and checked against the forbidden set there. A
+`def`-nested import in one of THOSE external files is guarded exactly the
+way benchmarks/membench/judge/backends.py:486 guards its own `import httpx`
+("lazy: offline flows must not require the dependency"): it never executes
+merely by importing the enclosing module, so it is not a real dependency of
+that import and must not fail this test on ITS behalf. Using the exhaustive
+rule everywhere would flag that lazy httpx import as "reached" even though
+nothing outside backends.py itself ever touches it.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BENCHMARKS_ROOT = REPO_ROOT / "benchmarks"
+REPORTS_ROOT = BENCHMARKS_ROOT / "reports"
+
+#: Forbidden dotted names/prefixes. Matched after stripping an optional
+#: leading "benchmarks." (both spellings reach the same file via
+#: tests/conftest.py's sys.path insert of benchmarks/ alongside the repo
+#: root itself being on sys.path).
+FORBIDDEN_PREFIXES = (
+    "lme.providers",
+    "lme.runner",
+    "memorybench.export",
+    "memorybench.recording_proxy",
+    "memorybench.traffic",
+    "httpx",
+    "requests",
+    "urllib.request",
+    "openai",
+    "anthropic",
+    "aiohttp",
+)
+#: "socket" is forbidden everywhere in the closure except inside
+#: protocol/offline.py, the one sanctioned network guard.
+SOCKET_NAME = "socket"
+SOCKET_EXCEPTION_FILE = BENCHMARKS_ROOT / "protocol" / "offline.py"
+
+
+def _strip_benchmarks_prefix(name: str) -> str:
+    if name == "benchmarks":
+        return ""
+    if name.startswith("benchmarks."):
+        return name[len("benchmarks.") :]
+    return name
+
+
+def _load_level_imports(path: Path, *, full_scan: bool) -> list[tuple[str, int]]:
+    """Every (dotted_name, ast_level) import reachable in `path`.
+
+    `ast_level` is the ImportFrom relative-import level (0 for absolute).
+    When `full_scan` is True (files under benchmarks/reports/ itself), every
+    scope is scanned -- the tree is walked unconditionally, function and
+    async-function bodies included, at any nesting depth: this is OUR code,
+    so a function-scoped forbidden import inside it counts even if nothing
+    calls that function today. When False (a module reached transitively
+    OUTSIDE the package), only module- and class-scope statements are
+    considered: a FunctionDef/AsyncFunctionDef subtree is never descended
+    into there, matching real Python import-time semantics -- a `def`-nested
+    import in an external module never executes merely by importing it.
+    """
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: list[tuple[str, int]] = []
+
+    def walk(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if not full_scan and isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue  # deferred: never executes merely by importing the module
+            if isinstance(child, ast.Import):
+                for alias in child.names:
+                    found.append((alias.name, 0))
+            elif isinstance(child, ast.ImportFrom):
+                if child.module:
+                    for alias in child.names:
+                        found.append((f"{child.module}.{alias.name}", child.level))
+                    found.append((child.module, child.level))
+                else:
+                    for alias in child.names:
+                        found.append((alias.name, child.level))
+            else:
+                walk(child)
+
+    walk(tree)
+    return found
+
+
+def _resolve_internal(path: Path, dotted: str, level: int) -> Path | None:
+    """Resolve a load-time import to a file under benchmarks/, if it is one."""
+
+    if level > 0:
+        base = path.parent
+        for _ in range(level - 1):
+            base = base.parent
+        parts = dotted.split(".") if dotted else []
+    else:
+        name = _strip_benchmarks_prefix(dotted)
+        if not name:
+            return None
+        base = BENCHMARKS_ROOT
+        parts = name.split(".")
+
+    candidate = base.joinpath(*parts)
+    module_file = candidate.with_suffix(".py")
+    if module_file.is_file():
+        return module_file
+    package_init = candidate / "__init__.py"
+    if package_init.is_file():
+        return package_init
+    # Falling one segment short is still informative for ImportFrom's
+    # doubled (module, module.name) entries -- try the parent too.
+    if len(parts) > 1:
+        parent_file = base.joinpath(*parts[:-1]).with_suffix(".py")
+        if parent_file.is_file():
+            return parent_file
+    return None
+
+
+def _is_under_reports_root(path: Path) -> bool:
+    try:
+        path.relative_to(REPORTS_ROOT)
+    except ValueError:
+        return False
+    return True
+
+
+def reports_import_closure() -> tuple[set[str], set[Path]]:
+    """(forbidden-checkable dotted names, files visited) reachable from reports/.
+
+    `rglob`, not `glob`: files under REPORTS_ROOT are scanned at every scope
+    regardless of nesting depth within the package (see
+    `_is_under_reports_root` / `_load_level_imports`'s `full_scan`).
+    """
+
+    visited: set[Path] = set()
+    names: set[str] = set()
+    queue = sorted(REPORTS_ROOT.rglob("*.py"))
+    while queue:
+        path = queue.pop()
+        if path in visited:
+            continue
+        visited.add(path)
+        full_scan = _is_under_reports_root(path)
+        for dotted, level in _load_level_imports(path, full_scan=full_scan):
+            if dotted != SOCKET_NAME or path != SOCKET_EXCEPTION_FILE:
+                names.add(_strip_benchmarks_prefix(dotted) if level == 0 else dotted)
+            resolved = _resolve_internal(path, dotted, level)
+            if resolved is not None and resolved not in visited:
+                queue.append(resolved)
+    return names, visited
+
+
+def _forbidden_hit(names: set[str]) -> str | None:
+    for name in names:
+        if name == SOCKET_NAME:
+            return name
+        for prefix in FORBIDDEN_PREFIXES:
+            if name == prefix or name.startswith(prefix + "."):
+                return name
+    return None
+
+
+def test_reports_closure_reaches_no_forbidden_module() -> None:
+    names, visited = reports_import_closure()
+    assert visited, "closure walk must visit at least the reports/ modules themselves"
+    hit = _forbidden_hit(names)
+    assert hit is None, f"forbidden import reachable from benchmarks/reports/: {hit}"
+
+
+def test_reports_closure_does_reach_protocol_offline() -> None:
+    """Sanity: the walker actually resolves internal edges, not vacuously empty."""
+
+    _names, visited = reports_import_closure()
+    assert SOCKET_EXCEPTION_FILE in visited
+
+
+@pytest.mark.parametrize(
+    "forbidden_snippet",
+    [
+        "import httpx\n",
+        "from lme.runner import execute_run\n",
+        "from memorybench.export import build_export\n",
+        # H1: a function-scoped import INSIDE a reports/ file must still be
+        # caught -- the FunctionDef skip is for files reached OUTSIDE the
+        # package, never for reports/ itself.
+        "def _sneaky_helper():\n    import httpx\n\n",
+    ],
+    ids=["module-httpx", "module-lme.runner", "module-memorybench.export", "function-scoped-httpx"],
+)
+def test_closure_goes_red_when_a_forbidden_import_is_injected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, forbidden_snippet: str
+) -> None:
+    """R6: mutate a scratch copy of render.py, prove this test would catch it."""
+
+    import shutil
+
+    scratch_benchmarks = tmp_path / "benchmarks"
+    shutil.copytree(BENCHMARKS_ROOT / "reports", scratch_benchmarks / "reports")
+    shutil.copytree(BENCHMARKS_ROOT / "protocol", scratch_benchmarks / "protocol")
+    render_path = scratch_benchmarks / "reports" / "render.py"
+    render_path.write_text(
+        forbidden_snippet + render_path.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    this_module = sys.modules[__name__]
+    monkeypatch.setattr(this_module, "BENCHMARKS_ROOT", scratch_benchmarks)
+    monkeypatch.setattr(this_module, "REPORTS_ROOT", scratch_benchmarks / "reports")
+    monkeypatch.setattr(
+        this_module, "SOCKET_EXCEPTION_FILE", scratch_benchmarks / "protocol" / "offline.py"
+    )
+    names, _visited = reports_import_closure()
+    assert _forbidden_hit(names) is not None

--- a/tests/test_reports_latency.py
+++ b/tests/test_reports_latency.py
@@ -1,0 +1,162 @@
+"""D3 reports/latency.py + R3: no cross-provider latency COMPARISON is
+publishable from this host (design.md #10, 4b.40) -- every provider's own
+number still renders, individually labelled "indicative"; two or more
+distinct providers additionally carry the withheld marker, but never lose a
+provider's own row (operational-quality-bench/spec.md:30-41: "latency on
+such hosts renders per-provider as indicative-only").
+"""
+
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+
+import pytest
+from protocol.models import MemoryBenchLatency
+
+
+def _host_unvalidated() -> MemoryBenchLatency:
+    return MemoryBenchLatency(publishable=False, reason="host_unvalidated")
+
+
+def test_zero_providers_render_nothing() -> None:
+    from reports.latency import assert_no_cross_provider_latency
+
+    assert assert_no_cross_provider_latency([]) == ""
+
+
+def test_a_single_provider_renders_with_the_word_indicative() -> None:
+    from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+
+    rendered = assert_no_cross_provider_latency(
+        [ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=12.5)]
+    )
+    assert "indicative" in rendered
+    assert "12.5" in rendered
+    assert "exomem" in rendered
+    assert "aggregate" not in rendered.lower()
+
+
+def test_r3_two_providers_get_a_withheld_marker_but_keep_their_own_rows() -> None:
+    """R3 + F1: a run whose export carries host_unvalidated latency for two
+    providers must never render a COMPARATIVE column -- but per spec.md's
+    own scenario ("latency on such hosts renders per-provider as
+    indicative-only"), neither provider's own figure is dropped."""
+
+    from reports.latency import WITHHELD_LATENCY, ProviderLatency, assert_no_cross_provider_latency
+
+    rendered = assert_no_cross_provider_latency(
+        [
+            ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=12.5),
+            ProviderLatency(provider="basic-memory", latency=_host_unvalidated(), value_ms=930.0),
+        ]
+    )
+    assert WITHHELD_LATENCY in rendered
+    assert "| exomem | 12.5 | indicative (host_unvalidated) |" in rendered
+    assert "| basic-memory | 930 | indicative (host_unvalidated) |" in rendered
+    # No comparative construct: the two never sit inside one juxtaposed cell.
+    assert "12.5 | 930" not in rendered
+    assert "exomem | basic-memory" not in rendered
+
+
+def test_three_providers_get_exactly_one_withheld_marker_and_three_rows() -> None:
+    from reports.latency import WITHHELD_LATENCY, ProviderLatency, assert_no_cross_provider_latency
+
+    rendered = assert_no_cross_provider_latency(
+        [
+            ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=1.0),
+            ProviderLatency(provider="basic-memory", latency=_host_unvalidated(), value_ms=2.0),
+            ProviderLatency(provider="supermemory", latency=_host_unvalidated(), value_ms=3.0),
+        ]
+    )
+    assert rendered.count(WITHHELD_LATENCY) == 1
+    assert rendered.count("indicative (host_unvalidated)") == 3
+    for provider in ("exomem", "basic-memory", "supermemory"):
+        assert f"| {provider} |" in rendered
+
+
+def test_repeated_observations_from_one_provider_are_not_treated_as_cross_provider() -> None:
+    """Two samples from the SAME provider are still one provider: only the
+    identity set matters, not the observation count."""
+
+    from reports.latency import WITHHELD_LATENCY, ProviderLatency, assert_no_cross_provider_latency
+
+    rendered = assert_no_cross_provider_latency(
+        [
+            ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=1.0),
+            ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=2.0),
+        ]
+    )
+    assert "indicative" in rendered
+    assert WITHHELD_LATENCY not in rendered
+
+
+def test_a_missing_value_ms_renders_as_not_available() -> None:
+    """reports/consolidate.py's own memorybench-export.v1.json source never
+    carries a millisecond figure (see ProviderLatency's docstring) -- the
+    cell must say so honestly rather than fabricate a number."""
+
+    from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+
+    rendered = assert_no_cross_provider_latency(
+        [ProviderLatency(provider="exomem", latency=_host_unvalidated())]
+    )
+    assert "| exomem | n/a | indicative (host_unvalidated) |" in rendered
+
+
+def test_f2_the_publishable_flag_is_load_bearing_not_decorative() -> None:
+    """F2: a number renders WITHOUT the indicative label only if
+    `latency.publishable` is True. Unreachable via the real model today
+    (`MemoryBenchLatency.publishable` is pinned `Literal[False]` -- pydantic
+    refuses to construct one with `publishable=True`), so this exercises the
+    branch with a duck-typed stand-in carrying the same `.publishable` /
+    `.reason` shape, proving the code actually reads the flag rather than
+    hardcoding "indicative" for every row."""
+
+    from pydantic import ValidationError
+    from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+
+    with pytest.raises(ValidationError):  # sanity: the real model truly forbids this
+        MemoryBenchLatency(publishable=True, reason="host_unvalidated")
+
+    validated_stand_in = SimpleNamespace(publishable=True, reason="host_validated")
+    rendered = assert_no_cross_provider_latency(
+        [ProviderLatency(provider="exomem", latency=validated_stand_in, value_ms=5.0)]  # type: ignore[arg-type]
+    )
+    assert "indicative" not in rendered
+    assert "| exomem | 5 | host_validated |" in rendered
+
+
+def test_withheld_latency_pins_against_the_real_membench_constant() -> None:
+    """reports/ deliberately does not import membench.reporting at module
+    scope (it transitively reaches membench.judge.backends' lazily-imported
+    httpx, see test_reports_import_closure.py); this pins the duplicated
+    string against the value membench actually renders so drift is caught."""
+
+    from membench.reporting import WITHHELD_LATENCY as membench_withheld
+    from reports.latency import WITHHELD_LATENCY as reports_withheld
+
+    assert reports_withheld == membench_withheld
+
+
+def test_the_module_never_touches_a_real_socket() -> None:
+    """RM8-style offline proof, scoped to this module: nothing in it must
+    require a network round trip to compute a refusal."""
+
+    original = socket.socket.connect
+
+    def _fail_if_called(self, address):  # type: ignore[no-untyped-def]
+        raise AssertionError(f"reports.latency touched the network: connect({address!r})")
+
+    socket.socket.connect = _fail_if_called
+    try:
+        from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+
+        assert_no_cross_provider_latency(
+            [
+                ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=1.0),
+                ProviderLatency(provider="basic-memory", latency=_host_unvalidated(), value_ms=2.0),
+            ]
+        )
+    finally:
+        socket.socket.connect = original

--- a/tests/test_reports_latency.py
+++ b/tests/test_reports_latency.py
@@ -3,7 +3,9 @@ publishable from this host (design.md #10, 4b.40) -- every provider's own
 number still renders, individually labelled "indicative"; two or more
 distinct providers additionally carry the withheld marker, but never lose a
 provider's own row (operational-quality-bench/spec.md:30-41: "latency on
-such hosts renders per-provider as indicative-only").
+such hosts renders per-provider as indicative-only"), and per the "Latency
+column refused" scenario's other half, no table column or header is ever
+SHARED across providers -- each gets its own heading and its own table.
 """
 
 from __future__ import annotations
@@ -20,15 +22,15 @@ def _host_unvalidated() -> MemoryBenchLatency:
 
 
 def test_zero_providers_render_nothing() -> None:
-    from reports.latency import assert_no_cross_provider_latency
+    from reports.latency import render_indicative_latency
 
-    assert assert_no_cross_provider_latency([]) == ""
+    assert render_indicative_latency([]) == ""
 
 
 def test_a_single_provider_renders_with_the_word_indicative() -> None:
-    from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+    from reports.latency import ProviderLatency, render_indicative_latency
 
-    rendered = assert_no_cross_provider_latency(
+    rendered = render_indicative_latency(
         [ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=12.5)]
     )
     assert "indicative" in rendered
@@ -37,32 +39,44 @@ def test_a_single_provider_renders_with_the_word_indicative() -> None:
     assert "aggregate" not in rendered.lower()
 
 
-def test_r3_two_providers_get_a_withheld_marker_but_keep_their_own_rows() -> None:
-    """R3 + F1: a run whose export carries host_unvalidated latency for two
-    providers must never render a COMPARATIVE column -- but per spec.md's
-    own scenario ("latency on such hosts renders per-provider as
-    indicative-only"), neither provider's own figure is dropped."""
+def test_r3_two_providers_never_share_a_latency_ms_column() -> None:
+    """R3 + H1: operational-quality-bench/spec.md's "Latency column refused"
+    scenario, BOTH halves -- "no cross-provider latency column renders AND
+    each latency cell carries the indicative-only label". Neither provider's
+    own figure is dropped, but no table row-set (no shared `latency_ms`
+    header) is ever populated by more than one provider."""
 
-    from reports.latency import WITHHELD_LATENCY, ProviderLatency, assert_no_cross_provider_latency
+    from reports.latency import WITHHELD_LATENCY, ProviderLatency, render_indicative_latency
 
-    rendered = assert_no_cross_provider_latency(
+    rendered = render_indicative_latency(
         [
             ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=12.5),
             ProviderLatency(provider="basic-memory", latency=_host_unvalidated(), value_ms=930.0),
         ]
     )
     assert WITHHELD_LATENCY in rendered
-    assert "| exomem | 12.5 | indicative (host_unvalidated) |" in rendered
-    assert "| basic-memory | 930 | indicative (host_unvalidated) |" in rendered
-    # No comparative construct: the two never sit inside one juxtaposed cell.
-    assert "12.5 | 930" not in rendered
-    assert "exomem | basic-memory" not in rendered
+    assert "### exomem" in rendered
+    assert "### basic-memory" in rendered
+    assert "indicative (host_unvalidated)" in rendered
+
+    # H1's core assertion: the `latency_ms` header is never shared -- each
+    # provider owns its own table, so the header line appears once PER
+    # provider, never once for both.
+    assert rendered.count("| latency_ms | disposition |") == 2
+
+    # And structurally: each provider's own number lives ONLY inside its own
+    # block, never reachable by reading down a column that also carries the
+    # other provider's rows.
+    exomem_block = rendered.split("### exomem", 1)[1].split("### basic-memory", 1)[0]
+    basic_memory_block = rendered.split("### basic-memory", 1)[1]
+    assert "12.5" in exomem_block and "930" not in exomem_block
+    assert "930" in basic_memory_block and "12.5" not in basic_memory_block
 
 
-def test_three_providers_get_exactly_one_withheld_marker_and_three_rows() -> None:
-    from reports.latency import WITHHELD_LATENCY, ProviderLatency, assert_no_cross_provider_latency
+def test_three_providers_get_exactly_one_withheld_marker_and_three_own_tables() -> None:
+    from reports.latency import WITHHELD_LATENCY, ProviderLatency, render_indicative_latency
 
-    rendered = assert_no_cross_provider_latency(
+    rendered = render_indicative_latency(
         [
             ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=1.0),
             ProviderLatency(provider="basic-memory", latency=_host_unvalidated(), value_ms=2.0),
@@ -71,17 +85,21 @@ def test_three_providers_get_exactly_one_withheld_marker_and_three_rows() -> Non
     )
     assert rendered.count(WITHHELD_LATENCY) == 1
     assert rendered.count("indicative (host_unvalidated)") == 3
+    # One own table per provider -- the header is never shared, so it
+    # appears exactly as many times as there are distinct providers.
+    assert rendered.count("| latency_ms | disposition |") == 3
     for provider in ("exomem", "basic-memory", "supermemory"):
-        assert f"| {provider} |" in rendered
+        assert f"### {provider}" in rendered
 
 
 def test_repeated_observations_from_one_provider_are_not_treated_as_cross_provider() -> None:
     """Two samples from the SAME provider are still one provider: only the
-    identity set matters, not the observation count."""
+    identity set matters, not the observation count -- both rows land in
+    that ONE provider's own table, no withheld marker."""
 
-    from reports.latency import WITHHELD_LATENCY, ProviderLatency, assert_no_cross_provider_latency
+    from reports.latency import WITHHELD_LATENCY, ProviderLatency, render_indicative_latency
 
-    rendered = assert_no_cross_provider_latency(
+    rendered = render_indicative_latency(
         [
             ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=1.0),
             ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=2.0),
@@ -89,6 +107,10 @@ def test_repeated_observations_from_one_provider_are_not_treated_as_cross_provid
     )
     assert "indicative" in rendered
     assert WITHHELD_LATENCY not in rendered
+    assert rendered.count("### exomem") == 1
+    assert rendered.count("| latency_ms | disposition |") == 1
+    assert "| 1 | indicative (host_unvalidated) |" in rendered
+    assert "| 2 | indicative (host_unvalidated) |" in rendered
 
 
 def test_a_missing_value_ms_renders_as_not_available() -> None:
@@ -96,12 +118,13 @@ def test_a_missing_value_ms_renders_as_not_available() -> None:
     carries a millisecond figure (see ProviderLatency's docstring) -- the
     cell must say so honestly rather than fabricate a number."""
 
-    from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+    from reports.latency import ProviderLatency, render_indicative_latency
 
-    rendered = assert_no_cross_provider_latency(
+    rendered = render_indicative_latency(
         [ProviderLatency(provider="exomem", latency=_host_unvalidated())]
     )
-    assert "| exomem | n/a | indicative (host_unvalidated) |" in rendered
+    assert "### exomem" in rendered
+    assert "| n/a | indicative (host_unvalidated) |" in rendered
 
 
 def test_f2_the_publishable_flag_is_load_bearing_not_decorative() -> None:
@@ -114,17 +137,17 @@ def test_f2_the_publishable_flag_is_load_bearing_not_decorative() -> None:
     hardcoding "indicative" for every row."""
 
     from pydantic import ValidationError
-    from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+    from reports.latency import ProviderLatency, render_indicative_latency
 
     with pytest.raises(ValidationError):  # sanity: the real model truly forbids this
         MemoryBenchLatency(publishable=True, reason="host_unvalidated")
 
     validated_stand_in = SimpleNamespace(publishable=True, reason="host_validated")
-    rendered = assert_no_cross_provider_latency(
+    rendered = render_indicative_latency(
         [ProviderLatency(provider="exomem", latency=validated_stand_in, value_ms=5.0)]  # type: ignore[arg-type]
     )
     assert "indicative" not in rendered
-    assert "| exomem | 5 | host_validated |" in rendered
+    assert "| 5 | host_validated |" in rendered
 
 
 def test_withheld_latency_pins_against_the_real_membench_constant() -> None:
@@ -150,9 +173,9 @@ def test_the_module_never_touches_a_real_socket() -> None:
 
     socket.socket.connect = _fail_if_called
     try:
-        from reports.latency import ProviderLatency, assert_no_cross_provider_latency
+        from reports.latency import ProviderLatency, render_indicative_latency
 
-        assert_no_cross_provider_latency(
+        render_indicative_latency(
             [
                 ProviderLatency(provider="exomem", latency=_host_unvalidated(), value_ms=1.0),
                 ProviderLatency(provider="basic-memory", latency=_host_unvalidated(), value_ms=2.0),

--- a/tests/test_reports_render.py
+++ b/tests/test_reports_render.py
@@ -1,0 +1,236 @@
+"""D3 reports/render.py: render_all composes the LME and Epistemic lane
+renderers under one offline_guard, per-ability x per-variant only, refusing
+non-terminal manifests and unknown schema_versions, and never an aggregate.
+
+Fixtures are built with the real writers: `lme.runner.execute_run` for LME
+run directories (mirrors tests/test_report_offline.py's `_run`), and the real
+epistemic cohort/evidence writers for a validated cohort artifact (mirrors
+tests/test_epistemic_report.py's `_stored_cohort`) -- never hand-written JSON
+that merely "looks like" a manifest or cohort.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+FIXTURE = Path("benchmarks/lme/fixtures/mini.json")
+
+
+def _lme_run(out: Path, run_id: str, provider: str = "hybrid-rag-control"):
+    from lme.reader import StubReader
+    from lme.runner import RunConfig, execute_run
+
+    with mock.patch.dict(os.environ, {"PROTOCOL_FIXTURE_EMBEDDER": "1", "EXOMEM_DISABLE_EMBEDDINGS": "1"}):
+        return execute_run(
+            RunConfig(dataset=FIXTURE, out=out, reader_name="stub", run_id=run_id, provider=provider),
+            reader=StubReader(),
+        )
+
+
+def _started_manifest(run_dir: Path) -> None:
+    from protocol.manifest import start_manifest
+
+    start_manifest(
+        run_dir, run_id="started",
+        dataset={"id": "fixture", "variant": "mini", "source": "local", "revision": "1", "sha256": "a" * 64, "case_count": 0},
+        started_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _epistemic_cohort(tmp_path: Path) -> Path:
+    """A minimal validated cohort: one product row, two negative controls.
+
+    Copied from tests/test_epistemic_report.py::_stored_cohort's shape (same
+    real writers: persist_assertion_evidence, validate_epistemic_cohort,
+    persist_validated_cohort) -- this file does not import that test module,
+    matching the repo's convention of a small local fixture per test file.
+    """
+
+    from epistemic.assertions import AssertionContext, no_retired_state_served_as_current
+    from epistemic.cohort import (
+        CohortAssertionResult,
+        CohortExpectationIdentity,
+        EpistemicCohortRow,
+        persist_validated_cohort,
+        validate_epistemic_cohort,
+    )
+    from epistemic.evidence import persist_assertion_evidence
+    from epistemic.snapshot import (
+        EpistemicStateSnapshot,
+        FieldDeclaration,
+        ProjectorMeta,
+        StateItem,
+    )
+
+    def snapshot(provider: str, *, current: str) -> EpistemicStateSnapshot:
+        return EpistemicStateSnapshot(
+            provider=provider, variant="native" if provider == "prod|uct" else "control",
+            phase="p1", taken_at="2026-08-11T00:00:00Z",
+            items=(
+                StateItem(
+                    id="retired", kind="claim", title="retired", text="stale",
+                    current=current, retired_reason="superseded",
+                ),
+            ),
+            declarations=(
+                FieldDeclaration(field="current", status="declared", evidence="https://example.invalid/current"),
+            ),
+            projector=ProjectorMeta(
+                name="fixture", version="1", author="test", endpoints_used=("broker:state.read",), loc=1,
+            ),
+        )
+
+    identity = CohortExpectationIdentity(
+        scenario_id="scenario|one", scenario_sha256="1" * 64,
+        phase_id="p1", expectation_ordinal=1, assertion="no_retired_state_served_as_current",
+        subject="retired", counterpart=None, tolerance=0.0, freshness_bound_s=None,
+    )
+
+    def cell(provider: str, *, current: str) -> CohortAssertionResult:
+        context = AssertionContext(snapshot=snapshot(provider, current=current), subject="retired")
+        result = no_retired_state_served_as_current(context)
+        evidence_ref = persist_assertion_evidence(
+            run_root=tmp_path, scenario_id="scenario|one", scenario_sha256="1" * 64,
+            family_id="f01", phase_id="p1", expectation_ordinal=1,
+            assertion=result.name, context=context, result=result,
+        )
+        return CohortAssertionResult(identity=identity, result=result, evidence_ref=evidence_ref)
+
+    rows = (
+        EpistemicCohortRow(provider="prod|uct", variant="native", assertions=(cell("prod|uct", current="no"),)),
+        EpistemicCohortRow(provider="grep-markdown", variant="control", assertions=(cell("grep-markdown", current="no"),)),
+        EpistemicCohortRow(provider="no-memory", variant="control", assertions=(cell("no-memory", current="no"),)),
+    )
+    cohort = validate_epistemic_cohort(run_id="run-1", rows=rows, run_root=tmp_path)
+    return persist_validated_cohort(tmp_path / "validated-cohort.v1.json", cohort, run_root=tmp_path)
+
+
+def test_composes_an_lme_run_per_ability_table(tmp_path: Path) -> None:
+    from reports.render import LmeRun, render_all
+
+    result = _lme_run(tmp_path, "compose-lme")
+    rendered = render_all([LmeRun(run_dir=result.run_dir)])
+    assert "| Ability | Variant | Questions |" in rendered
+    assert "aggregate" not in rendered.lower()
+
+
+def test_composes_lme_and_epistemic_sections_together(tmp_path: Path) -> None:
+    from reports.render import EpistemicCohort, LmeRun, render_all
+
+    lme_dir = tmp_path / "lme"
+    result = _lme_run(lme_dir, "compose-both")
+    cohort_root = tmp_path / "epistemic"
+    cohort_root.mkdir()
+    cohort_path = _epistemic_cohort(cohort_root)
+
+    rendered = render_all(
+        [
+            LmeRun(run_dir=result.run_dir),
+            EpistemicCohort(cohort_path=cohort_path, run_root=cohort_root),
+        ]
+    )
+    assert "| Ability | Variant | Questions |" in rendered
+    assert "Epistemic State Bench" in rendered
+    assert "Signal disposition" in rendered
+    assert "aggregate" not in rendered.lower()
+
+
+def test_r1_a_non_terminal_manifest_refuses(tmp_path: Path) -> None:
+    from reports.render import LmeRun, render_all
+
+    _started_manifest(tmp_path)
+    with pytest.raises(ValueError, match="non-terminal"):
+        render_all([LmeRun(run_dir=tmp_path)])
+
+
+def test_r2_an_unknown_schema_version_refuses(tmp_path: Path) -> None:
+    from reports.render import LmeRun, render_all
+
+    run_root = tmp_path / "run"
+    result = _lme_run(run_root, "schema-drift")
+    mutated = tmp_path / "schema-drift-mutated"
+    shutil.copytree(result.run_dir, mutated)
+    manifest = json.loads((mutated / "manifest.json").read_text(encoding="utf-8"))
+    manifest["schema_version"] = 99
+    (mutated / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema_version"):
+        render_all([LmeRun(run_dir=mutated)])
+
+
+def test_r7_aggregate_is_never_rendered_even_if_a_composed_section_tries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import reports.render as render_module
+
+    monkeypatch.setattr(render_module, "render_run_report", lambda run_dir, offline: "Aggregate: 0.9")
+    with pytest.raises(render_module.ReportRefused, match="aggregate"):
+        render_module.render_all([render_module.LmeRun(run_dir=tmp_path)])
+
+
+def test_r5_render_all_offline_guard_actually_wraps_the_composition(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """R5: a renderer that tries to reach the network is refused -- the outer
+    offline_guard genuinely wraps the composition, not just decoratively."""
+
+    import reports.render as render_module
+
+    def _sneaky(run_dir, offline):  # type: ignore[no-untyped-def]
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.settimeout(1.0)
+        with probe:
+            probe.connect(("127.0.0.1", 9))
+        return "unreachable"
+
+    monkeypatch.setattr(render_module, "render_run_report", _sneaky)
+    with pytest.raises(OSError, match="offline report generation forbids socket.connect"):
+        render_module.render_all([render_module.LmeRun(run_dir=tmp_path)])
+
+
+def test_r5_no_real_socket_call_is_ever_reached_by_a_genuinely_unpatched_render(tmp_path: Path) -> None:
+    """R5, other half: F3 -- the prior version of this test claimed "genuine
+    (non-monkeypatched)" while actually patching `render_run_report` with a
+    tracking wrapper, which never exercises the real code path. This one
+    patches nothing in `reports.render` at all: it runs a real LME fixture
+    run through the real `render_run_report`, and proves the real path never
+    reaches a live socket by installing a raising sentinel on
+    `socket.socket.connect` *before* the call -- if anything inside
+    render_all's real, unpatched composition ever reached a real connect, the
+    sentinel (not offline_guard's own patch) would be hit and raise."""
+
+    from reports.render import LmeRun, render_all
+
+    result = _lme_run(tmp_path, "r5-genuinely-unpatched")
+    original_connect = socket.socket.connect
+    sentinel_calls: list[tuple] = []
+
+    def _sentinel(self, address):  # type: ignore[no-untyped-def]
+        sentinel_calls.append(address)
+        raise AssertionError(f"reached the real socket stack: connect({address!r})")
+
+    socket.socket.connect = _sentinel
+    try:
+        rendered = render_all([LmeRun(run_dir=result.run_dir)])
+    finally:
+        socket.socket.connect = original_connect
+
+    assert "| Ability | Variant | Questions |" in rendered
+    assert not sentinel_calls, "render_all must never reach outside offline_guard's own patch"
+
+
+def test_sole_reused_offline_guard_identity() -> None:
+    """RM8-style pin: render.py must reuse protocol.offline.offline_guard,
+    never a lookalike copy."""
+
+    from protocol.offline import offline_guard as shared_offline_guard
+    from reports import render as render_module
+
+    assert render_module.offline_guard is shared_offline_guard


### PR DESCRIPTION
## What

Ledger 9.1–9.4 of `add-competitive-benchmark-programme`: the cross-lane `benchmarks/reports/` package.

- `render.py` composes the existing LME and epistemic renderers under the shared offline guard, per-ability by per-variant only, inheriting the manifest loader's refusal of non-terminal and unknown-schema manifests.
- `latency.py` renders one indicative block per provider from the MemoryBench export's publishable flag and never a column spanning providers.
- `consolidate.py` reads only stored artifacts, re-derives the pre-registration identity before rendering, validates every MemoryBench export through its model, and writes the identity before the report.
- `fairness.py`, `compat.py`, `adversarial.py` render the fairness matrix (eight contract fields read from the contract document at assert time), the declared-vs-observed compat matrix with first-class divergences and status-aware invalidation, and the adversarial review packet with a hash-bound review disposition.
- `guards.py` carries the no-aggregate refusal every renderer returns through.
- An import-closure test keeps provider and network imports out of the report path.

## Verification

- Two implementer lanes, each with red-first tests, a fresh independent review, correction rounds and targeted rechecks to APPROVE; then one integration review of the merged diff (REQUEST_CHANGES on a shared latency column, corrected, recheck APPROVE). Reviewers ran their own mutations at every stage; the lanes' tables stand at 11 and 43 killed guards.
- Reports test set: 123 passed, 0 failed. `tests/test_ci_reliability_contract.py` 24 passed with `tests/harness_modules.txt` regenerated. `ruff` clean. Public-artifact privacy gate clean (3577 files).
- Fixtures come from the real writers (`lme.runner.execute_run`, the epistemic cohort writers, the `MemoryBenchExport` model serialized as `export.py` serializes).

## Known gaps, recorded in the ledger

- The fairness, compat and adversarial renderers are reachable from no entry point yet; 9.5/9.6 own composing them into the one-command regeneration path.
- `basic_memory_direct.PROVIDER_ID` (`basic-memory-direct`) is not in the design's registered variant vocabulary, so the compat matrix discloses "provider comparison not possible" for Basic Memory direct runs instead of checking it (ledger residual 2.3c).
- Compat deliberately accepts a non-terminal manifest into a diagnostic matrix and withholds publishability through `invalidates()`; consolidate's load-time refusal is the publication gate (decision recorded in the module docstring).
