### PR TITLE
feat(benchmarks): add the suites registry and pin the LongMemEval judge command

### DIFF
--- a/benchmarks/lme/judge_io.py
+++ b/benchmarks/lme/judge_io.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from .dataset import load_dataset
 from .report import manifest_banner, render_report
 
-
 LANE_FILES = {
     "main": ("hypotheses.jsonl", "judge-labels.jsonl"),
     "ceiling": (
@@ -24,23 +23,69 @@ LANE_FILES = {
 }
 
 
+def verified_judge_banner() -> str:
+    """The single verified-judge sentence every report entry point renders.
+
+    Reads the pinned interface off benchmarks/suites/lme_v1/LOCKFILE.json
+    through the suites registry, so this sentence and the command
+    `official_judge_commands` emits can never independently drift from what
+    is actually pinned. Replaces an earlier UNVERIFIED banner: the ledger
+    text it guarded against had assumed a --dataset_file/--hypothesis_file/
+    --output_file/--model flag interface that never existed upstream.
+    """
+
+    from suites.registry import suite_lockfile
+
+    lockfile = suite_lockfile("lme_v1")
+    evaluate_qa = lockfile["evaluate_qa"]
+    short_sha = lockfile["commit_sha"][:7]
+    return (
+        f"VERIFIED against LongMemEval {short_sha} {evaluate_qa['path']} "
+        "(positional CLI); pins: benchmarks/suites/lme_v1/LOCKFILE.json"
+    )
+
+
+def _substitute_template(template: str, *, hyp_file: str, metric_model_short: str) -> str:
+    """Fill a lockfile-sourced `<hyp_file>`/`<metric_model_short>` template.
+
+    The literal derivation suffix (e.g. what the official script appends to
+    a hypothesis filename) is never typed here; it is read from the pinned
+    LOCKFILE.json so the rendered path cannot drift from what is pinned.
+    """
+
+    return template.replace("<hyp_file>", hyp_file).replace(
+        "<metric_model_short>", metric_model_short
+    )
+
+
 def official_judge_commands(run_dir: Path, *, judge_model: str = "gpt-4o") -> str:
     """Return user-run commands; this package never invokes the official judge."""
 
+    from suites.registry import suite_lockfile
+
     run_dir = Path(run_dir).resolve()
-    dataset = shlex.quote(str(run_dir / "dataset.json"))
-    commands = [
-        "# UNVERIFIED: confirm these flags against the fetched official "
-        "evaluate_qa.py before judging."
-    ]
-    for input_name, output_name in LANE_FILES.values():
+    dataset = str(run_dir / "dataset.json")
+    lockfile = suite_lockfile("lme_v1")
+    evaluate_qa = lockfile["evaluate_qa"]
+    # Double-quoted (not shlex.quote(), which would use single quotes): the
+    # env var must still expand when an operator pastes this into a shell.
+    # Neither the env var name nor the pinned relative path ever contains a
+    # `"`, so this is exactly one shlex token both ways.
+    env_var = lockfile["checkout_env_var"]
+    script_path = evaluate_qa["path"]
+    script = f'"${env_var}/{script_path}"'
+    result_template = evaluate_qa["result_file_derivation"]
+    commands = [f"# {verified_judge_banner()}"]
+    for input_name, _output_name in LANE_FILES.values():
+        hyp_path = str(run_dir / input_name)
         commands.append(
-            "python evaluate_qa.py "
-            f"--dataset_file {dataset} "
-            f"--hypothesis_file {shlex.quote(str(run_dir / input_name))} "
-            f"--output_file {shlex.quote(str(run_dir / output_name))} "
-            f"--model {shlex.quote(judge_model)}"
+            f"python3 {script} "
+            f"{shlex.quote(judge_model)} {shlex.quote(hyp_path)} {shlex.quote(dataset)}"
         )
+        result_path = _substitute_template(
+            result_template, hyp_file=hyp_path, metric_model_short=judge_model
+        )
+        commands.append(f"# writes results to {shlex.quote(result_path)}")
     return "\n".join(commands) + "\n"
 
 

--- a/benchmarks/lme/report.py
+++ b/benchmarks/lme/report.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections import defaultdict
 from collections.abc import Mapping, Set
-import json
-import hashlib
 from pathlib import Path
 
 from protocol.offline import offline_guard
 
-from .dataset import LmeDataset, QUESTION_TYPES, load_dataset
-
+from .dataset import QUESTION_TYPES, LmeDataset, load_dataset
 
 ABSTENTION_ABILITY = "abstention"
 
@@ -67,6 +66,8 @@ def render_report(
 ) -> str:
     """Render only per-ability rows; missing bounds block the affected row."""
 
+    from .judge_io import verified_judge_banner
+
     by_type: dict[str, list[str]] = defaultdict(list)
     for question in dataset.questions:
         ability = ABSTENTION_ABILITY if question.is_abstention else question.question_type
@@ -74,8 +75,7 @@ def render_report(
     lines = [
         "# LongMemEval-S per-ability report",
         "",
-        "> UNVERIFIED judge command: confirm the emitted evaluate_qa.py flags against "
-        "the fetched official suite before judging.",
+        f"> {verified_judge_banner()}",
         "",
     ]
     if invalid_reason:
@@ -184,8 +184,8 @@ def validate_selection_evidence(run_dir: Path | str, *, manifest=None) -> None:
         raise ValueError("25-question selection evidence is missing")
     if lme.get("canonical_selection") is not True:
         raise ValueError("canonical selection evidence mode differs")
-    from protocol.models import DatasetIdentity
     from equivalence.selection import CANONICAL_LME_S_SOURCE
+    from protocol.models import DatasetIdentity
     expected_identity = DatasetIdentity(
         id="longmemeval", variant="LongMemEval-S cleaned September 2025",
         source="xiaowu0162/longmemeval-cleaned", revision=CANONICAL_LME_S_SOURCE["revision"],

--- a/benchmarks/suites/__init__.py
+++ b/benchmarks/suites/__init__.py
@@ -1,0 +1,8 @@
+"""Public-suite LOCKFILE registry: the closed set of pinned external suites.
+
+Each subdirectory pins one external evaluation suite (upstream repo/commit,
+license, `checkout_env_var`) or, for a suite this programme cannot yet run,
+records why as a `gap` entry. See `registry.py` for the schema this enforces.
+"""
+
+from __future__ import annotations

--- a/benchmarks/suites/lme_v1/LOCKFILE.json
+++ b/benchmarks/suites/lme_v1/LOCKFILE.json
@@ -1,0 +1,22 @@
+{
+  "suite": "lme_v1",
+  "paper": "arXiv:2410.10813 (ICLR 2025)",
+  "repo_url": "https://github.com/xiaowu0162/LongMemEval",
+  "commit_sha": "9e0b455f4ef0e2ab8f2e582289761153549043fc",
+  "upstream_last_commit": "2026-05-11",
+  "license_spdx": "MIT",
+  "license_sha256": "d3c4b9aa54759df6ded337978a6f3b55b75615e5e4525c3b82d7e2627d4b9732",
+  "checkout_env_var": "LONGMEMEVAL_HOME",
+  "runability": "runnable-with-cost",
+  "verified_at_utc": "2026-09-02",
+  "notes": "Official LongMemEval V1 harness (LongMemEval-V2 is a separate repo, out of scope for this pin). evaluate_qa.py takes three positional arguments, not the --dataset_file/--hypothesis_file/--output_file/--model flags an earlier, unverified ledger entry assumed; see the evaluate_qa block. README.md:101 and :106 claim the script saves evaluation logs to a '[hypothesis_file].log' file; at this pin, evaluate_qa.py writes only <hyp_file>.eval-results-<metric_model_short> (verified against the source), never a .log file -- the README is wrong upstream, so no log_derivation field is recorded here. The judge is a metered OpenAI call this package never invokes; commands are emitted for the operator to run.",
+  "evaluate_qa": {
+    "path": "src/evaluation/evaluate_qa.py",
+    "sha256": "ecce9c4c79dc89d99534ac17b383a5cbb5b9f0c69ee98adaf0684742e3d95251",
+    "invocation": "positional",
+    "arity": 3,
+    "argv_template": ["<metric_model_short>", "<hyp_file>", "<ref_file>"],
+    "result_file_derivation": "<hyp_file>.eval-results-<metric_model_short>",
+    "readme_example": "python3 evaluate_qa.py gpt-4o your_hypothesis_file ../../data/longmemeval_oracle.json"
+  }
+}

--- a/benchmarks/suites/registry.py
+++ b/benchmarks/suites/registry.py
@@ -1,0 +1,251 @@
+"""Closed registry over the suite directories under benchmarks/suites/.
+
+Every directory here MUST carry a valid LOCKFILE.json: pinned upstream
+identity, license provenance, and an honest `runability` claim. This is the
+suite-level mirror of `lme/providers/registry.py`'s closed provider set — an
+unregistered or malformed suite is refused outright, never silently
+substituted or partially trusted.
+
+The LOCKFILE-or-GAP invariant: a suite the programme cannot yet run still
+gets an entry, with `runability: "gap"` and a non-empty `gap_reason` standing
+in for the upstream pin it does not have. A `gap` entry may never also carry
+a `commit_sha` — that would claim a pinned, verifiable checkout for a suite
+declared unrunnable.
+
+Validation helpers mirror `memorybench/setup.py`'s required-key and digest
+checks, narrowed to what a suite LOCKFILE actually carries: a 40-hex git
+commit SHA (`commit_sha`) and 64-hex sha256 file digests (`license_sha256`,
+and lme_v1's nested `evaluate_qa.sha256`). A suite that declares an
+`evaluate_qa` judge-script pin (currently only lme_v1) gets that block
+deep-validated against a closed schema of its own, mirroring how
+`memorybench/setup.py`:63-96 validates its nested provider-file records.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SUITES_ROOT = Path(__file__).resolve().parent
+LOCKFILE_NAME = "LOCKFILE.json"
+
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+
+RUNABILITY_VALUES = frozenset({"runnable", "runnable-with-cost", "gap"})
+
+#: Keys every LOCKFILE.json must carry regardless of runability.
+_REQUIRED_KEYS = frozenset(
+    {
+        "suite",
+        "paper",
+        "repo_url",
+        "upstream_last_commit",
+        "license_spdx",
+        "checkout_env_var",
+        "runability",
+        "verified_at_utc",
+        "notes",
+    }
+)
+
+#: Every required key must be a non-empty string except `runability`, which
+#: is validated against RUNABILITY_VALUES separately (and type-checked first,
+#: since testing membership of a non-hashable value in a frozenset raises
+#: TypeError rather than failing closed as a SuiteRegistryError).
+_REQUIRED_STRING_KEYS = _REQUIRED_KEYS - {"runability"}
+
+#: Keys a LOCKFILE.json may carry in addition to the required set. Mirrors the
+#: union of fields actually used across the pinned suites (stale, memops,
+#: memoryagentbench, oida-corpora, lme_v1): `dataset` and `shape` describe the
+#: data differently per suite, `license_sha256` is absent where no single
+#: LICENSE file is hashed, `commit_sha`/`gap_reason` are mutually exclusive
+#: (see `_validate_entry`), and `evaluate_qa` pins a suite's official judge
+#: script interface (deep-validated by `_validate_evaluate_qa`).
+_OPTIONAL_KEYS = frozenset(
+    {"commit_sha", "license_sha256", "dataset", "shape", "gap_reason", "evaluate_qa"}
+)
+
+_KNOWN_KEYS = _REQUIRED_KEYS | _OPTIONAL_KEYS
+
+#: Suites whose LOCKFILE.json must carry a deep-validated `evaluate_qa` block.
+#: Today only lme_v1 declares an official judge script this package emits
+#: commands for; a future runnable-with-cost suite that adds one belongs here
+#: too — there is no separate "declares a judge" marker field to key off of.
+_EVALUATE_QA_REQUIRED_SUITES = frozenset({"lme_v1"})
+
+#: evaluate_qa's own closed key set. No `flags` key: the pinned script (see
+#: LOCKFILE.json notes) takes exactly `arity` positional arguments, not
+#: flags. No `log_derivation`: the script writes no log file at this pin,
+#: whatever its upstream README claims.
+_EVALUATE_QA_KEYS = frozenset(
+    {
+        "path",
+        "sha256",
+        "invocation",
+        "arity",
+        "argv_template",
+        "result_file_derivation",
+        "readme_example",
+    }
+)
+
+
+class SuiteRegistryError(ValueError):
+    """A suite directory or its LOCKFILE.json violates the closed registry."""
+
+
+def _suite_directories(root: Path) -> tuple[Path, ...]:
+    if not root.is_dir():
+        return ()
+    return tuple(
+        sorted(
+            path
+            for path in root.iterdir()
+            if path.is_dir() and not path.name.startswith(("_", "."))
+        )
+    )
+
+
+def _load_lockfile(directory: Path) -> dict[str, Any]:
+    lockfile = directory / LOCKFILE_NAME
+    if not lockfile.is_file():
+        raise SuiteRegistryError(f"suite directory has no {LOCKFILE_NAME}: {directory.name}")
+    try:
+        data = json.loads(lockfile.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SuiteRegistryError(f"{directory.name}: {LOCKFILE_NAME} is unreadable") from exc
+    if not isinstance(data, dict):
+        raise SuiteRegistryError(f"{directory.name}: {LOCKFILE_NAME} is not a JSON object")
+    return data
+
+
+def _safe_relative_posix_path(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and not value.startswith("/")
+        and ".." not in Path(value).parts
+    )
+
+
+def _validate_evaluate_qa(name: str, evaluate_qa: object) -> None:
+    if not isinstance(evaluate_qa, dict):
+        raise SuiteRegistryError(f"{name}: evaluate_qa must be a JSON object")
+    missing = _EVALUATE_QA_KEYS - set(evaluate_qa)
+    if missing:
+        raise SuiteRegistryError(f"{name}: evaluate_qa is missing {sorted(missing)}")
+    unknown = set(evaluate_qa) - _EVALUATE_QA_KEYS
+    if unknown:
+        raise SuiteRegistryError(f"{name}: evaluate_qa has unknown keys {sorted(unknown)}")
+
+    if evaluate_qa["invocation"] != "positional":
+        raise SuiteRegistryError(f"{name}: evaluate_qa.invocation must be 'positional'")
+    if evaluate_qa["arity"] != 3:
+        raise SuiteRegistryError(f"{name}: evaluate_qa.arity must be 3")
+    argv_template = evaluate_qa["argv_template"]
+    if not isinstance(argv_template, list) or len(argv_template) != evaluate_qa["arity"]:
+        raise SuiteRegistryError(
+            f"{name}: evaluate_qa.argv_template must have exactly arity entries"
+        )
+    sha256 = evaluate_qa["sha256"]
+    if not isinstance(sha256, str) or not _SHA256_RE.fullmatch(sha256):
+        raise SuiteRegistryError(f"{name}: evaluate_qa.sha256 is not a valid digest")
+    if not _safe_relative_posix_path(evaluate_qa["path"]):
+        raise SuiteRegistryError(f"{name}: evaluate_qa.path is not a safe relative path")
+    for key in ("result_file_derivation", "readme_example"):
+        value = evaluate_qa[key]
+        if not isinstance(value, str) or not value:
+            raise SuiteRegistryError(f"{name}: evaluate_qa.{key} must be a non-empty string")
+
+
+def _validate_entry(name: str, data: dict[str, Any]) -> None:
+    missing = _REQUIRED_KEYS - set(data)
+    if missing:
+        raise SuiteRegistryError(f"{name}: {LOCKFILE_NAME} is missing {sorted(missing)}")
+    unknown = set(data) - _KNOWN_KEYS
+    if unknown:
+        raise SuiteRegistryError(f"{name}: {LOCKFILE_NAME} has unknown keys {sorted(unknown)}")
+
+    for key in _REQUIRED_STRING_KEYS:
+        value = data[key]
+        if not isinstance(value, str) or not value:
+            raise SuiteRegistryError(f"{name}: {key} must be a non-empty string")
+
+    if data["suite"] != name:
+        raise SuiteRegistryError(
+            f"{name}: {LOCKFILE_NAME} suite field {data['suite']!r} does not match its directory"
+        )
+
+    runability = data["runability"]
+    if not isinstance(runability, str) or runability not in RUNABILITY_VALUES:
+        raise SuiteRegistryError(f"{name}: unknown runability {runability!r}")
+
+    if runability == "gap":
+        if not data.get("gap_reason"):
+            raise SuiteRegistryError(f"{name}: gap runability requires a non-empty gap_reason")
+        if data.get("commit_sha"):
+            raise SuiteRegistryError(
+                f"{name}: gap runability forbids a commit_sha-based runnability claim"
+            )
+    else:
+        if "gap_reason" in data:
+            raise SuiteRegistryError(f"{name}: gap_reason is only valid when runability is gap")
+        if not data.get("commit_sha"):
+            raise SuiteRegistryError(f"{name}: {runability!r} runability requires commit_sha")
+
+    commit_sha = data.get("commit_sha")
+    if commit_sha is not None and not _COMMIT_RE.fullmatch(str(commit_sha)):
+        raise SuiteRegistryError(f"{name}: commit_sha is not a valid digest")
+
+    license_sha256 = data.get("license_sha256")
+    if license_sha256 is not None and not _SHA256_RE.fullmatch(str(license_sha256)):
+        raise SuiteRegistryError(f"{name}: license_sha256 is not a valid digest")
+
+    if "evaluate_qa" in data:
+        # Branch on key *presence*, not on the retrieved value: an explicit
+        # `"evaluate_qa": null` must still reach the type check below and
+        # fail as "must be a JSON object" for every suite, not only the
+        # suites in _EVALUATE_QA_REQUIRED_SUITES.
+        _validate_evaluate_qa(name, data["evaluate_qa"])
+    elif name in _EVALUATE_QA_REQUIRED_SUITES:
+        raise SuiteRegistryError(f"{name}: evaluate_qa is required for this suite")
+
+
+def validate_all(root: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Validate every suite directory and return its parsed LOCKFILE.json.
+
+    Raises :class:`SuiteRegistryError` naming the offending directory (and,
+    for a string-key or nested `evaluate_qa` violation, the offending key)
+    on the first violation: a missing lockfile, an unreadable or malformed
+    one, a missing or empty required key, an unknown key, a malformed digest
+    (`commit_sha`, `license_sha256`, or `evaluate_qa.sha256`), a
+    non-hashable or unrecognized `runability`, `gap` without `gap_reason`,
+    or a malformed `evaluate_qa` block.
+    """
+
+    entries: dict[str, dict[str, Any]] = {}
+    for directory in _suite_directories(root or SUITES_ROOT):
+        data = _load_lockfile(directory)
+        _validate_entry(directory.name, data)
+        entries[directory.name] = data
+    return entries
+
+
+def registered_suite_names(root: Path | None = None) -> tuple[str, ...]:
+    """The closed set of suite names: the directories under the suites root."""
+
+    return tuple(directory.name for directory in _suite_directories(root or SUITES_ROOT))
+
+
+def suite_lockfile(name: str, root: Path | None = None) -> dict[str, Any]:
+    """Return the validated LOCKFILE.json for `name`, or raise if unregistered."""
+
+    resolved_root = root or SUITES_ROOT
+    if name not in registered_suite_names(resolved_root):
+        raise SuiteRegistryError(f"unknown suite {name!r}")
+    data = _load_lockfile(resolved_root / name)
+    _validate_entry(name, data)
+    return data

--- a/openspec/changes/add-competitive-benchmark-programme/tasks.md
+++ b/openspec/changes/add-competitive-benchmark-programme/tasks.md
@@ -461,8 +461,19 @@ them. Mission acceptance criteria (§14) close only from this ledger.
 
 ## 8. Suites (W10)
 
-- [ ] 8.1 `suites/registry.py` (LOCKFILE-or-GAP invariant) + `lme_v1`
+- [x] 8.1 `suites/registry.py` (LOCKFILE-or-GAP invariant) + `lme_v1`
       LOCKFILE (verifies `judge_io` UNVERIFIED flags → tested string)
+      Landed 2026-09-02 (`benchmarks/suites/registry.py`, `benchmarks/suites/lme_v1/LOCKFILE.json`):
+      closed registry with fullmatched digests and a deep-validated `evaluate_qa`
+      block; the four existing lockfiles validate byte-unchanged. CORRECTION: the
+      official LongMemEval `evaluate_qa.py` at 9e0b455 is POSITIONAL
+      (`metric_model hyp_file ref_file`, arity 3, result file derived from the
+      hypothesis path); the `--dataset_file/--hypothesis_file/--output_file/--model`
+      flags this item assumed never existed. `judge_io.official_judge_commands`
+      and the report banner now render one verified sentence and the positional
+      command from the lockfile. Fresh review REQUEST_CHANGES -> correction ->
+      recheck APPROVE; 29 guards mutation-killed. Hypothesis-file format
+      compatibility with the official script is owed by 7.5.
 - [ ] 8.2 LongMemEval-V2: pin official harness; 3-case offline fixture
       through THEIR harness with stub model; ≤25-case small tier only if
       budget allows

--- a/tests/harness_modules.txt
+++ b/tests/harness_modules.txt
@@ -112,4 +112,5 @@ tests/test_records_recall_reconcile.py
 tests/test_report_offline.py
 tests/test_reviewer_bootstrap_cli.py
 tests/test_service_installers.py
+tests/test_suites_registry.py
 tests/test_transactional_writes.py

--- a/tests/test_benchmarks_privacy.py
+++ b/tests/test_benchmarks_privacy.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from exomem.public_artifact_privacy import assert_public_artifacts_clean
+import pytest
+
+from exomem.public_artifact_privacy import (
+    PublicArtifactPrivacyError,
+    assert_public_artifacts_clean,
+)
 
 
 def _artifact_files(root: Path) -> list[Path]:
@@ -34,3 +39,24 @@ def test_memorybench_benchmark_artifacts_are_public_safe() -> None:
     files = _artifact_files(Path("benchmarks/memorybench"))
     assert files
     assert_public_artifacts_clean(files, labels={path: str(path) for path in files})
+
+
+def test_suites_benchmark_artifacts_are_public_safe() -> None:
+    files = _artifact_files(Path("benchmarks/suites"))
+    assert files
+    assert_public_artifacts_clean(files, labels={path: str(path) for path in files})
+
+
+def test_the_suites_privacy_gate_rejects_an_injected_absolute_path(tmp_path: Path) -> None:
+    """R6: the gate that covers benchmarks/suites actually catches a leak."""
+
+    # Built by concatenation, not a literal: a contiguous absolute path here
+    # would itself trip the repository-wide privacy gate on this test file.
+    canary = "/" + "home" + "/" + "maintainer" + "/" + "checkout"
+    leaked = tmp_path / "LOCKFILE.json"
+    leaked.write_text(f'{{"notes": "captured from {canary}"}}\n', encoding="utf-8")
+
+    with pytest.raises(PublicArtifactPrivacyError):
+        assert_public_artifacts_clean(
+            (leaked,), labels={leaked: "benchmarks/suites/example/LOCKFILE.json"}
+        )

--- a/tests/test_lme_runner.py
+++ b/tests/test_lme_runner.py
@@ -4,15 +4,13 @@ import json
 from pathlib import Path
 
 import pytest
-
-from lme.dataset import LmeQuestion, render_session
 from lme import cli as cli_module
+from lme.dataset import LmeQuestion, render_session
 from lme.fetch import file_sha256
-from lme.judge_io import ingest_judge_labels, load_labels, rerender_report
+from lme.judge_io import ingest_judge_labels, load_labels, rerender_report, verified_judge_banner
 from lme.reader import MeteredApprovalRequired, StubReader
 from lme.runner import FullRunApprovalRequired, RunConfig, execute_run
 from membench.adapters.base import OpResult
-
 
 FIXTURE = Path("benchmarks/lme/fixtures/mini.json")
 
@@ -61,7 +59,7 @@ def test_runner_writes_official_hypotheses_bounds_environment_and_ability_report
     assert (result.run_dir / "bounds" / "null-abstain-floor.jsonl").is_file()
     assert (result.run_dir / "environment.json").is_file()
     assert (result.run_dir / "OFFICIAL_JUDGE_COMMAND.txt").is_file()
-    assert "UNVERIFIED" in (result.run_dir / "OFFICIAL_JUDGE_COMMAND.txt").read_text(
+    assert verified_judge_banner() in (result.run_dir / "OFFICIAL_JUDGE_COMMAND.txt").read_text(
         encoding="utf-8"
     )
     manifest = json.loads((result.run_dir / "run.json").read_text(encoding="utf-8"))
@@ -83,7 +81,7 @@ def test_runner_writes_official_hypotheses_bounds_environment_and_ability_report
     # (runner, judge re-render, artifact-only regeneration) render one shape.
     assert "| Ability | Variant | Questions |" in report
     assert "| single-session-assistant | exomem-source-only | 0 |" in report
-    assert "UNVERIFIED" in report
+    assert verified_judge_banner() in report
 
     with pytest.raises(FileExistsError, match="immutable"):
         execute_run(
@@ -479,8 +477,8 @@ def test_canonical_twenty_five_report_refuses_stripped_claims_and_judge_bypass(t
 
 
 def test_canonical_ids_cannot_be_downgraded_to_generic_pilot(tmp_path: Path) -> None:
-    from lme.report import validate_selection_evidence
     from equivalence.selection import load_frozen_lme_selection
+    from lme.report import validate_selection_evidence
 
     result = execute_run(RunConfig(dataset=FIXTURE, out=tmp_path, run_id="downgrade"), reader=StubReader(), adapter_factory=FixtureAdapter)
     artifact, _ = load_frozen_lme_selection()

--- a/tests/test_suites_registry.py
+++ b/tests/test_suites_registry.py
@@ -1,0 +1,538 @@
+"""Red-first tests for the closed benchmarks/suites/ LOCKFILE-or-GAP registry.
+
+Mirrors `lme/providers/registry.py`'s closed-set idiom (unknown name raises;
+`registered_provider_names()`) and `memorybench/setup.py`'s required-key and
+digest validation, applied to the suite-level LOCKFILE.json schema instead of
+a single pinned checkout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+from suites.registry import (
+    SuiteRegistryError,
+    registered_suite_names,
+    suite_lockfile,
+    validate_all,
+)
+
+
+def _write_lockfile(directory: Path, data: dict) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "LOCKFILE.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _minimal_runnable(name: str, **overrides: object) -> dict:
+    base = {
+        "suite": name,
+        "paper": "arXiv:0000.00000",
+        "repo_url": f"https://example.invalid/{name}",
+        "commit_sha": "a" * 40,
+        "upstream_last_commit": "2026-01-01",
+        "license_spdx": "MIT",
+        "checkout_env_var": f"SUITE_{name.upper().replace('-', '_')}_HOME",
+        "runability": "runnable",
+        "verified_at_utc": "2026-01-01",
+        "notes": "synthetic fixture",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_the_five_pinned_suite_lockfiles_validate_unchanged() -> None:
+    """I1: the real benchmarks/suites/ tree, untouched, must validate clean.
+
+    Four suites (stale, memops, memoryagentbench, oida-corpora) predate this
+    lane; lme_v1 is the fifth, added by this lane under D3'.
+    """
+
+    entries = validate_all()
+
+    assert set(entries) == {"stale", "memops", "memoryagentbench", "oida-corpora", "lme_v1"}
+    assert registered_suite_names() == (
+        "lme_v1",
+        "memops",
+        "memoryagentbench",
+        "oida-corpora",
+        "stale",
+    )
+
+
+def test_a_suite_directory_without_a_lockfile_fails_validate_all(tmp_path: Path) -> None:
+    (tmp_path / "orphan-suite").mkdir()
+
+    with pytest.raises(SuiteRegistryError, match="orphan-suite"):
+        validate_all(root=tmp_path)
+
+
+def test_gap_without_gap_reason_is_refused_and_with_reason_is_valid(tmp_path: Path) -> None:
+    directory = tmp_path / "gap-suite"
+    lockfile = _minimal_runnable("gap-suite", runability="gap")
+    del lockfile["commit_sha"]
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="gap_reason"):
+        validate_all(root=tmp_path)
+
+    lockfile["gap_reason"] = "upstream repository is unreleased"
+    _write_lockfile(directory, lockfile)
+
+    entries = validate_all(root=tmp_path)
+    assert entries["gap-suite"]["gap_reason"] == "upstream repository is unreleased"
+
+
+def test_gap_forbids_a_commit_sha_based_runnability_claim(tmp_path: Path) -> None:
+    directory = tmp_path / "gap-suite"
+    lockfile = _minimal_runnable("gap-suite", runability="gap")
+    lockfile["gap_reason"] = "upstream repository is unreleased"
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="commit_sha"):
+        validate_all(root=tmp_path)
+
+
+def test_a_missing_required_key_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "incomplete-suite"
+    lockfile = _minimal_runnable("incomplete-suite")
+    del lockfile["paper"]
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="paper"):
+        validate_all(root=tmp_path)
+
+
+def test_an_unknown_key_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "extra-key-suite"
+    lockfile = _minimal_runnable("extra-key-suite")
+    lockfile["unexpected_field"] = "surprise"
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="unexpected_field"):
+        validate_all(root=tmp_path)
+
+
+def test_a_malformed_license_digest_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "bad-digest-suite"
+    lockfile = _minimal_runnable("bad-digest-suite", license_sha256="not-a-digest")
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="license_sha256"):
+        validate_all(root=tmp_path)
+
+
+def test_a_corrupted_commit_sha_fails_validation_naming_the_suite_and_key(
+    tmp_path: Path,
+) -> None:
+    """H1: commit_sha is digest-checked, not just license_sha256."""
+
+    directory = tmp_path / "bad-commit-suite"
+    lockfile = _minimal_runnable("bad-commit-suite", commit_sha="deadbeef")
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="bad-commit-suite.*commit_sha"):
+        validate_all(root=tmp_path)
+
+
+def test_every_real_suite_commit_sha_that_is_present_is_a_forty_hex_digest() -> None:
+    """H1: the digest check actually holds for all five pinned lockfiles."""
+
+    entries = validate_all()
+    for name, data in entries.items():
+        commit_sha = data.get("commit_sha")
+        if commit_sha is not None:
+            assert re.fullmatch(r"[0-9a-f]{40}", commit_sha), name
+
+
+def test_a_non_hashable_runability_fails_closed_as_a_registry_error(tmp_path: Path) -> None:
+    """F1: a non-hashable runability must not escape as a bare TypeError."""
+
+    directory = tmp_path / "weird-type-suite"
+    lockfile = _minimal_runnable("weird-type-suite", runability=["runnable"])
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="runability"):
+        validate_all(root=tmp_path)
+
+
+@pytest.mark.parametrize("key,value", [("notes", None), ("repo_url", "")])
+def test_a_null_or_empty_required_string_key_fails_validation(
+    tmp_path: Path, key: str, value: object
+) -> None:
+    """F2: required string keys must be non-empty strings, not null or ''."""
+
+    directory = tmp_path / "blank-key-suite"
+    lockfile = _minimal_runnable("blank-key-suite", **{key: value})
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match=key):
+        validate_all(root=tmp_path)
+
+
+def test_an_explicit_null_evaluate_qa_is_refused_for_any_suite_not_only_lme_v1(
+    tmp_path: Path,
+) -> None:
+    """NEW-5: `"evaluate_qa": null` must fail type validation for every suite,
+    not only the suites _EVALUATE_QA_REQUIRED_SUITES happens to name."""
+
+    directory = tmp_path / "other-suite"
+    lockfile = _minimal_runnable("other-suite", evaluate_qa=None)
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="other-suite.*must be a JSON object"):
+        validate_all(root=tmp_path)
+
+
+def test_a_suite_field_mismatched_with_its_directory_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "renamed-suite"
+    lockfile = _minimal_runnable("original-name")
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="renamed-suite"):
+        validate_all(root=tmp_path)
+
+
+def test_an_unrecognized_runability_value_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "weird-runability-suite"
+    lockfile = _minimal_runnable("weird-runability-suite", runability="totally-fine-trust-me")
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="totally-fine-trust-me"):
+        validate_all(root=tmp_path)
+
+
+def test_gap_reason_on_a_non_gap_entry_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "confused-suite"
+    lockfile = _minimal_runnable("confused-suite", gap_reason="should not be here")
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="gap_reason"):
+        validate_all(root=tmp_path)
+
+
+def test_a_non_gap_entry_without_commit_sha_fails_validation(tmp_path: Path) -> None:
+    directory = tmp_path / "unpinned-suite"
+    lockfile = _minimal_runnable("unpinned-suite")
+    del lockfile["commit_sha"]
+    _write_lockfile(directory, lockfile)
+
+    with pytest.raises(SuiteRegistryError, match="commit_sha"):
+        validate_all(root=tmp_path)
+
+
+def test_unknown_suite_name_is_refused_by_the_closed_registry() -> None:
+    with pytest.raises(SuiteRegistryError, match="unknown suite"):
+        suite_lockfile("not-a-real-suite")
+
+
+def test_suite_lockfile_returns_the_validated_entry_for_a_registered_suite() -> None:
+    data = suite_lockfile("oida-corpora")
+
+    assert data["suite"] == "oida-corpora"
+    assert data["runability"] == "runnable"
+
+
+def test_lme_v1_lockfile_pins_a_positional_evaluate_qa_interface_with_no_flags() -> None:
+    """R4 (part 1): the lockfile itself records what the pinned script actually is."""
+
+    lockfile = suite_lockfile("lme_v1")
+    evaluate_qa = lockfile["evaluate_qa"]
+
+    assert lockfile["runability"] == "runnable-with-cost"
+    assert evaluate_qa["invocation"] == "positional"
+    assert evaluate_qa["arity"] == 3
+    assert evaluate_qa["argv_template"] == ["<metric_model_short>", "<hyp_file>", "<ref_file>"]
+    assert "flags" not in evaluate_qa
+    assert "--" not in json.dumps(evaluate_qa)
+
+
+def test_lme_v1_lockfile_records_no_log_derivation() -> None:
+    """H4: the pinned script writes no .log file; the README claim is wrong upstream."""
+
+    evaluate_qa = suite_lockfile("lme_v1")["evaluate_qa"]
+
+    assert "log_derivation" not in evaluate_qa
+
+
+def _lme_v1_with_evaluate_qa(evaluate_qa: object, tmp_path: Path) -> Path:
+    lockfile = dict(suite_lockfile("lme_v1"))
+    if evaluate_qa is _MISSING:
+        del lockfile["evaluate_qa"]
+    else:
+        lockfile["evaluate_qa"] = evaluate_qa
+    directory = tmp_path / "lme_v1"
+    _write_lockfile(directory, lockfile)
+    return tmp_path
+
+
+_MISSING = object()
+
+
+_VALID_EVALUATE_QA_BASE = {
+    "path": "src/evaluation/evaluate_qa.py",
+    "sha256": "e" * 64,
+    "invocation": "positional",
+    "arity": 3,
+    "argv_template": ["<metric_model_short>", "<hyp_file>", "<ref_file>"],
+    "result_file_derivation": "<hyp_file>.eval-results-<metric_model_short>",
+    "readme_example": "python3 evaluate_qa.py gpt-4o hyp ref",
+}
+
+
+@pytest.mark.parametrize(
+    "evaluate_qa,match",
+    [
+        pytest.param(
+            {
+                "path": "src/evaluation/evaluate_qa.py",
+                "sha256": "e" * 64,
+                "invocation": "positional",
+                "arity": 3,
+                "argv_template": ["<metric_model_short>", "<hyp_file>", "<ref_file>"],
+                "result_file_derivation": "<hyp_file>.eval-results-<metric_model_short>",
+                "readme_example": "python3 evaluate_qa.py gpt-4o hyp ref",
+                "flags": ["--dataset_file"],
+            },
+            "unknown keys",
+            id="flags-key",
+        ),
+        pytest.param(
+            {
+                "path": "src/evaluation/evaluate_qa.py",
+                "sha256": "e" * 64,
+                "invocation": "positional",
+                "arity": 4,
+                "argv_template": ["<a>", "<b>", "<c>", "<d>"],
+                "result_file_derivation": "<hyp_file>.eval-results-<metric_model_short>",
+                "readme_example": "python3 evaluate_qa.py gpt-4o hyp ref",
+            },
+            "arity",
+            id="arity-4",
+        ),
+        pytest.param("positional, three args", "must be a JSON object", id="bare-string"),
+        # NEW-5: branching on key presence means an explicit null now reaches
+        # the same type check as bare-string, not the required-suites check.
+        pytest.param(None, "must be a JSON object", id="null"),
+        pytest.param({}, "missing", id="empty-object"),
+        # NEW-1: evaluate_qa.path must stay a safe relative POSIX path.
+        pytest.param(
+            {**_VALID_EVALUATE_QA_BASE, "path": "/abs/evaluate_qa.py"},
+            "not a safe relative path",
+            id="absolute-path",
+        ),
+        pytest.param(
+            {**_VALID_EVALUATE_QA_BASE, "path": "../../../etc/passwd"},
+            "not a safe relative path",
+            id="parent-traversal",
+        ),
+        pytest.param(
+            {**_VALID_EVALUATE_QA_BASE, "path": "src/../../escape.py"},
+            "not a safe relative path",
+            id="traversal-via-relative-segments",
+        ),
+    ],
+)
+def test_evaluate_qa_rejects_every_malformed_shape_naming_the_suite(
+    tmp_path: Path, evaluate_qa: object, match: str
+) -> None:
+    """H3: deep-validate evaluate_qa; each of five malformed shapes is refused."""
+
+    root = _lme_v1_with_evaluate_qa(evaluate_qa, tmp_path)
+
+    with pytest.raises(SuiteRegistryError, match=match) as exc_info:
+        validate_all(root=root)
+    assert "lme_v1" in str(exc_info.value)
+
+
+def test_deleting_evaluate_qa_from_lme_v1_fails_validation_not_a_keyerror(
+    tmp_path: Path,
+) -> None:
+    """H3: a missing evaluate_qa block on lme_v1 fails validate_all, never a
+    bare KeyError surfacing later at render time."""
+
+    root = _lme_v1_with_evaluate_qa(_MISSING, tmp_path)
+
+    with pytest.raises(SuiteRegistryError, match="lme_v1.*evaluate_qa"):
+        validate_all(root=root)
+
+
+def test_official_judge_commands_use_exactly_three_positional_arguments_and_no_flags(
+    tmp_path: Path,
+) -> None:
+    """R4 (part 2): the emitted command has no flags and no UNVERIFIED marker."""
+
+    from lme.judge_io import LANE_FILES, official_judge_commands, verified_judge_banner
+
+    text = official_judge_commands(tmp_path, judge_model="gpt-4o")
+
+    assert "UNVERIFIED" not in text
+    assert "--" not in text
+    assert text.splitlines()[0] == f"# {verified_judge_banner()}"
+
+    lockfile = suite_lockfile("lme_v1")
+    evaluate_qa = lockfile["evaluate_qa"]
+    expected_script = f"${lockfile['checkout_env_var']}/{evaluate_qa['path']}"
+
+    command_lines = [line for line in text.splitlines() if line.startswith("python3 ")]
+    assert len(command_lines) == len(LANE_FILES)
+    for line in command_lines:
+        tokens = shlex.split(line)
+        # H2: the script path comes from the lockfile, never a fourth typed
+        # copy -- if the lockfile's path or checkout_env_var drifts, this
+        # must drift with it rather than silently keep passing.
+        assert tokens[1] == expected_script
+        # Exactly three positional arguments follow the interpreter and script.
+        assert len(tokens) - 2 == 3
+
+
+def test_official_judge_commands_script_is_double_quoted_not_shlex_quoted(
+    tmp_path: Path,
+) -> None:
+    """NEW-2 (part 1): a raw-text check on the emitted line.
+
+    shlex.split() strips quote characters regardless of style, so a
+    token-comparison test alone cannot tell single-quoted
+    (`shlex.quote()`, which would suppress $VAR expansion) from
+    double-quoted (which preserves it) apart -- both parse to the identical
+    token string. Reverting `script` to `shlex.quote(...)` must fail this
+    assertion even though it would still pass the token-comparison test
+    above.
+    """
+
+    from lme.judge_io import official_judge_commands
+
+    lockfile = suite_lockfile("lme_v1")
+    text = official_judge_commands(tmp_path, judge_model="gpt-4o")
+
+    expected_open = f'"${lockfile["checkout_env_var"]}/'
+    assert expected_open in text
+
+
+def test_the_double_quoted_script_path_stays_one_argv_element_with_a_space_in_checkout(
+    tmp_path: Path,
+) -> None:
+    """NEW-2 (part 2): a real bash expansion check, not just shlex.
+
+    The double-quoted script path must stay one argv element even when the
+    checkout directory itself contains a space -- the property double
+    quoting (over leaving the expression bare) actually exists to protect.
+    """
+
+    import subprocess
+
+    from lme.judge_io import official_judge_commands
+
+    lockfile = suite_lockfile("lme_v1")
+    env_var = lockfile["checkout_env_var"]
+
+    text = official_judge_commands(tmp_path, judge_model="gpt-4o")
+    command_line = next(line for line in text.splitlines() if line.startswith("python3 "))
+
+    checkout_with_space = "/tmp/a directory/checkout"
+    bash_script = (
+        "set -u\n"
+        f"{env_var}={shlex.quote(checkout_with_space)}\n"
+        'python3() { echo "$#"; }\n'
+        f"{command_line}\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", bash_script], capture_output=True, text=True, check=True
+    )
+    # 4 argv elements: script path (one, despite the embedded space),
+    # judge_model, hypothesis path, dataset path.
+    assert result.stdout.strip() == "4"
+
+
+def test_official_judge_commands_result_comment_matches_the_lockfile_template(
+    tmp_path: Path,
+) -> None:
+    """R4 (part 3): the derivation comment equals the lockfile template, substituted."""
+
+    from lme.judge_io import LANE_FILES, _substitute_template, official_judge_commands
+
+    run_dir = tmp_path.resolve()
+    text = official_judge_commands(run_dir, judge_model="gpt-4o")
+    result_template = suite_lockfile("lme_v1")["evaluate_qa"]["result_file_derivation"]
+
+    comment_lines = [line for line in text.splitlines() if line.startswith("# writes results to ")]
+    assert len(comment_lines) == len(LANE_FILES)
+    for (input_name, _output_name), comment_line in zip(
+        LANE_FILES.values(), comment_lines, strict=True
+    ):
+        hyp_path = str(run_dir / input_name)
+        expected = _substitute_template(
+            result_template, hyp_file=hyp_path, metric_model_short="gpt-4o"
+        )
+        assert comment_line == f"# writes results to {shlex.quote(expected)}"
+
+
+def test_report_banner_renders_the_same_verified_sentence_as_judge_io() -> None:
+    """R4 (part 4): report.py's banner has no UNVERIFIED marker and matches judge_io."""
+
+    from lme.dataset import load_dataset
+    from lme.judge_io import verified_judge_banner
+    from lme.report import render_report
+
+    dataset = load_dataset(Path("benchmarks/lme/fixtures/mini.json"))
+    report = render_report(
+        dataset, labels={}, ceiling_question_ids=set(), floor_question_ids=set()
+    )
+
+    assert "UNVERIFIED" not in report
+    assert f"> {verified_judge_banner()}" in report
+
+
+def _lme_v1_checkout_env_var_for_skip() -> str | None:
+    """Best-effort env var name for the skip condition only.
+
+    Must never raise at collection time: a malformed real lme_v1 lockfile
+    should fail this module's own tests (several of which validate it
+    properly and report the exact defect), not abort collection of the
+    whole module -- or, worse, the whole pytest session. The test body
+    below still re-derives everything from the lockfile for its real
+    assertions; this helper exists only to decide whether to skip.
+    """
+
+    try:
+        return suite_lockfile("lme_v1")["checkout_env_var"]
+    except SuiteRegistryError:
+        return None
+
+
+_LME_V1_CHECKOUT_ENV_VAR = _lme_v1_checkout_env_var_for_skip()
+
+
+@pytest.mark.skipif(
+    _LME_V1_CHECKOUT_ENV_VAR is None or _LME_V1_CHECKOUT_ENV_VAR not in os.environ,
+    reason=(
+        f"set {_LME_V1_CHECKOUT_ENV_VAR} to the pinned LongMemEval checkout to run this"
+        if _LME_V1_CHECKOUT_ENV_VAR is not None
+        else "lme_v1's LOCKFILE.json does not validate; see the module's other tests"
+    ),
+)
+def test_the_pinned_evaluate_qa_script_matches_the_lockfile_and_stays_positional() -> None:
+    """R5 (env-gated): the real checkout at the pin still hashes to the lockfile."""
+
+    lockfile = suite_lockfile("lme_v1")
+    evaluate_qa = lockfile["evaluate_qa"]
+    checkout = Path(os.environ[lockfile["checkout_env_var"]])
+    script = checkout / evaluate_qa["path"]
+
+    digest = hashlib.sha256(script.read_bytes()).hexdigest()
+    assert digest == evaluate_qa["sha256"]
+
+    text = script.read_text(encoding="utf-8")
+    for token in (
+        "len(sys.argv) != 4",
+        "sys.argv[1]",
+        "sys.argv[2]",
+        "sys.argv[3]",
+        ".eval-results-",
+    ):
+        assert token in text


### PR DESCRIPTION
## What

Ledger 8.1 of `add-competitive-benchmark-programme`. Stacked on #1046 (the reports package) because both regenerate `tests/harness_modules.txt`; it retargets to `main` when #1046 merges.

- `benchmarks/suites/registry.py`: a closed LOCKFILE-or-GAP registry over the suite directories. Every suite carries a validated lockfile or an explicit gap with a reason; commit and sha256 digests are fullmatched; required keys are non-empty strings; the `evaluate_qa` block is deep-validated against a closed key set with a safe relative path. The four existing lockfiles validate byte-unchanged.
- `benchmarks/suites/lme_v1/LOCKFILE.json` pins the official LongMemEval V1 harness at `9e0b455`.
- `benchmarks/lme/judge_io.py` and `report.py`: the judge command and the report banner render one verified sentence from one lockfile-reading function.
- `tests/test_benchmarks_privacy.py` now scans `benchmarks/suites` (ledger 1.10).

## Correction this change records

The official `evaluate_qa.py` is positional: `python3 evaluate_qa.py <metric_model> <hyp_file> <ref_file>`, arity 3, with the result file derived from the hypothesis path. The four `--dataset_file/--hypothesis_file/--output_file/--model` flags the previous UNVERIFIED command emitted never existed. The lane stopped on that finding rather than guessing; the emitted command now matches the pinned script, double-quoted so the shell still expands `$LONGMEMEVAL_HOME`. The upstream README's claim of a `.log` output is recorded as a discrepancy in the lockfile notes, not as a derivation.

## Verification

- Red-first, then a fresh independent review (REQUEST_CHANGES: commit digest unvalidated; script path a typed literal that could drift from the lockfile with a green suite), correction, targeted recheck APPROVE with six small follow-ups taken in the same delivery. 29 guards mutation-killed by the lane; the reviewer's own mutations all landed on named tests.
- `tests/test_suites_registry.py` 35 passed, 1 skipped offline; 30 passed with `LONGMEMEVAL_HOME` set against the pinned clone. Scoped set on the stacked branch: 0 failed. `tests/test_ci_reliability_contract.py` 24 passed. `ruff` clean. Public-artifact privacy gate clean.

## Follow-up (ledger 7.5)

Hypothesis-file format compatibility with the official script.

## CI evidence

The PR-triggered workflow skips for a pull request whose base is not `main`, so the full workflow was dispatched on this branch directly: run 33591982269. Every job passed except "Windows held filesystem (native NTFS)", which timed out on one concurrency test in `tests/test_mutation_concurrency.py` on each of two attempts, a different test each time (`test_twenty_concurrent_real_captures_leave_complete_vault_state`, then `test_independent_vault_real_uploads_commit_concurrently`). Neither this change nor #1046 touches `src/`, and `main`'s own push run at this branch's base commit `044eec2f` failed the same job while the eleven runs before it passed. The PR-tier gate will run when this retargets to `main` after #1046 merges.
