### PR TITLE
docs: add GitHub Sponsors funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: substrate-systems


### PR DESCRIPTION
Adds `.github/FUNDING.yml` pointing the Sponsor button at the **substrate-systems** organization, matching the Endstate repos. The org's GitHub Sponsors profile is live at https://github.com/sponsors/substrate-systems.

After merge, enable Settings → General → Features → **Sponsorships** for the button to render.