### PR TITLE
docs(openspec): propose accelerate-governed-recall

### DIFF
--- a/openspec/changes/accelerate-governed-recall/.openspec.yaml
+++ b/openspec/changes/accelerate-governed-recall/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/accelerate-governed-recall/design.md
+++ b/openspec/changes/accelerate-governed-recall/design.md
@@ -1,0 +1,177 @@
+## Context
+
+See proposal.md for the measurements. The shape of today's read path that the
+design has to respect:
+
+- A recall's structured-filter plan is classified by `plan_index_candidates`.
+  Only exact positive `unit.category` and `unit.kind` clauses are "complete"
+  and seed from the semantic-unit sidecar; every page-level field (`projects`,
+  `tags`, `types`, speakers, file types) is "unsupported" and falls to the
+  canonical full-scan oracle, which walks the Markdown scope and parses
+  frontmatter on the reader thread. That oracle is also the definition of
+  correctness: an index-backed answer must equal it for the same generation.
+- `scope="kb"` auto-widens through the out-of-KB reserve, which resolves
+  eligibility again with vault scope and then runs BM25 over every non-KB page,
+  building a Python corpus when the maintained FTS5 catalogue is not fresh.
+- Substrate caches (lexical corpus, eligibility catalogue, frontmatter cache,
+  embedding matrix) key on whole-scope freshness keys. Any governed write moves
+  the key, so on a busy day every recall rebuilds what the previous write
+  discarded. The `accelerate-durable-write-acknowledgement` change already
+  gives each governed write an exact receipt naming its paths and a
+  pending-visibility row per path; nothing on the read side consumes them for
+  invalidation yet.
+- Timing diagnostics merge registered intervals into `unattributed_ms`; the
+  stages that #983 converted are intervals now, but nothing enforces that a new
+  stage is, and stages do not say whether they were answered from an index.
+- The recall projection admission and the lexical repair worker already
+  implement the "warm away from the reader" pattern this change extends.
+- The 2026-08-31 plan's tranche 1 (#951, matrix copy) is on main; #983 and #984
+  are closed. Their combined effect on the live cell has not been measured.
+- The live cell runs in WSL on a box shared with test suites; the graph
+  scheduler's whole-vault rebuild can livelock under a sustained writer
+  (`converge-graph-incrementally`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Zero corpus walks on the reader thread for any supported request shape,
+  enforced by diagnostics and a test sentinel, not by review.
+- Read-side caches that survive governed writes through exact receipt custody.
+- A measured, ratcheting latency contract on the live cell.
+- Result identity: every index-backed path returns the set the scan oracle would.
+
+**Non-Goals:**
+- Approximate retrieval, dropped features, ANN, or any quality-for-speed trade.
+- Changing what hybrid recall computes (embed, vector, graph, fusion, rerank).
+- Fixing the graph rebuild's optimistic check (owned elsewhere).
+- Rust, process changes, or moving the cell off the shared box.
+
+## Decisions
+
+### 1. Page-level filters get a maintained page-metadata index
+
+A page-metadata table keyed by relative path holds the filterable frontmatter
+fields (`type`, `projects`, `tags`, `speakers`, file type, status) plus the
+page's content hash and the generation that wrote it. It lives in the existing
+lexical catalogue store, is written by the existing writer fan-out component
+that already touches the catalogue on every governed write, and is rebuilt by
+the same single-flight repair worker that rebuilds the catalogue.
+`plan_index_candidates` learns page-level clauses, so a plan is "complete" when
+every clause is either a unit clause the sidecar answers or a page clause the
+metadata table answers; AND/OR/NOT composition stays exactly as today.
+
+The oracle stays. It becomes the identity test's reference and the offline
+(unmanaged) fallback, never a managed reader's path.
+
+**Alternative rejected: derive page eligibility from FTS5 columns.** The
+catalogue stores text for ranking, not typed metadata; encoding list fields
+into it makes `$in` and `$exists` semantics a text-matching approximation.
+
+### 2. Exact custody flows from the receipts to the read-side caches
+
+Each substrate cache registers an invalidation seam keyed by relative path.
+When a governed write commits, the receipt's path set is applied to those
+seams: rows for those paths are evicted or refreshed; nothing else moves. The
+whole-scope freshness key keeps its role for receipt-less changes only: the
+reconciliation pass that detects an external edit invalidates the scope it
+found drift in, as today.
+
+The pending-visibility overlay already shadows stale rows for paths pending
+custody and re-offers the committed pages; the eligibility evaluation consumes
+the same overlay so a filter sees the committed frontmatter before the
+catalogue row is refreshed.
+
+**Alternative rejected: keep whole-scope keys and make rebuilds cheaper.** A
+rebuild that costs 8 s at 8k pages costs 32 s at 32k; the fix has to remove
+the rebuild from the request, not shave it.
+
+### 3. Out-of-KB widening is a request option with a hard reserve
+
+`scope="kb"` serves the KB. A new boolean request option enables widening; the
+`ask_memory` product default is off. When on, widening runs one catalogue query
+over the out-of-KB eligible set (from the same metadata index) and reserves at
+most `limit - 1` slots, as today. If the catalogue is not live the stage
+declines and says so in the diagnostics. The MCP tool surface changes, so the
+hosted artifact set is regenerated in the delivery (see the surface-change
+pattern in the knowledge base).
+
+**Alternative rejected: delete the reserve.** The reserve exists for terse
+out-of-KB pages whose title is the query; removing it silently changes answers
+for callers that rely on it. Opt-in keeps the behaviour reachable and stops the
+default from paying for it.
+
+### 4. Timing completeness is a property test, and stages carry a source
+
+`FindTimings.span` remains the only way a stage gets a duration; a manual write
+into the stages table is rejected by construction (the table becomes
+write-through from spans). Every span records a `source` in
+{`index`, `cache`, `declined`, `computed`}. A test drives the real public leaf
+with timing enabled and asserts the two attribution bounds; a second test
+asserts that no stage on the reference corpus reports a walk. The walk sentinel
+is a directory-enumeration counter installed for the duration of the request
+in tests, so the assertion is structural, not a timing threshold.
+
+### 5. The latency gate refuses to measure under load
+
+`scripts/recall_latency_gate.py` runs the series from the proposal against the
+live cell over the direct transport, novel query per sample (nonce), warm
+caches, and reads the per-stage diagnostics. It checks the one-minute load
+average before starting and between samples; above 2.0 it waits a bounded
+time and then exits without a verdict, naming the load. It records the load it
+ran under next to every percentile. Ceilings live in the script as the
+contract and are not calibrated from the runner.
+
+CI keeps a model-free structural guard (the walk sentinel and the attribution
+bounds) on every PR; the live-cell numbers are produced on the operator's box
+at delivery and after each release, because CI runners cannot host the 8k-page
+warm cell.
+
+### 6. Delivery order follows measurement, not ambition
+
+Tranche order: (1) walk sentinel and timing completeness, because every later
+claim is measured through them; (2) page-metadata index and index-backed
+eligibility, the largest win; (3) exact custody invalidation; (4) opt-in
+widening and the surface regeneration; (5) the live-cell gate and the
+before/after series, including re-measuring #951/#983/#984 together on the
+live cell for the first time. Each tranche is a lane with its own
+author-independent reviewer and mutation proofs, after the pattern that
+delivered the write-side change.
+
+## Risks / Trade-offs
+
+- **[Risk] The page-metadata index drifts from frontmatter.** → It is written
+  by the same component and receipt that publish the catalogue; the identity
+  test compares it against the scan oracle on the reference corpus, and
+  reconciliation audits drift the way the graph is audited.
+- **[Risk] Exact invalidation misses a path.** → Receipts name every path a
+  write touched, moves included; the audit compares cache rows against
+  frontmatter after a burst; an unmatched row fails closed to a scope
+  invalidation, never to a stale answer.
+- **[Risk] Default `scope="kb"` results change for callers that relied on the
+  reserve.** → Called out as a behaviour change; the option is on the surface;
+  the connector docs name it.
+- **[Risk] The gate never sees a quiet box.** → It refuses rather than reports;
+  the operator can pause suites, and the structural guards still run in CI.
+- **[Risk] A faster read path raises the write rate a client sustains, and the
+  graph rebuild livelocks more often.** → Owned by
+  `converge-graph-incrementally`; this change ensures a rebuild in flight cannot
+  invalidate the read-side caches.
+
+## Migration Plan
+
+1. Land tranches 1 to 3 behind no flag: they are result-identical by
+   construction and proven by the identity tests.
+2. Land tranche 4 with the widening option default off; regenerate the hosted
+   artifacts, the ChatGPT pending digest and the v1 release identities in the
+   same commit.
+3. Release; upgrade the live cell; run the gate; record before/after in the
+   change; then archive.
+
+Rollback is a release rollback; no data migration, since the metadata index is
+derived and rebuilds from the vault.
+
+## Open Questions
+
+- Whether `speakers` and file-type filters need the metadata table or can stay
+  on the media sidecar they read today; decided by the lane that inventories
+  the filter registry, without changing the specs.

--- a/openspec/changes/accelerate-governed-recall/proposal.md
+++ b/openspec/changes/accelerate-governed-recall/proposal.md
@@ -1,0 +1,95 @@
+## Why
+
+Governed recall on the live cell is not sub-second, and on a busy day it is not
+even sub-minute: two timed hybrid `ask_memory` calls on 2026-09-02 took 29.5 s
+and 17.7 s, of which actual retrieval (vector, keyword, graph, fusion, rerank)
+was 2.9 s and 1.4 s. The rest was two whole-vault walks per request:
+`filter_eligibility` (18.1 s, 7.9 s), which resolves a structured filter by
+reading every page's frontmatter whenever the filter cannot be answered from the
+index, and `outside_kb` (7.6 s, 8.3 s), the `scope="kb"` auto-widening pass that
+re-runs eligibility with vault scope and then a BM25 pass over every non-KB file.
+The same two stages cost about 40 ms on 2026-08-31, when recall median was
+1.4 s, and recall median was 719 ms on 2026-09-01. Every call over Cloudflare's
+100-second edge cap surfaced to the ChatGPT connector as a 502.
+
+The remaining gap between 700 ms and the 300 ms target is fixed per-request
+cost that the 2026-08-31 recall-performance plan already attributed: the
+embedding matrix copy (#951, landed), the query embedded twice per mixed-level
+recall (#984, closed), and three stages that wrote into the timings table
+without registering an interval, so `unattributed_ms` double-counted them
+(#983, closed). Those fixes have never been measured together on the live cell,
+and there is no gate that would notice if any of them regressed. The
+`accelerate-durable-write-acknowledgement` change (0.69.0) removed the write-side
+floor; this change removes the read-side one.
+
+## What Changes
+
+- Structured-filter eligibility becomes index-backed for every supported filter:
+  `projects`, `tags`, `types`, categories, kinds, speakers and file types resolve
+  from the maintained catalogue or the semantic-unit sidecar, and a request that
+  cannot be answered from an index returns the typed warming outcome instead of
+  walking the Markdown scope on the reader thread.
+- Outside-KB widening for `scope="kb"` becomes opt-in and index-backed. The
+  default `kb` scope serves the KB only; a caller that wants the reserve asks
+  for it, and the reserve then runs one catalogue-backed BM25 query with the
+  eligibility set resolved from the same index, never a second vault walk.
+- Read-side caches take exact custody from the derived receipts: a governed
+  write invalidates only the catalogue rows, eligibility entries and BM25
+  postings for the paths it changed, through the same batch receipts and
+  pending-visibility rows that already give writes exact custody. A whole-scope
+  freshness change no longer discards the lexical corpus or the eligibility
+  catalogue.
+- Span accounting is made complete and enforced: every stage that reports time
+  registers an interval, `sum(stages) + unattributed_ms <= total_ms` holds for a
+  real `op_find`, and `unattributed_ms` is bounded.
+- A live-cell recall latency contract replaces the catastrophic-blowup backstop:
+  hybrid p50 at or below 300 ms and p95 at or below 600 ms on a quiescent cell
+  of at least 8,000 pages, keyword p50 at or below 120 ms, zero corpus walks on
+  the read path, measured by the existing timing diagnostics and checked by a
+  script that refuses to measure under load rather than reporting noise.
+- The graph rebuild's whole-vault optimistic check stays out of scope; it is
+  owned by `converge-graph-incrementally`. This change only ensures a rebuild in
+  flight cannot invalidate the read-side caches.
+
+## Capabilities
+
+### New Capabilities
+- `recall-latency-contract`: the live-cell recall latency ceilings, the
+  no-corpus-walk read-path invariant, the quiescence and attribution rules for
+  measuring them, and the regression gate that enforces them.
+
+### Modified Capabilities
+- `structured-retrieval-filters`: `Governed Unit Metadata Is Filterable` gains the
+  requirement that eligibility for every supported filter resolves from an index
+  and never walks the Markdown scope on the reader thread; an unanswerable plan
+  yields a typed warming outcome.
+- `find-recall-efficiency`: `Hot Find Cache With Freshness Invalidation` is
+  narrowed from whole-scope invalidation to exact path custody; `Optional Find
+  Timing Diagnostics` gains completeness (every material stage is an interval and
+  the sum bound holds); a new requirement makes `scope="kb"` widening opt-in and
+  index-backed.
+- `recall-read-path`: `Server Recall Never Rebuilds Projection On The Reader
+  Thread` is extended from the recall projection to the lexical corpus and the
+  eligibility catalogue.
+
+## Impact
+
+- Code: `src/exomem/find.py` (eligibility resolution, outside-KB widening, spans),
+  `src/exomem/find_candidates.py` (spans, candidate hydration),
+  `src/exomem/structured_filters.py` (index plan coverage), `src/exomem/lexstore.py`
+  and `src/exomem/bm25.py` (exact-path invalidation, catalogue-backed reserve),
+  `src/exomem/freshness.py` and `src/exomem/pending_recall.py` (receipt-driven
+  invalidation), `src/exomem/find_types.py` (timing merge), `src/exomem/commands.py`
+  (the widening option on `ask_memory`/`find`), `scripts/recall_latency_gate.py`
+  (new), `tests/test_recall_latency_gate.py` (new), `tests/test_read_path_timing_attribution.py`.
+- APIs: `ask_memory` and the `find` leaf gain an explicit widening option; the
+  default `scope="kb"` result set changes for callers that relied on out-of-KB
+  reserve hits appearing without asking. The MCP tool surface moves, so the
+  hosted artifacts, the ChatGPT plugin pending digest and the v1 release
+  identities are regenerated in the same delivery.
+- Dependencies: the derived batch receipts and pending-visibility rows shipped in
+  `accelerate-durable-write-acknowledgement`; the maintained FTS5 catalogue; the
+  semantic-unit sidecar.
+- Operations: the live cell shares its box with test suites; the gate refuses to
+  run above a load average of 2.0 and records the load it ran under, so a
+  contended measurement is never mistaken for a regression.

--- a/openspec/changes/accelerate-governed-recall/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/accelerate-governed-recall/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,126 @@
+## MODIFIED Requirements
+
+### Requirement: Hot Find Cache With Freshness Invalidation
+
+The system SHALL maintain a small bounded in-process cache for repeated identical `find` requests.
+The cache key MUST include every request parameter that can affect ranking or filtering. The cache
+MUST be invalidated or bypassed when markdown freshness for the relevant scope changes, when an
+embedding or CLIP sidecar that can affect the request changes, or when the active ranking config
+identity changes. Cache hits MUST return copies or immutable results so caller mutation cannot alter
+future cached responses.
+
+Beyond the hit-list cache, the per-request substrate caches (the lexical corpus,
+the eligibility catalogue, the frontmatter cache and the embedding matrix) SHALL
+take exact path custody from the governed write receipts: a governed write
+invalidates only the entries for the paths its receipt names, and a change in a
+whole-scope freshness key MUST NOT by itself discard a substrate cache whose
+paths are all covered by exact receipts. A change that arrives without a
+receipt, such as an external edit detected by reconciliation, MAY invalidate the
+affected scope.
+
+#### Scenario: Repeated identical request can use cache
+
+- **WHEN** the same `find` request is executed twice without vault, sidecar, or ranking-config
+  freshness changes
+- **THEN** the second call may be served from the hot cache
+- **AND** timing diagnostics, when requested, report a cache hit
+- **AND** the returned hits match the uncached result
+
+#### Scenario: Markdown edit invalidates cached recall
+
+- **WHEN** a markdown file that is in scope for a cached `find` request is created, edited, moved,
+  or deleted
+- **THEN** the next matching `find` request does not reuse the stale cached hit list
+- **AND** the next result reflects the changed vault contents
+
+#### Scenario: Sidecar freshness invalidates semantic recall cache
+
+- **WHEN** an embedding or CLIP sidecar that can contribute to a cached hybrid, vector, or visual
+  `find` request changes
+- **THEN** the next matching `find` request does not reuse stale cached semantic results
+
+#### Scenario: Different request knobs do not collide
+
+- **WHEN** two `find` calls differ by query, filters, limit, scope, mode, graph/rerank options,
+  date filters, activity preferences, or ranking configuration
+- **THEN** they do not share the same cached hit list
+
+#### Scenario: A governed write keeps the substrate caches warm
+
+- **WHEN** one governed page is written while the lexical corpus and eligibility catalogue are loaded
+- **THEN** the next recall pays an exact update for that page's rows only
+- **AND** the substrate caches are not rebuilt from the scope
+
+#### Scenario: A receipt-less external edit still invalidates
+
+- **WHEN** a page under the scope changes without a governed write receipt
+- **THEN** reconciliation invalidates the affected scope and the next recall reflects the edit
+
+### Requirement: Optional Find Timing Diagnostics
+
+The system SHALL expose opt-in timing diagnostics for `find` calls. When requested, the response
+SHALL include total elapsed time, cache status, and per-stage timing entries for the retrieval work
+that may affect latency, including freshness/cache lookup, keyword, BM25, vector, CLIP, graph,
+temporal, fusion, filtering/hit construction, rerank, out-of-KB widening, date filtering, pack
+assembly, and serialization. A skipped or unavailable optional lane MUST be represented as skipped
+or unavailable rather than causing the call to fail. Timing diagnostics MUST NOT include note bodies,
+excerpts, vectors, or other bulk content.
+
+Every reported stage SHALL be a registered interval so the unattributed remainder
+is computed from real intervals, and each stage SHALL carry its source (`index`,
+`cache`, `declined` or `computed`) so a corpus walk is visible in the diagnostics.
+
+#### Scenario: Timing diagnostics are returned when requested
+
+- **WHEN** `find` is called with timing diagnostics enabled
+- **THEN** the result includes `timings.total_ms`
+- **AND** the result includes per-stage timing entries for the stages that ran or were skipped
+- **AND** the hit ranking is the same as the same request without timing diagnostics
+
+#### Scenario: Timing diagnostics are omitted by default
+
+- **WHEN** `find` is called without timing diagnostics enabled
+- **THEN** the response shape is unchanged from the existing default `find` response
+- **AND** no timing object is included in the returned hits
+
+#### Scenario: Optional lane failure remains soft-fail
+
+- **WHEN** an optional vector, CLIP, or rerank lane is unavailable during a timed `find` call
+- **THEN** `find` still returns the fallback results it would return today
+- **AND** the timing diagnostics identify that lane as skipped, unavailable, or failed without
+  exposing bulk content
+
+#### Scenario: Every stage is an interval with a source
+
+- **WHEN** a timed `find` runs through the public leaf
+- **THEN** every stage entry carries a duration produced by a registered interval and a source value
+- **AND** `sum(stage.ms) + unattributed_ms` does not exceed `total_ms`
+
+## ADDED Requirements
+
+### Requirement: Scope Widening Is Opt-In And Index-Backed
+
+A recall with `scope="kb"` SHALL serve the knowledge-base scope only by
+default. A caller MAY request out-of-KB widening explicitly; when requested, the
+widening SHALL run one catalogue-backed lexical query restricted to the eligible
+out-of-KB paths resolved from the same index as the KB eligibility, SHALL
+reserve at most `limit - 1` slots, and SHALL NOT walk the vault or rebuild a
+lexical corpus on the reader thread. A widening the catalogue cannot serve
+SHALL be reported as declined in the diagnostics and omitted, not substituted
+by a scan.
+
+#### Scenario: Default KB recall does not widen
+
+- **WHEN** a recall runs with `scope="kb"` and no widening request
+- **THEN** no out-of-KB widening stage runs and the diagnostics report it as skipped
+
+#### Scenario: Requested widening is catalogue-backed
+
+- **WHEN** a recall requests widening and the maintained catalogue is live
+- **THEN** out-of-KB hits come from one catalogue query over the index-resolved eligible set
+- **AND** the stage reports `index` as its source
+
+#### Scenario: Widening declines when the catalogue is not live
+
+- **WHEN** a recall requests widening while the catalogue generation is stale
+- **THEN** the widening stage is reported as declined and the KB results are returned unchanged

--- a/openspec/changes/accelerate-governed-recall/specs/recall-latency-contract/spec.md
+++ b/openspec/changes/accelerate-governed-recall/specs/recall-latency-contract/spec.md
@@ -1,0 +1,78 @@
+## Purpose
+
+The recall latency contract states what a governed recall may cost on the live
+cell, forbids corpus walks on the read path, and defines how the numbers are
+measured so a contended box cannot be mistaken for a regression.
+
+## ADDED Requirements
+
+### Requirement: Governed Recall Meets Fixed Latency Ceilings On A Quiescent Cell
+
+On a quiescent cell of at least 8,000 governed pages with warm caches, a hybrid
+recall without structured filters SHALL complete with p50 at or below 300 ms and
+p95 at or below 600 ms; a keyword recall SHALL complete with p50 at or below
+120 ms; a hybrid recall carrying one supported structured filter SHALL complete
+with p50 at or below 400 ms. The ceilings are the capability's contract, not
+calibrated from any runner, and a gate MUST NOT loosen them. A request that
+returns the typed warming outcome is excluded from the percentiles and counted
+separately; more than one warming outcome in a measured series SHALL fail the
+gate.
+
+#### Scenario: Warm hybrid recall on the reference corpus
+
+- **WHEN** thirty novel hybrid recalls run back to back against a warm cell of at least 8,000 pages with the load average at or below 2.0
+- **THEN** the p50 of their total elapsed time is at or below 300 ms and the p95 at or below 600 ms
+- **AND** no recall in the series reports a corpus walk in any stage
+
+#### Scenario: A filtered recall pays only an index lookup
+
+- **WHEN** the same series runs with a `projects` filter that the index can answer
+- **THEN** the eligibility stage reports an index outcome with a duration under 20 ms
+- **AND** the p50 stays at or below 400 ms
+
+#### Scenario: A contended measurement is refused, not reported
+
+- **WHEN** the gate is started while the one-minute load average is above 2.0
+- **THEN** it waits a bounded time for quiescence and otherwise exits without a result, naming the load it observed
+- **AND** it never emits ceiling comparisons from samples taken under that load
+
+### Requirement: The Read Path Never Walks The Corpus
+
+No stage of a governed recall SHALL enumerate, read or parse every page of the
+vault or of the knowledge-base scope on the reader thread. Eligibility,
+widening, hydration and hit construction SHALL consume maintained indexes and
+exact receipts, and a stage that cannot be answered from an index SHALL return
+the typed warming outcome. Timing diagnostics SHALL expose, per stage, whether
+the stage was answered from an index, from a cache, or declined, so a walk that
+reappears is visible without a benchmark.
+
+#### Scenario: Walk sentinel stays silent on the reference corpus
+
+- **WHEN** a hybrid recall with a structured filter runs with timing diagnostics enabled
+- **THEN** every stage reports `index`, `cache` or `declined` as its source
+- **AND** the process performed no directory enumeration of the knowledge-base scope during the request
+
+#### Scenario: An unanswerable filter declines instead of walking
+
+- **WHEN** a recall names a supported filter field whose index is not live for the current generation
+- **THEN** the recall returns the retryable warming outcome for that stage
+- **AND** the reader thread does not read page frontmatter to evaluate the filter
+
+### Requirement: Timing Attribution Is Complete
+
+For a real recall with timing diagnostics enabled, the sum of stage durations
+plus `unattributed_ms` SHALL NOT exceed `total_ms`, and `unattributed_ms` SHALL
+NOT exceed fifteen percent of `total_ms`. Every stage that reports a duration
+SHALL be an interval registered with the timing merge, never a manual
+difference written into the table.
+
+#### Scenario: A real recall satisfies the attribution bound
+
+- **WHEN** an opt-in timed hybrid recall runs through the public leaf, not a hand-built timing object
+- **THEN** `sum(stage.ms) + unattributed_ms <= total_ms` holds
+- **AND** `unattributed_ms <= 0.15 * total_ms` holds
+
+#### Scenario: A manual timing write fails the completeness check
+
+- **WHEN** a stage writes its duration into the table without registering an interval
+- **THEN** the completeness check fails by reporting that stage as double-counted

--- a/openspec/changes/accelerate-governed-recall/specs/recall-read-path/spec.md
+++ b/openspec/changes/accelerate-governed-recall/specs/recall-read-path/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Server Recall Never Rebuilds Projection On The Reader Thread
+
+An activated managed server request SHALL NOT rebuild a recall projection, projected resolver, referent projection, or catalogue allowlist by walking the vault. It SHALL consume one exact checkpoint-bound proof tying maintained catalogues to the live projections used by that request, or return an explicit retryable warming/unavailable outcome. Correctness-triggered cache eviction and downstream resolver or referent acquisition MUST NOT silently convert the next server reader into the rebuild worker.
+
+The same boundary SHALL hold for the lexical corpus and the structured-filter
+eligibility catalogue: a server reader SHALL NOT build a lexical corpus or
+evaluate a filter by reading pages, and a missing or stale corpus or catalogue
+SHALL yield the retryable warming outcome while a single-flight background
+repair rebuilds it.
+
+#### Scenario: Missing projection fails fast
+
+- **WHEN** a server reader requests recall after correctness eviction and no replacement projection is live
+- **THEN** it receives the retryable retrieval-warming outcome
+- **AND** the full-vault walk and resolver rebuild seams are not invoked on that reader
+
+#### Scenario: Background recovery restores readers
+
+- **WHEN** background seed and catalogue repair publish matching authoritative checkpoints after eviction
+- **THEN** subsequent server readers resume using the maintained projection without a process restart
+
+#### Scenario: Downstream resolver miss preserves the no-walk boundary
+
+- **WHEN** top-level admission succeeds but a hybrid, vector, resolver, or referent stage cannot obtain the matching maintained generation
+- **THEN** that stage declines or returns the retryable warming outcome
+- **AND** it does not rebuild from a vault walk on the request thread
+
+#### Scenario: Cold optional referents warm away from the request
+
+- **WHEN** a managed request has an entity cue but no registry cached for its exact live projection
+- **THEN** the response omits the optional referent block and schedules one single-flight background build
+- **AND** the request thread does not enumerate entity folders or parse the full entity registry
+
+#### Scenario: A lexical corpus miss warms away from the request
+
+- **WHEN** a server reader needs the lexical corpus or the eligibility catalogue and neither is live for the current generation
+- **THEN** the reader returns the retryable warming outcome and one background repair is scheduled
+- **AND** the request thread does not read pages to build either

--- a/openspec/changes/accelerate-governed-recall/specs/structured-retrieval-filters/spec.md
+++ b/openspec/changes/accelerate-governed-recall/specs/structured-retrieval-filters/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Structured Filter Eligibility Resolves From Indexes
+
+Every supported structured filter field, including `projects`, `tags`, `types`,
+categories, kinds, speakers, file types and the governed unit fields, SHALL be
+answerable from a maintained index for the current generation, and eligibility
+resolution for a recall SHALL consume that index. A filter plan the index cannot
+answer SHALL yield the typed retryable warming outcome and schedule the
+single-flight repair; it SHALL NOT evaluate the plan by reading page frontmatter
+on the reader thread. Pending-visibility custody SHALL shadow and re-offer the
+paths it owns so a filter is evaluated against the committed page, not a stale
+index row. The result set of an index-backed evaluation SHALL equal the result
+set the full-scan evaluation would produce for the same generation.
+
+#### Scenario: A project filter resolves from the catalogue
+
+- **WHEN** a recall carries `projects=["<key>"]` and the catalogue is live for the current generation
+- **THEN** the eligible path set comes from the catalogue without reading any page
+- **AND** the set equals the full-scan evaluation of the same filter
+
+#### Scenario: A pending write is filtered against its committed page
+
+- **WHEN** a page's project changes in a governed write whose derived work is still pending
+- **THEN** a recall filtered on the new project includes the page and one filtered on the old project excludes it
+
+#### Scenario: A stale index declines rather than walks
+
+- **WHEN** the catalogue generation does not match the live projection for a filtered recall
+- **THEN** the eligibility stage returns the retryable warming outcome
+- **AND** no page under the scope is read to answer the filter
+
+#### Scenario: An unsupported field is rejected at compile time
+
+- **WHEN** a filter names a field with no index-backed evaluation
+- **THEN** compilation fails with an unknown-filter-field error rather than falling back to a scan

--- a/openspec/changes/accelerate-governed-recall/tasks.md
+++ b/openspec/changes/accelerate-governed-recall/tasks.md
@@ -1,0 +1,45 @@
+## 0. Intake And Baseline
+
+- [ ] 0.1 Record the baseline on the live cell before any code lands: thirty novel hybrid recalls, thirty keyword recalls and thirty `projects`-filtered hybrid recalls over the direct transport with timing diagnostics, load average at or below 2.0, p50/p95 per series and per-stage medians; store the content-free artifact under the change and verify the two walk stages (`filter_eligibility`, `outside_kb`) are present in the filtered series.
+- [ ] 0.2 Inventory every supported structured-filter field and record, per field, whether today's plan classifies it complete or unsupported and which index (semantic-unit sidecar, lexical catalogue, media sidecar) can answer it; verify the inventory lists every field the registry accepts.
+- [ ] 0.3 Prepare one delegation packet per lane (1–5) from this change with base SHA, allowlist, red-first nodes, mutant matrix, exact gates with out-of-tree state roots and basetemp, and a fresh reviewer; verify every gate line executes once before dispatch.
+
+## 1. Lane 1 — Walk Sentinel And Timing Completeness
+
+- [ ] 1.1 Add red tests: a walk sentinel that counts directory enumeration of the knowledge-base scope during one real `find` and fails when it is non-zero, and an attribution test that drives the public leaf with timing enabled and asserts `sum(stage.ms) + unattributed_ms <= total_ms` and `unattributed_ms <= 0.15 * total_ms`; verify both fail on the current tree for a `projects`-filtered hybrid recall.
+- [ ] 1.2 Make the stages table write-through from registered spans, add the per-stage `source` value, and span every remaining manual timing region named in the 2026-08-31 plan (`_find_semantic`, admission folded into `recall_projection`, the unit lane embed, the deep copies); verify the attribution test passes and the diagnostics carry a source for every stage.
+- [ ] 1.3 Mutation proofs in a harness-owned copy: restore one manual timing write and require the attribution test red; remove the sentinel installation and require the walk test red; restore and verify green, Ruff and `git diff --check` clean.
+- [ ] 1.4 Author-independent reviewer attacks the sentinel (can a walk hide behind a cached listing or a subprocess), the bounds, and the source vocabulary; apply corrections and require recheck before acceptance.
+
+## 2. Lane 2 — Index-Backed Structured-Filter Eligibility
+
+- [ ] 2.1 Add red tests: a `projects` filter, a `tags` filter, a `types` filter and an AND of a page clause with a unit clause each resolve with the walk sentinel at zero and return the same path set as the scan oracle on a fixture vault; a stale catalogue generation yields the typed warming outcome; a pending write is evaluated against its committed frontmatter; verify they fail before implementation.
+- [ ] 2.2 Implement the page-metadata index in the lexical catalogue store (path, filterable frontmatter fields, content hash, generation), written by the existing catalogue fan-out component under the write receipt and rebuilt by the single-flight repair; extend `plan_index_candidates` to page clauses; route eligibility through the index for managed readers and keep the oracle for offline mode; verify `tests/test_structured_filters.py`, `tests/test_find_filters*.py` and the new tests pass with an out-of-tree state root.
+- [ ] 2.3 Add an identity test that evaluates every filter in the inventory from 0.2 against both the index and the oracle on the fixture vault and requires equal sets; verify it passes and is model-free.
+- [ ] 2.4 Mutation proofs: drop one field from the index writer and require the identity test red; answer a stale generation from the index and require the warming test red; restore and verify green.
+- [ ] 2.5 Reviewer attacks correctness of `$in`, `$exists`, `NOT` and OR composition against the oracle, generation binding, and the pending overlay; apply corrections and require recheck.
+
+## 3. Lane 3 — Exact Custody For Read-Side Caches
+
+- [ ] 3.1 Add red tests: after one governed write the lexical corpus, eligibility catalogue and frontmatter cache report an exact update of that page's rows only (no rebuild counter increment); a receipt-less external edit still invalidates the scope on reconciliation; a burst of writes to distinct pages leaves every cache row equal to the page's current frontmatter; verify they fail before implementation.
+- [ ] 3.2 Implement per-path invalidation seams on the substrate caches and apply each committed receipt's path set to them; keep whole-scope invalidation for receipt-less drift; verify the tests pass and `tests/test_read_after_write_visibility.py`, `tests/test_pending_recall_delta.py` and `tests/test_lexical_deferred_upsert.py` stay green.
+- [ ] 3.3 Add an audit that compares cache rows against frontmatter after a burst and fails closed to a scope invalidation on any mismatch; verify the audit test passes and a seeded mismatch is caught.
+- [ ] 3.4 Mutation proofs: skip a moved path's old row and require the burst test red; let a whole-scope key evict a receipt-covered cache and require the exact-update test red; restore and verify green.
+- [ ] 3.5 Reviewer attacks moves, deletes, restart hydration, and an in-flight graph rebuild's ability to invalidate read caches; apply corrections and require recheck.
+
+## 4. Lane 4 — Opt-In Widening And Surface Regeneration
+
+- [ ] 4.1 Add red tests: default `scope="kb"` runs no widening stage and reports it skipped; the widening option runs one catalogue query over the index-resolved out-of-KB set with the sentinel at zero; a stale catalogue declines; the reserve never exceeds `limit - 1`; verify they fail before implementation.
+- [ ] 4.2 Add the widening option to the `find` leaf and `ask_memory` (default off), implement the catalogue-backed reserve, and regenerate the MCP schema fixtures, the tool-surface contract, the hosted candidates and both Claude directory channels, the ChatGPT pending digest and the v1 release identities; verify `tests/test_mcp_schema_fidelity.py`, `tests/test_connector_guardrails.py`, `tests/test_hosted_epistemic_profile.py`, `tests/test_hosted_marketplace_release.py`, `tests/test_hosted_plugin_rendering.py` and `tests/test_lazy_imports.py` pass.
+- [ ] 4.3 Mutation proofs: re-enable widening by default and require the default test red; let a stale catalogue fall through to the scan and require the decline test red; restore and verify green.
+- [ ] 4.4 Reviewer attacks the surface change, the reserve cap, and the documentation of the behaviour change; apply corrections and require recheck.
+
+## 5. Lane 5 — Integration, Gate And Live Evidence
+
+- [ ] 5.1 Merge the accepted lanes into one integration worktree, rerun each lane's focused gate, and verify the aggregate diff stays inside the union of the lane allowlists.
+- [ ] 5.2 Add `scripts/recall_latency_gate.py` with the three series from the contract, novel queries, warm caches, quiescence refusal above load 2.0, load recorded per percentile, content-free output, and `--check` against the fixed ceilings; add `tests/test_recall_latency_gate.py` pinning the ceilings, the refusal, and the series shape; verify the tests pass.
+- [ ] 5.3 Run the full guard→mutant→test matrix of lanes 1–4 against the aggregate source copy and verify every node turns red under its mutant and green after restore; preserve the matrix results.
+- [ ] 5.4 Run the full corpus on the merged tree with an out-of-tree basetemp and `--timeout=300`, Ruff, the privacy gate, `git diff --check` and `openspec validate --all --strict`; record commands, exit codes and SHAs, and attribute every failure.
+- [ ] 5.5 Fresh integration reviewer over the aggregate diff with adversarial probes for result identity, stale-answer paths, and the surface change; apply corrections and require recheck.
+- [ ] 5.6 After release and upgrade of the live cell, run the gate on a quiescent cell and record before/after against 0.1: hybrid p50 at or below 300 ms and p95 at or below 600 ms, keyword p50 at or below 120 ms, filtered hybrid p50 at or below 400 ms, zero walks; verify the artifact is stored under the change.
+- [ ] 5.7 Update task checkboxes from evidence, sync delta specs into the canonical specs, run `openspec validate --all --strict`, archive with `openspec archive accelerate-governed-recall`, and validate again.


### PR DESCRIPTION
OpenSpec proposal, design, delta specs and lane task plan for sub-second governed recall. No code.

Measured motivation (live cell, 2026-09-02): two timed hybrid recalls took 29.5 s and 17.7 s, of which retrieval was 2.9 s and 1.4 s; the rest was two whole-vault walks per request, `filter_eligibility` (page-level filters fall to the scan oracle because only `unit.category`/`unit.kind` are index-complete) and `outside_kb` (the `scope=kb` reserve re-resolves eligibility with vault scope and runs BM25 over every non-KB page). The same stages cost ~40 ms on 2026-08-31.

What the change specifies: a page-metadata index so every supported filter resolves without a walk; exact receipt custody for the lexical corpus, eligibility catalogue and frontmatter cache so a governed write invalidates only its paths; opt-in, catalogue-backed out-of-KB widening (default `scope=kb` serves the KB only; MCP surface changes); write-through timing spans with a per-stage source and a walk sentinel; a live-cell latency gate that refuses to measure above load 2.0. Ceilings: hybrid p50 300 ms / p95 600 ms, keyword p50 120 ms, filtered hybrid p50 400 ms on a quiescent cell of at least 8k pages.

`openspec validate --all --strict`: 175 passed.