### PR TITLE
fix(hosted): fail the operation on an immutable resource conflict

### DIFF
--- a/docs/runbooks/hosted/cell.md
+++ b/docs/runbooks/hosted/cell.md
@@ -138,8 +138,11 @@ file.
 set -euo pipefail
 operator_pod=exomem-init-retry-recovery
 helm_release=exomem-platform
+# Select only the chart-managed lock. The name label alone also matches an
+# orphaned ConfigMap left by an earlier manual apply, and under `set -e` the
+# count assertion below then aborts this procedure before it starts.
 mapfile -t lock_names < <(kubectl -n exomem-platform get configmap \
-  -l app.kubernetes.io/name=exomem-hosted-deployment-lock \
+  -l app.kubernetes.io/name=exomem-hosted-deployment-lock,app.kubernetes.io/managed-by=Helm \
   -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 test "${#lock_names[@]}" -eq 1
 lock_name="${lock_names[0]}"
@@ -193,6 +196,7 @@ spec:
         - {name: EXOMEM_RECOVERY_PROVIDER_RECOVERY_PUBLIC_KEY, valueFrom: {secretKeyRef: {name: exomem-provider-recovery-verifier, key: public-key}}}
         - {name: EXOMEM_RECOVERY_HCLOUD_TOKEN, valueFrom: {secretKeyRef: {name: exomem-hcloud-capacity-reader, key: token}}}
         - {name: EXOMEM_RECOVERY_DEPLOYMENT_LOCK_JSON, valueFrom: {configMapKeyRef: {name: $lock_name, key: $lock_key}}}
+        - {name: EXOMEM_RECOVERY_SOURCE_DEPLOYMENT_LOCK_JSON, valueFrom: {configMapKeyRef: {name: $lock_name, key: $lock_key}}}
         - {name: EXOMEM_RECOVERY_RUNTIME_SELECTION, value: $runtime_selection}
         - {name: EXOMEM_RECOVERY_DATABASE_SCHEMA, value: exomem_provisioner}
         - {name: EXOMEM_RECOVERY_DATABASE_ROLE, value: exomem_provisioner_runtime}
@@ -201,6 +205,27 @@ spec:
 EOF
 kubectl -n exomem-platform wait --for=condition=Ready "pod/$operator_pod" --timeout=60s
 ```
+
+`load_recovery_settings` requires the `EXOMEM_RECOVERY_*` set above **exactly** --
+it compares the set of supplied names for equality and refuses on any missing or
+extra one, and it also refuses if any `EXOMEM_PROVISIONER_*` or `EXOMEM_PROVIDER_*`
+name is present (`recovery_settings.py`). A pod that is short one variable does not
+degrade; every recovery mode fails with `recovery environment is invalid`.
+
+`EXOMEM_RECOVERY_SOURCE_DEPLOYMENT_LOCK_JSON` names the lock the stuck operation was
+created under. It is the currently selected lock above whenever the cell was
+provisioned under it, which is the ordinary case. When starting an **initial**
+retarget (`retarget-preflight` or `successor-retarget-preflight`) for a cell whose
+operation was created under a **superseded** lock, supply that older lock's JSON
+instead: those two match the operation's runtime request against the source lock, so
+the current one would compare against the wrong runtime. The resume and retry
+preflights match against the target lock by then -- the stored request has already
+been rewritten -- so this variable is unused there and a stale value is harmless.
+
+Whichever lock you supply must itself contain the selected runtime:
+`validate_selected_runtime` resolves `EXOMEM_RECOVERY_RUNTIME_SELECTION` against **both**
+locks, so an older lock that predates that runtime name fails with the same
+`recovery environment is invalid` and no further explanation.
 
 Before the preflight, scale the routine provisioner worker to zero and leave it
 there through reopen and recovery verification. This is not a global database

--- a/docs/runbooks/hosted/deploy.md
+++ b/docs/runbooks/hosted/deploy.md
@@ -137,7 +137,7 @@ infra/scripts/prepare_hosted_release.py \
   --values-output "${deploy_work_dir}/release-values.json" \
   --control-hostname "$control_hostname" \
   --transfer-hostname "$transfer_hostname"
-infra/scripts/verify_hosted_release.py \
+uv run --project infra/provisioner python infra/scripts/verify_hosted_release.py \
   --phase "$EXOMEM_DEPLOYMENT_PHASE" \
   --lock-pair "$lock_pair" \
   --lock-evidence "$lock_evidence" \

--- a/docs/runbooks/hosted/runtime-upgrades.md
+++ b/docs/runbooks/hosted/runtime-upgrades.md
@@ -118,8 +118,8 @@ Compose the pair with `hosted_composition_lock.py`, using the derived legacy fil
 the exact signed runtime/provisioner inputs, and both coupled trust inputs:
 
 ```text
---runtime-upgrade <runtime-upgrade.json>:<sha256>
---substrate-trust <substrate-trust.json>:<sha256>
+--runtime-upgrade <runtime-upgrade.json>=<sha256>
+--substrate-trust <substrate-trust.json>=<sha256>
 ```
 
 The composer requires exact agreement on target, Substrate consumer commit,

--- a/infra/provisioner/src/exomem_provisioner/worker.py
+++ b/infra/provisioner/src/exomem_provisioner/worker.py
@@ -10,6 +10,7 @@ from .capacity import CapacityIdentityConflict
 from .driver import (
     DriverFinal,
     DriverPending,
+    DriverResource,
     DriverRetryable,
     DriverTerminal,
     EffectContext,
@@ -17,7 +18,13 @@ from .driver import (
     ProvisionerDriver,
 )
 from .models import OperationAction
-from .repository import ClaimConflict, OperationRepository, OperationSnapshot, StaleFence
+from .repository import (
+    ClaimConflict,
+    ImmutableMetadataConflict,
+    OperationRepository,
+    OperationSnapshot,
+    StaleFence,
+)
 from .wire_protocol import FINAL_MODELS_BY_PROTOCOL, WIRE_PROTOCOL_V2, runtime_identity
 
 
@@ -168,6 +175,58 @@ class ProvisionerWorker:
                     lost.set()
                     return
 
+    async def _record_resources(
+        self,
+        operation: OperationSnapshot,
+        resources: tuple[DriverResource, ...],
+        *,
+        claim: dict[str, Any],
+        claim_lost: asyncio.Event,
+    ) -> bool:
+        """Record each driver resource, or terminally fail the operation.
+
+        A recorded resource is immutable, so a provider reference that no longer
+        matches one can never be reconciled by retrying -- the provider resource it
+        named is gone. Letting that escape kills the process, and the restarted pod
+        re-claims this same operation and re-drives its effect without bound.
+
+        Scoped deliberately to these calls. `complete()` raises the same exception for
+        unrelated capacity-ledger integrity violations, and converting those here would
+        park a DISCARD or DESTROY under a provider-metadata code that `reopen()` cannot
+        recover, because it admits only PROVISION.
+
+        Returns False when the operation was failed and the caller must stop.
+        """
+
+        try:
+            for resource in resources:
+                await self._repository.record_resource(
+                    operation_id=operation.id,
+                    worker_id=self._worker_id,
+                    tenant_id=operation.tenant_id,
+                    cell_id=operation.cell_id,
+                    kind=resource.kind,
+                    recoverable_reference=resource.recoverable_reference,
+                    provider_operation_id=operation.external_operation_id,
+                    provider_fence_generation=operation.fence_generation,
+                    **claim,
+                )
+        except ImmutableMetadataConflict:
+            if not claim_lost.is_set():
+                try:
+                    await self._repository.fail(
+                        operation.id,
+                        self._worker_id,
+                        code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+                        **claim,
+                    )
+                except (ClaimConflict, StaleFence):
+                    # The claim expired while handling the conflict. The row becomes
+                    # claimable again and the next holder reaches the same outcome.
+                    pass
+            return False
+        return True
+
     async def _run_claimed(
         self,
         operation: OperationSnapshot,
@@ -267,18 +326,10 @@ class ProvisionerWorker:
         if claim_lost.is_set():
             return True
         if isinstance(outcome, DriverPending):
-            for resource in outcome.resources:
-                await self._repository.record_resource(
-                    operation_id=operation.id,
-                    worker_id=self._worker_id,
-                    tenant_id=operation.tenant_id,
-                    cell_id=operation.cell_id,
-                    kind=resource.kind,
-                    recoverable_reference=resource.recoverable_reference,
-                    provider_operation_id=operation.external_operation_id,
-                    provider_fence_generation=operation.fence_generation,
-                    **claim,
-                )
+            if not await self._record_resources(
+                operation, outcome.resources, claim=claim, claim_lost=claim_lost
+            ):
+                return True
             await self._repository.mark_pending(
                 operation.id,
                 self._worker_id,
@@ -310,18 +361,10 @@ class ProvisionerWorker:
             self._worker_id,
             **claim,
         )
-        for resource in outcome.resources:
-            await self._repository.record_resource(
-                operation_id=operation.id,
-                worker_id=self._worker_id,
-                tenant_id=operation.tenant_id,
-                cell_id=operation.cell_id,
-                kind=resource.kind,
-                recoverable_reference=resource.recoverable_reference,
-                provider_operation_id=operation.external_operation_id,
-                provider_fence_generation=operation.fence_generation,
-                **claim,
-            )
+        if not await self._record_resources(
+            operation, outcome.resources, claim=claim, claim_lost=claim_lost
+        ):
+            return True
         await self._repository.complete(
             operation.id,
             outcome.result,

--- a/infra/provisioner/tests/test_worker.py
+++ b/infra/provisioner/tests/test_worker.py
@@ -13,14 +13,21 @@ from exomem_provisioner.database import ProvisionerDatabase
 from exomem_provisioner.driver import (
     DriverFinal,
     DriverPending,
+    DriverResource,
     DriverRetryable,
     EffectContext,
     FakeDriver,
 )
-from exomem_provisioner.models import OperationAction, OperationState
-from exomem_provisioner.repository import OperationRepository
+from exomem_provisioner.models import (
+    CapacityLedger,
+    OperationAction,
+    OperationState,
+    ResourceKind,
+)
+from exomem_provisioner.repository import ImmutableMetadataConflict, OperationRepository
 from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V2
 from exomem_provisioner.worker import ProvisionerWorker
+from exomem_provisioner.worker_ownership import DELETION_OPERATION_ACTIONS
 
 
 def _settings(path: Path) -> ProvisionerSettings:
@@ -631,6 +638,135 @@ async def test_expected_capacity_identity_conflict_fails_closed_without_crashing
     assert driver.effect_count("provision", operation.id) == 0
     assert failed is not None and failed.state is OperationState.ERROR
     assert failed.error_code == "PROVISIONER_CAPACITY_CONFLICT"
+
+
+@pytest.mark.asyncio
+async def test_immutable_resource_conflict_fails_closed_without_crashing_worker(
+    worker_context: tuple[ProvisionerDatabase, OperationRepository, FakeDriver],
+) -> None:
+    """A destroyed provider resource must fail its operation, never kill the worker.
+
+    A recorded resource is immutable. When the provider reference behind it is
+    destroyed, the driver reports a different one on the next attempt and
+    record_resource raises ImmutableMetadataConflict. If that escapes run_once the
+    process dies, the pod restarts, re-claims the same operation and crashes again --
+    an unbounded loop that also re-drives the effect it is stuck on.
+    """
+
+    _, repository, _ = worker_context
+    operation = await repository.submit(
+        "provision",
+        "immutable-resource-conflict",
+        _request(operationId="operation-immutable-resource-conflict"),
+    )
+
+    class DriftingResourceDriver:
+        """Report a different recoverable reference on each attempt."""
+
+        def __init__(self) -> None:
+            self.attempts = 0
+
+        async def observed_fence(self, tenant_id: str) -> int:
+            del tenant_id
+            return 0
+
+        async def execute(self, action, request, context):
+            del action, request, context
+            self.attempts += 1
+            return DriverPending(
+                checkpoint="volume-registration-required",
+                retry_after_seconds=1,
+                resources=(
+                    DriverResource(
+                        kind=ResourceKind.KUBERNETES_NAMESPACE,
+                        recoverable_reference=f"namespace-attempt-{self.attempts}",
+                    ),
+                ),
+            )
+
+    driver = DriftingResourceDriver()
+    worker = ProvisionerWorker(
+        repository,
+        driver,
+        worker_id="immutable-resource-conflict-worker",
+        capacity_admission=_AllowingAdmission(),
+    )
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+
+    # First attempt records the resource and leaves the operation pending.
+    assert await worker.run_once(now=now) is True
+    pending = await repository.get_by_id(operation.id)
+    assert pending is not None and pending.state is OperationState.PENDING
+
+    # Second attempt reports a different reference for the same recorded resource.
+    # Advance past the pending retry interval so the operation is claimable again.
+    later = now + timedelta(seconds=2)
+    assert await worker.run_once(now=later) is True
+    assert driver.attempts == 2
+    failed = await repository.get_by_id(operation.id)
+    assert failed is not None and failed.state is OperationState.ERROR
+    assert failed.error_code == "PROVISIONER_PROVIDER_METADATA_CONFLICT"
+
+
+@pytest.mark.asyncio
+async def test_capacity_ledger_conflict_on_discard_is_never_relabelled(
+    worker_context: tuple[ProvisionerDatabase, OperationRepository, FakeDriver],
+) -> None:
+    """Only record_resource conflicts convert; complete()'s must still propagate.
+
+    `_release_completed_capacity` raises the same ImmutableMetadataConflict for
+    capacity-ledger integrity violations, and it is reachable only for DISCARD and
+    DESTROY. Converting those would park a destructive operation under a
+    provider-metadata code, and `operation_recovery.reopen()` admits only PROVISION --
+    so the operator helper could never recover it. A loud crash is the correct outcome
+    for a cause this handler cannot substantiate.
+
+    This drives the real raise site on the real deletion worker rather than stubbing
+    `complete`, so it still fails if that raise moves or changes type.
+    """
+
+    database, repository, _ = worker_context
+    operation = await repository.submit(
+        "discard",
+        "discard-ledger-conflict",
+        _request(operationId="operation-discard-ledger-conflict"),
+    )
+    async with database.session_factory() as session:
+        ledger = await session.get(CapacityLedger, 1)
+        if ledger is not None:
+            await session.delete(ledger)
+            await session.commit()
+
+    class DestroyingDriver:
+        """Return the exact discard proof that reaches the capacity ledger."""
+
+        async def observed_fence(self, tenant_id: str) -> int:
+            del tenant_id
+            return 0
+
+        async def execute(self, action, request, context):
+            del action, request, context
+            return DriverFinal(
+                result={
+                    "computeDestroyed": True,
+                    "storageDestroyed": True,
+                    "keysDestroyed": True,
+                }
+            )
+
+    worker = ProvisionerWorker(
+        repository,
+        DestroyingDriver(),
+        worker_id="discard-ledger-conflict-worker",
+        allowed_actions=DELETION_OPERATION_ACTIONS,
+    )
+
+    with pytest.raises(ImmutableMetadataConflict, match="capacity ledger"):
+        await worker.run_once(now=datetime(2030, 1, 1, tzinfo=UTC))
+
+    untouched = await repository.get_by_id(operation.id)
+    assert untouched is not None
+    assert untouched.error_code is None
 
 
 @pytest.mark.asyncio

--- a/infra/scripts/verify_hosted_release.py
+++ b/infra/scripts/verify_hosted_release.py
@@ -809,7 +809,11 @@ def _validate_frozen_v1_corpus(raw: bytes) -> None:
             WIRE_PROTOCOL_V1,
         )
     except ImportError as error:
-        raise ValueError("strict provisioner wire models are unavailable") from error
+        raise ValueError(
+            "strict provisioner wire models are unavailable: the provisioner "
+            "dependencies are not installed in this interpreter. Run this verifier "
+            "under `uv run --project infra/provisioner`."
+        ) from error
     finally:
         if inserted:
             sys.path.remove(provisioner_source)


### PR DESCRIPTION
## What this fixes

`ProvisionerWorker.run_once` caught only `ClaimConflict` and `StaleFence`. When `record_resource` raised `ImmutableMetadataConflict` — which happens whenever a recorded resource's provider reference no longer matches reality, such as a deleted volume — the exception escaped and killed the process. The pod restarted, re-claimed the same operation, and crashed again.

Measured in production while deploying 0.68.3: `exomem-volume-worker` in CrashLoopBackOff for 17 hours across 14 restarts, `claim_generation` at 67 and 2472 on two wedged operations. Each restart re-drove the effect, which is how a deleted cell was rebuilt and its provider volume re-billed.

A recorded resource is immutable, so this can never reconcile by retrying. The fix converts it to the terminal `PROVISIONER_PROVIDER_METADATA_CONFLICT` failure the driver's own path already produces. Notably `operation_recovery.reopen()` already gated on exactly that state — main shipped a recovery funnel for a state nothing could reach, because the crash came first.

## Why the catch is scoped, not top-level

The conversion lives in `_record_resources`, wrapping only the two `record_resource` loops. `complete()` raises the same exception type for capacity-ledger integrity violations, and `build_deletion_operation_worker` shares this loop — so a top-level catch would park a DISCARD or DESTROY under a provider-metadata code that `reopen()` cannot recover, since it admits only PROVISION. That would trade a loud crash for a quiet, mislabelled, unrecoverable failure.

`test_capacity_ledger_conflict_on_discard_is_never_relabelled` pins this by driving the real raise site on the real deletion worker.

## Operator traps also fixed

Each was hit while performing the 0.68.3 upgrade:

- **Recovery pod could never start.** `cell.md` set 10 of the 11 `EXOMEM_RECOVERY_*` variables that `recovery_settings.py:107` enforces by strict set equality. Its lock-ConfigMap selector also matched an unmanaged leftover — verified live: the name-only selector returns 2, aborting at `test -eq 1` about 50 lines before the missing variable is even read.
- **Composer argument format.** Documented as `PATH:SHA256`; `hosted_composition_lock.py:1136` requires `PATH=SHA256`.
- **Misleading verifier error.** Missing dependencies surfaced as `strict provisioner wire models are unavailable`, which reads as a corrupt artifact.

## Verification

Red-first: the new test fails *by crashing* before the fix, passes after. Three mutants, all killed — conversion removed, `fail()` removed, and the rejected top-level catch restored (caught by the scope test).

| Gate | Result |
|---|---|
| Provisioner suite | 506 passed, 17 skipped |
| `test_worker.py` | 23 passed |
| Hosted docs/contracts | 139 passed, 5 failed |
| `ruff check` | clean |

The 5 failures are `test_active_secret_registry_*`, identical on pristine `origin/main` in a disposable worktree — pre-existing and environment-dependent. `test_authorization_membership.py` and `test_live_provider.py` are excluded: they import the parent `exomem` package, absent from the provisioner-only venv, and neither references the changed code.

Independent adversarial review returned REJECT on a MAJOR (the over-broad catch scope described above) plus three MINORs, then ACCEPT after correction.
