### PR TITLE
fix(hosted): let the fleet collector name its kubectl

### DIFF
--- a/docs/runbooks/hosted/runtime-upgrades.md
+++ b/docs/runbooks/hosted/runtime-upgrades.md
@@ -70,6 +70,17 @@ and is deleted before its observation is accepted. Never use a mutable tag or an
 image that did not pass the signed-candidate checks. Omit the option once the
 installed provisioner contains the collector.
 
+The collector shells out to `kubectl`. A k3s node has no bare `kubectl` — it is
+`k3s kubectl` — so when running this on the node, put a wrapper on a private path
+and name it with `--kubectl` (or `EXOMEM_KUBECTL`). Do not install a system-wide
+shim; the operator workspace owns it:
+
+```bash
+install -d -m 0700 "$operation_dir/bin"
+printf '#!/bin/sh\nexec k3s kubectl "$@"\n' > "$operation_dir/bin/kubectl"
+chmod 0700 "$operation_dir/bin/kubectl"
+```
+
 ```bash
 provisioner_observer_args=()
 if test -n "${EXOMEM_PROVISIONER_BOOTSTRAP_IMAGE:-}"; then
@@ -83,6 +94,7 @@ infra/scripts/hosted_fleet_inventory.py collect \
   --substrate-token-file "${EXOMEM_SUBSTRATE_OPERATOR_TOKEN_FILE:?set the private token file}" \
   --runtime-catalog "$operation_dir/runtime-catalog.json" \
   --target "$target" --observed-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --kubectl "$operation_dir/bin/kubectl" \
   "${provisioner_observer_args[@]}" \
   --inventory-output "$operation_dir/inventory-before-expand.json" \
   --facts-output "$operation_dir/inventory-before-expand-facts.json"

--- a/infra/scripts/hosted_fleet_inventory.py
+++ b/infra/scripts/hosted_fleet_inventory.py
@@ -1738,6 +1738,15 @@ def _parser() -> argparse.ArgumentParser:
     collect.add_argument("--facts-output", type=Path, required=True)
     collect.add_argument("--timeout-seconds", type=float, default=15)
     collect.add_argument("--provisioner-bootstrap-image")
+    collect.add_argument(
+        "--kubectl",
+        default=os.environ.get("EXOMEM_KUBECTL", "kubectl"),
+        help=(
+            "kubectl executable used for the read-only provisioner and Kubernetes "
+            "observations. A k3s node has no bare kubectl; point this at a wrapper "
+            "that execs `k3s kubectl`. Defaults to $EXOMEM_KUBECTL, else kubectl."
+        ),
+    )
     return parser
 
 
@@ -1764,12 +1773,14 @@ def main(argv: list[str] | None = None) -> int:
             ),
             "provisioner": collect_provisioner(
                 timeout_seconds=args.timeout_seconds,
+                kubectl=args.kubectl,
                 bootstrap_image=args.provisioner_bootstrap_image,
             ),
             "kubernetes": collect_kubernetes(
                 runtime_catalog=runtime_catalog,
                 observed_at=args.observed_at,
                 timeout_seconds=args.timeout_seconds,
+                kubectl=args.kubectl,
             ),
         }
         inventory = reconcile_inventory(sources, target=target)

--- a/tests/test_hosted_fleet_inventory.py
+++ b/tests/test_hosted_fleet_inventory.py
@@ -1041,6 +1041,7 @@ def test_operator_cli_collects_three_authorities_and_writes_private_phase_facts(
     assert facts == module.execution_inventory_facts(inventory)
     assert provisioner_arguments == {
         "timeout_seconds": 15,
+        "kubectl": "kubectl",
         "bootstrap_image": observer_image,
     }
     if os.name != "nt":
@@ -1070,3 +1071,51 @@ def test_collector_failures_never_echo_tokens_paths_or_remote_output(
     message = str(captured.value)
     assert message == "substrate collector failed"
     assert "secret" not in message and os.fspath(token) not in message
+
+
+def _collect_argv(tmp_path, *extra: str) -> list[str]:
+    return [
+        "collect",
+        "--substrate-endpoint",
+        "https://example.invalid",
+        "--substrate-token-file",
+        str(tmp_path / "token"),
+        "--runtime-catalog",
+        str(tmp_path / "catalog.json"),
+        "--target",
+        str(tmp_path / "target.json"),
+        "--observed-at",
+        "2026-09-02T00:00:00Z",
+        "--inventory-output",
+        str(tmp_path / "inventory.json"),
+        "--facts-output",
+        str(tmp_path / "facts.json"),
+        *extra,
+    ]
+
+
+def test_collect_accepts_an_explicit_kubectl_executable(tmp_path) -> None:
+    """A k3s node has no bare kubectl, so the operator must be able to name one."""
+
+    module = _module()
+    parsed = module._parser().parse_args(
+        _collect_argv(tmp_path, "--kubectl", "/opt/exomem/bin/kubectl")
+    )
+    assert parsed.kubectl == "/opt/exomem/bin/kubectl"
+
+
+def test_collect_kubectl_defaults_to_the_environment_then_plain_kubectl(
+    tmp_path, monkeypatch
+) -> None:
+    module = _module()
+
+    monkeypatch.delenv("EXOMEM_KUBECTL", raising=False)
+    assert module._parser().parse_args(_collect_argv(tmp_path)).kubectl == "kubectl"
+
+    monkeypatch.setenv("EXOMEM_KUBECTL", "/opt/exomem/bin/kubectl")
+    assert module._parser().parse_args(_collect_argv(tmp_path)).kubectl == "/opt/exomem/bin/kubectl"
+    # An explicit flag still wins over the environment default.
+    assert (
+        module._parser().parse_args(_collect_argv(tmp_path, "--kubectl", "kubectl")).kubectl
+        == "kubectl"
+    )


### PR DESCRIPTION
## Problem

`hosted_fleet_inventory.py collect` shells out to a bare `kubectl`. A k3s node has no bare `kubectl` — it is `k3s kubectl`.

That matters because the collector *must* run on the node. The k3s API server certificate carries SANs for `127.0.0.1`, `10.50.1.10` and `10.43.0.1` but no public IP, and `/etc/ssh/sshd_config.d/99-exomem-hardening.conf` sets `AllowTcpForwarding no`, so an `ssh -L` tunnel binds locally, looks like it worked, and then has every channel reset. On the alpha node only port 22 is open; 6443 is firewalled.

So the collector could not run on a workstation (no route to the API) and could not run on the node (no `kubectl`). It was unrunnable in the position its own runbook puts it in.

## Change

- `--kubectl`, defaulting to `$EXOMEM_KUBECTL` and then `kubectl`, threaded into both `collect_provisioner` (and onward to the bootstrap observer) and `collect_kubernetes`. The existing `[A-Za-z0-9._/-]+` validation is unchanged, so a path is accepted and a two-word command still is not.
- The runbook now shows creating a `0700` wrapper inside the operation directory instead of installing a system-wide shim, keeping it scoped to the operation and removed with it.

## Verification

    PYTHONPATH=$PWD/src uv run --frozen python -m pytest tests/test_hosted_fleet_inventory.py -q
    32 passed

Two new tests cover the flag and the environment default. Both were confirmed **red** against `origin/main`'s collector before the fix:

    FAILED test_collect_accepts_an_explicit_kubectl_executable
    FAILED test_collect_kubectl_defaults_to_the_environment_then_plain_kubectl
    2 failed

One existing assertion was updated rather than worked around: `test_operator_cli_collects_three_authorities_and_writes_private_phase_facts` pins the exact kwargs the CLI passes to the collector, so it now includes `"kubectl": "kubectl"` — the default, proving the CLI still passes the documented value.

`ruff check` clean, `ruff format` applied.