### PR TITLE
docs(openspec): propose make-hosted-admission-self-describing

### DIFF
--- a/openspec/changes/make-hosted-admission-self-describing/.openspec.yaml
+++ b/openspec/changes/make-hosted-admission-self-describing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/make-hosted-admission-self-describing/design.md
+++ b/openspec/changes/make-hosted-admission-self-describing/design.md
@@ -1,0 +1,136 @@
+## Context
+
+Hosted admission is empirical by design. `hasLiveHostedCohortTarget`
+(`src/lib/exomem-hosted/hosted-cohort-target.ts`) admits a provision only when exactly
+one candidate for `EXOMEM_HOSTED_PROFILE` is `live` **and** every `bound` cell serving
+that candidate's release agrees on a single `observed_gateway_contract_digest`. The
+same shape appears as the `live_target` CTE in `redeemInviteAtomic`
+(`db.ts:777-795`), which is required only under wire protocol v2 (`db.ts:804-809`).
+
+That invariant is correct and should not be weakened. A hosted cell serves a gateway
+contract that Claude and ChatGPT cache; admitting a tenant onto a runtime whose
+observed contract nobody has proven breaks clients in a way the end user cannot
+diagnose. Deriving the catalogue from observation rather than declaration is the point.
+
+The failure is at the boundary. Every gate is phrased as "prove the new thing against
+the currently-running thing", which is well-defined for a fleet of size >= 1 and
+undefined at zero. The system currently handles zero through a privileged bootstrap
+(`docs/runbooks/exomem-hosted-alpha.md:357-401`), which is the right structural answer
+— the alternative, letting the first cell in unproven, is a gate anyone can bypass by
+draining to zero. But that bootstrap is undiscoverable from the failure, invisible in
+the inventory, and non-resumable when it goes wrong.
+
+Observed on 2026-09-02 while deploying 0.68.3: fleet inventory reported
+`status: empty, issues: []`; `liveCohortCandidateId` was `None`; no candidate existed
+for 0.68.3 at all (newest `hosted-alpha-agent-v4` were 0.63.1 and 0.66.0); and the
+invited person received "not admitting new accounts until its service catalogue is
+updated" with no route to the remedy.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A refusal names its own remedy without leaking tenant, invite, or cohort detail to
+  the refused party.
+- The closed state is visible in fleet inventory before a human encounters it.
+- The service catalogue cannot silently lag the deployed runtime.
+- The bootstrap can be retried without burning single-use inputs.
+- Promotion stops permanently foreclosing a platform.
+
+**Non-Goals:**
+
+- Weakening the bound-cell requirement, or adding a flag that admits tenants without
+  proven contract observation. The empirical gate stays.
+- Automating the reviewer bootstrap end to end. It should be resumable and
+  discoverable, not unattended.
+- Auto-promoting a candidate. Registering a `pending` candidate is not promotion, and
+  promotion stays an explicit operator act.
+- Changing wire protocol v1 behaviour or its admission rules.
+
+## Decisions
+
+**Classify the closure rather than adding a new error code.** `HOSTED_ADMISSION_CLOSED`
+already reaches the invited person with correct, non-leaking copy, and its three call
+sites (`db.ts:680`, `db.ts:862`, `oauth-store.ts:1479`) mean different things. Add a
+closure *reason* carried in the operator-facing envelope and structured log while the
+public message stays as it is. Alternative considered: a distinct
+`HOSTED_NO_LIVE_COHORT` code — rejected because it changes a user-visible contract for
+an audience that cannot act on the distinction, and every client would have to learn it.
+
+**Derive the inventory signal, do not store it.** `hosted_fleet_inventory.py:1549`
+computes `status` as `"inconsistent" if issues else "empty" if live_count == 0 else
+"consistent"`. Add `admission_closed` to the issue set when the reconciled fleet has
+zero bound cells and the Substrate observation reports no live cohort. This reuses the
+existing issue machinery, so it automatically blocks the upgrade phase gate at
+`hosted_runtime_upgrade.py:363` — which is correct: an upgrade should not advance into
+a fleet nobody can join. Alternative considered: a separate readiness endpoint —
+rejected as a second source of truth for the same fact.
+
+**Register the candidate from the publication pipeline, not the deployment.** The
+signed candidate already exists as a release artifact with a verified digest, and
+`hosted-image-candidate-publication` already owns its provenance. Registering the
+`pending` agent-contract candidate there keeps one producer for the identity.
+Registering at deploy time was considered and rejected: the deploy path is the
+provisioner's, has no Substrate write authority, and would make an operator-driven
+rollback silently mutate the catalogue.
+
+**Checkpoint the bootstrap on the authority record, not in the harness.** The
+`exomem_marketplace_reviewer_oauth_bootstrap_authorities` row already scopes one
+attempt and already has a lifecycle (`consumed`, revoked, expired). Recording per-step
+progress there makes resumption a server-side fact rather than local harness state,
+which survives a lost terminal — the case that actually strands attempts today.
+Alternative considered: a state file next to `scripts/reviewer_bootstrap.py` — rejected
+because the state that matters (invite consumed, client registered, tenant created)
+lives in the database, and a local file can disagree with it.
+
+**Keep promotion one-shot per *platform*, not per *candidate*.** The current trap is
+that promotion retires the rollout assignment that the `cells` precondition depends on
+(`agent-contract-store.ts`), so the bound proof a second platform needs is gone the
+moment the first is promoted. Preserve that proof — retain the assignment, or persist
+the routable-cell digest it attested — so a later pairing can verify against the same
+evidence. This is the largest change here and the only **BREAKING** one; it alters what
+promotion leaves behind.
+
+## Risks / Trade-offs
+
+- **Retaining the rollout assignment past promotion weakens a cleanup invariant.** →
+  Retain the attested digest rather than an `active` assignment where possible, so
+  nothing downstream mistakes a promoted candidate for one still rolling out. Whichever
+  is chosen must be proven by a test that fails when a promoted candidate is treated as
+  in-flight.
+- **`admission_closed` will make the upgrade gate refuse on an empty fleet.** → That is
+  intended, and it is also a behaviour change for anyone deliberately upgrading an
+  empty platform. The bootstrap must therefore be runnable while the execution is held,
+  and the gate must state which issue is blocking it.
+- **Auto-registering a pending candidate adds a Substrate write to the release
+  pipeline.** → Scope the credential to candidate registration only. A failure to
+  register must not fail the image publication, and must surface as its own alert;
+  registration is recoverable by hand, an unpublished image is not.
+- **Bootstrap checkpoints could resume into a half-built tenant.** → Each checkpoint
+  records what is provably true server-side. Resume must re-verify preconditions rather
+  than trusting the checkpoint, and must refuse when the world has moved.
+
+## Migration Plan
+
+1. Ship the inventory issue and the classified refusal first. Both are read-only
+   diagnostics and independently useful; neither changes admission behaviour.
+2. Ship candidate auto-registration next, backfilling a `pending` candidate for the
+   currently deployed release so the catalogue is truthful before anything depends on it.
+3. Ship bootstrap checkpointing before the promotion change, so an attempt at the
+   promotion work is itself retryable.
+4. Ship the promotion decoupling last, behind its own migration, since it is the only
+   breaking change and the only one that alters retained evidence.
+
+Rollback: steps 1-3 are additive and revert cleanly. Step 4 requires a migration that
+restores prior assignment retirement; a candidate promoted under the new behaviour must
+be treated as live and not re-promoted.
+
+## Open Questions
+
+- Does a second platform paired onto an already-promoted candidate require fresh
+  runtime health evidence, or does the retained attestation suffice? This decides
+  whether step 4 is a storage change or also a re-verification change.
+- Should `admission_closed` block the upgrade phase gate outright, or report as an
+  issue the operator can acknowledge for a deliberately empty platform?
+- Is there any legitimate operational state with zero bound cells where admission is
+  expected to stay open, which would make the inventory signal a false positive?

--- a/openspec/changes/make-hosted-admission-self-describing/proposal.md
+++ b/openspec/changes/make-hosted-admission-self-describing/proposal.md
@@ -1,0 +1,82 @@
+## Why
+
+Exomem Hosted cannot admit its first tenant into an empty fleet, and nothing in the
+running system says so. Deploying 0.68.3 to a fleet with zero cells produced a clean
+green fleet inventory (`status: empty`, `issues: []`) while admission was structurally
+shut: `hasLiveHostedCohortTarget` requires a candidate joined to an already-`bound`
+cell, and there was none. The invited person saw only "hosted admission is temporarily
+closed ... until its service catalogue is updated", which names no procedure, and the
+operator saw a passing inventory. The remedy exists — the virgin-install reviewer
+bootstrap in the promotion run sheet — but nothing at the point of failure points to
+it, and the release that was just deployed had never been registered as a candidate at
+all.
+
+The gates themselves are sound. Admission is empirical on purpose: a hosted cell serves
+a gateway contract that Claude and ChatGPT cache, so admitting a tenant onto a runtime
+whose observed contract nobody has proven would break clients in a way the end user
+cannot diagnose. The defect is that every invariant is phrased as "prove the new thing
+against the currently-running thing", which is correct for a fleet of size >= 1 and
+undefined at zero — and the system neither detects that state, explains it, nor lets
+the recovery from it be retried.
+
+## What Changes
+
+- Make every admission refusal name its own remedy. `HOSTED_ADMISSION_CLOSED` MUST
+  distinguish "no live cohort" from other closures and MUST carry an operator-facing
+  reference to the bootstrap procedure, without leaking tenant or invite detail to the
+  invited person.
+- Make the closed state observable before a human hits it. Zero bound cells combined
+  with no live cohort MUST be a reported fleet-inventory issue, not a clean `empty`.
+  An operator MUST be able to see "admission is closed" from the inventory alone.
+- Register the release with the control plane as part of publishing it. Publishing a
+  signed runtime image candidate MUST also record a `pending` agent-contract candidate
+  for that release, so the service catalogue cannot silently lag the deployed runtime.
+- Make the virgin-install reviewer bootstrap resumable. Each step MUST be individually
+  retryable against its own recorded checkpoint, and a failure MUST NOT consume the
+  invite, alias, staged release, or client record that the retry needs. Today a single
+  failure burns all four and strands a tenant that blocks the retry.
+- **BREAKING** Decouple platform selection from promotion. Promoting one platform MUST
+  NOT foreclose adding another to the same candidate. Today promotion retires the
+  rollout assignment that its own `cells` precondition depends on, so promoting Claude
+  alone permanently prevents pairing OpenAI onto that candidate — a permanent product
+  consequence that falls out of an implementation detail rather than a decision.
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-admission-bootstrap`: Defines how Hosted reports, detects, and recovers from
+  a fleet state in which no tenant can be admitted — the self-describing refusal, the
+  inventory signal that precedes it, the resumable bootstrap that clears it, and the
+  requirement that promotion leave a second platform pairable.
+
+### Modified Capabilities
+
+- `hosted-image-candidate-publication`: Publishing a signed runtime candidate also
+  registers the corresponding pending agent-contract candidate, so the deployed release
+  and the service catalogue cannot diverge silently.
+
+Note: the one-shot promotion behaviour this change replaces is not specified in any
+canonical spec today — it exists only as implementation in
+`agent-contract-store.ts` and as prose in the promotion run sheet, and the
+`hosted-runtime-upgrade` capability that would own it is still an unarchived change.
+The replacement is therefore stated as a new requirement here rather than as a delta
+against a requirement that does not exist.
+
+## Impact
+
+- Substrate: `src/lib/exomem-hosted/errors.ts` (refusal detail),
+  `hosted-cohort-target.ts` and `db.ts:680,804-809` (closure classification),
+  `agent-contract-store.ts` (promotion preconditions, assignment retirement),
+  `oauth-store.ts` (bootstrap authority checkpoints), plus database migrations for
+  bootstrap checkpoint state and any promotion-assignment change.
+- Exomem: `infra/scripts/hosted_fleet_inventory.py:1549` (issue classification),
+  `scripts/reviewer_bootstrap.py` and `scripts/promotion_evidence.py` (resumable
+  steps), the release workflow that publishes image candidates, and
+  `docs/runbooks/exomem-hosted-alpha.md:242-262,357-401`.
+- Operators: an empty fleet reports admission as closed instead of green; the bootstrap
+  can be retried without burning single-use inputs; the platform choice at promotion
+  stops being irreversible.
+- Tenants and invited people: no behavioural change to a working fleet. A refusal
+  during a closed window stays non-leaking, and the invitation remains unconsumed and
+  valid exactly as it does today.

--- a/openspec/changes/make-hosted-admission-self-describing/specs/hosted-admission-bootstrap/spec.md
+++ b/openspec/changes/make-hosted-admission-self-describing/specs/hosted-admission-bootstrap/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Admission refusal names its own remedy
+
+The system SHALL classify why admission is closed and SHALL make that classification
+available to the operator, while the message reaching the refused person remains
+non-leaking and unchanged in substance. A refusal caused by the absence of a live
+cohort SHALL be distinguishable from every other closure, and its operator-facing form
+SHALL reference the bootstrap procedure that clears it.
+
+#### Scenario: No live cohort refuses an invite redemption
+
+- **WHEN** an invited person redeems a valid, unconsumed invitation while no live
+  cohort target exists
+- **THEN** the refusal is classified as a no-live-cohort closure
+- **AND** the operator-facing envelope and structured log name the bootstrap procedure
+- **AND** the message shown to the invited person discloses no tenant, cohort,
+  candidate, or fleet detail
+- **AND** the invitation remains unconsumed, unrevoked, and valid
+
+#### Scenario: A closure with a different cause is not misreported
+
+- **WHEN** admission is refused for a reason other than the absence of a live cohort
+- **THEN** the classification names that other cause
+- **AND** it does not reference the bootstrap procedure
+
+### Requirement: A fleet that cannot admit anyone is reported as an issue
+
+The system SHALL treat a reconciled fleet with zero bound cells and no live cohort as a
+reported inventory issue rather than a clean empty result. Fleet inventory SHALL NOT
+report a status that an operator would read as healthy while no tenant can be admitted.
+
+#### Scenario: Empty fleet with no live cohort
+
+- **WHEN** fleet inventory reconciles a fleet with zero bound cells and the control
+  plane reports no live cohort
+- **THEN** the inventory reports an admission-closed issue
+- **AND** the inventory status is not `empty` or `consistent`
+
+#### Scenario: Empty fleet with a live cohort still available
+
+- **WHEN** fleet inventory reconciles a fleet with zero bound cells while a live cohort
+  target does exist
+- **THEN** the admission-closed issue is not reported
+
+#### Scenario: Upgrade phases refuse to advance into a closed fleet
+
+- **WHEN** a runtime-upgrade execution attempts to advance past inventory while the
+  admission-closed issue is present
+- **THEN** the phase gate refuses
+- **AND** the refusal names the admission-closed issue as the blocking condition
+
+### Requirement: The virgin-install bootstrap is resumable
+
+The system SHALL record bootstrap progress against the reviewer bootstrap authority so
+that an interrupted or failed attempt can be resumed. A failed step SHALL NOT consume
+the invitation, email alias, staged client release, or client record that the retry
+requires, and SHALL NOT leave a tenant that blocks the retry.
+
+#### Scenario: A step fails and the attempt is resumed
+
+- **WHEN** a bootstrap step fails after earlier steps have succeeded
+- **THEN** the completed steps remain recorded against the authority
+- **AND** the invitation, alias, staged release, and client record remain reusable
+- **AND** resuming continues from the first incomplete step
+
+#### Scenario: Resumption re-verifies rather than trusting the checkpoint
+
+- **WHEN** a bootstrap attempt is resumed after the underlying state has changed such
+  that a recorded checkpoint is no longer true
+- **THEN** resumption refuses
+- **AND** it names the precondition that no longer holds
+
+#### Scenario: A stranded tenant does not block a retry
+
+- **WHEN** a bootstrap attempt fails after a tenant has been created
+- **THEN** the retry either reuses that tenant or is able to retire it
+- **AND** the retry is not refused solely because the earlier attempt created it
+
+### Requirement: Promotion leaves a second platform pairable
+
+The system SHALL retain enough attested bound proof after promoting a candidate for a
+further platform to be paired onto that same candidate. Promoting one platform SHALL
+NOT permanently foreclose promoting another onto the same candidate.
+
+#### Scenario: A second platform is paired after a single-platform promotion
+
+- **WHEN** a candidate has been promoted for one platform only
+- **AND** the operator later supplies complete, valid evidence for a second platform
+- **THEN** the pairing is accepted against the retained attested proof
+- **AND** it does not require a fresh candidate, reviewer tenant, or evidence run for
+  the already-promoted platform
+
+#### Scenario: A promoted candidate is not mistaken for one still rolling out
+
+- **WHEN** any process inspects a candidate that has been promoted while its retained
+  proof is still present
+- **THEN** the candidate is reported as promoted
+- **AND** it is not selected or treated as an in-flight rollout

--- a/openspec/changes/make-hosted-admission-self-describing/specs/hosted-image-candidate-publication/spec.md
+++ b/openspec/changes/make-hosted-admission-self-describing/specs/hosted-image-candidate-publication/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Publishing a runtime candidate registers it with the service catalogue
+
+The system SHALL register a pending agent-contract candidate for a runtime release as
+part of publishing that release's signed image candidate, so the deployed runtime and
+the control-plane service catalogue cannot diverge silently. Registration SHALL record
+the candidate as pending only; it SHALL NOT promote it, make it live, or alter any
+existing live cohort.
+
+#### Scenario: A published runtime candidate appears in the catalogue
+
+- **WHEN** a signed runtime image candidate is published for a release
+- **THEN** a corresponding agent-contract candidate is registered for that release and
+  protocol version in state `pending`
+- **AND** no candidate is promoted and no live cohort changes as a result
+
+#### Scenario: Registration is idempotent for a republished release
+
+- **WHEN** publication runs again for a release whose candidate is already registered
+- **THEN** no duplicate candidate is created
+- **AND** the existing candidate's state is unchanged
+
+#### Scenario: A registration failure does not fail the publication
+
+- **WHEN** candidate registration fails while the signed image candidate has published
+  successfully
+- **THEN** the image publication remains successful and durable
+- **AND** the registration failure is surfaced as its own alert for manual recovery
+
+#### Scenario: Registration authority is scoped to the catalogue
+
+- **WHEN** the publication pipeline registers a candidate
+- **THEN** the credential it uses can register candidates only
+- **AND** it cannot promote a cohort, alter a live candidate, or modify tenant state

--- a/openspec/changes/make-hosted-admission-self-describing/tasks.md
+++ b/openspec/changes/make-hosted-admission-self-describing/tasks.md
@@ -1,0 +1,78 @@
+## 1. Classify the admission refusal
+
+- [ ] 1.1 Add a closure reason to the admission refusal path so the three call sites
+      (`db.ts:680`, `db.ts:862`, `oauth-store.ts:1479`) are distinguishable
+- [ ] 1.2 Carry the reason in the operator-facing envelope and structured log, leaving
+      the public `HOSTED_ADMISSION_CLOSED` message unchanged in substance
+- [ ] 1.3 Reference the bootstrap procedure only for the no-live-cohort reason
+- [ ] 1.4 Test that a no-live-cohort refusal leaks no tenant, cohort, candidate, or
+      fleet detail to the refused party, and leaves the invitation unconsumed
+- [ ] 1.5 Test that a refusal with a different cause does not reference the bootstrap
+
+## 2. Report a fleet nobody can join
+
+- [ ] 2.1 Add the `admission_closed` issue to `hosted_fleet_inventory.py` when the
+      reconciled fleet has zero bound cells and the Substrate observation reports no
+      live cohort
+- [ ] 2.2 Confirm the issue flows through the existing `status` derivation at
+      `hosted_fleet_inventory.py:1549` so the result is not `empty` or `consistent`
+- [ ] 2.3 Make the upgrade phase gate at `hosted_runtime_upgrade.py:363` name
+      `admission_closed` as the blocking condition when it refuses
+- [ ] 2.4 Test the three cases: zero bound cells with no live cohort (issue raised),
+      zero bound cells with a live cohort (no issue), and a populated fleet (no issue)
+- [ ] 2.5 Resolve the open question on whether an operator may acknowledge the issue for
+      a deliberately empty platform, and implement whichever answer is chosen
+
+## 3. Keep the catalogue current with the deployed runtime
+
+- [ ] 3.1 Register a `pending` agent-contract candidate as part of publishing a signed
+      runtime image candidate
+- [ ] 3.2 Scope the pipeline credential to candidate registration only, with no
+      promotion, live-candidate, or tenant authority
+- [ ] 3.3 Make registration idempotent for a republished release
+- [ ] 3.4 Ensure a registration failure surfaces its own alert and never fails the
+      image publication
+- [ ] 3.5 Backfill a pending candidate for the currently deployed release so the
+      catalogue is truthful before anything depends on it
+- [ ] 3.6 Test each scenario in the `hosted-image-candidate-publication` delta
+
+## 4. Make the bootstrap resumable
+
+- [ ] 4.1 Add per-step checkpoint state to the reviewer bootstrap authority record,
+      with a migration
+- [ ] 4.2 Record each step of `scripts/reviewer_bootstrap.py` against that authority as
+      it completes
+- [ ] 4.3 Ensure a failed step leaves the invitation, email alias, staged client
+      release, and client record reusable
+- [ ] 4.4 Make resume re-verify preconditions rather than trusting the checkpoint, and
+      refuse by naming the precondition that no longer holds
+- [ ] 4.5 Allow a retry to reuse or retire a tenant stranded by an earlier attempt
+- [ ] 4.6 Test an interrupted attempt resuming from the first incomplete step, and a
+      resume refused because the world moved
+- [ ] 4.7 Update `docs/runbooks/exomem-hosted-alpha.md:357-401` to describe resumption
+      and drop the guidance that a failure burns the whole set of inputs
+
+## 5. Decouple platform selection from promotion
+
+- [ ] 5.1 Answer the open question on whether a later pairing needs fresh runtime health
+      evidence or may rely on the retained attestation
+- [ ] 5.2 Retain the attested routable-cell proof past promotion, with a migration
+- [ ] 5.3 Change promotion so it no longer destroys the evidence a second platform's
+      precondition depends on
+- [ ] 5.4 Ensure a promoted candidate is reported as promoted and is never selected or
+      treated as an in-flight rollout
+- [ ] 5.5 Test pairing a second platform onto an already-promoted candidate without a
+      fresh candidate, reviewer tenant, or repeat evidence run for the first platform
+- [ ] 5.6 Test that a promoted candidate with retained proof is not treated as in-flight
+- [ ] 5.7 Update the promotion run sheet at `docs/runbooks/exomem-hosted-alpha.md:242-262`
+      to remove the permanent-foreclosure warning once the behaviour is gone
+
+## 6. Verification
+
+- [ ] 6.1 Run `openspec validate --all --strict`
+- [ ] 6.2 Exercise the whole path end to end on an empty fleet: inventory reports
+      `admission_closed`, a redemption attempt is classified and points at the run
+      sheet, the bootstrap runs to a bound cell, and inventory then reports clean
+- [ ] 6.3 Confirm ordering held during rollout — diagnostics (groups 1-2) shipped before
+      catalogue registration (3), and bootstrap resumability (4) before the promotion
+      change (5)


### PR DESCRIPTION
## Why

Deploying 0.68.3 to an empty fleet found that **Hosted cannot admit its first tenant, and nothing in the running system says so.**

Fleet inventory reported `status: empty, issues: []` — a clean green — while `hasLiveHostedCohortTarget` required a candidate joined to an already-`bound` cell and there was none. The invited person got "hosted admission is temporarily closed … until its service catalogue is updated", which names no procedure. The remedy exists (`docs/runbooks/exomem-hosted-alpha.md:357`, virgin-install reviewer bootstrap) but nothing at the point of failure points at it, and the release just deployed had never been registered as a candidate at all.

## The gates are right; the boundary isn't

Admission is empirical on purpose. A hosted cell serves a gateway contract that Claude and ChatGPT cache, so admitting a tenant onto a runtime whose observed contract nobody has proven breaks clients in a way the end user cannot diagnose. Deriving the catalogue from observation rather than assertion is the point, and this change does not weaken it.

The defect is that every invariant reads "prove the new thing against the currently-running thing" — well-defined for a fleet of size ≥ 1, undefined at zero. The system handles zero through a privileged bootstrap, which is the correct structural answer. But that bootstrap is undiscoverable from the failure, invisible in the inventory, and non-resumable when it goes wrong.

## What it proposes

1. **Classify the refusal** so a no-live-cohort closure is distinguishable and names the bootstrap — without changing what the refused person sees.
2. **Report `admission_closed`** in fleet inventory when zero bound cells meet no live cohort, so it stops reading as healthy.
3. **Register a pending candidate from the publication pipeline**, so the catalogue cannot lag the deployed runtime.
4. **Checkpoint the bootstrap on its authority record**, so a failure stops burning the invite, alias, stage, and client the retry needs.
5. **BREAKING** — **decouple platform selection from promotion**, so promoting Claude alone no longer permanently forecloses OpenAI on that candidate.

## Notes for review

- Item 5 is stated as a **new requirement, not a delta**: no canonical spec owns the one-shot promotion behaviour today. It exists as implementation in `agent-contract-store.ts` plus prose in the run sheet, and `hosted-runtime-upgrade` is still an unarchived change.
- Migration order is deliberate — diagnostics first (independently useful, no behaviour change), then catalogue registration, then bootstrap resumability, then the breaking promotion change last.
- Three open questions are recorded rather than guessed, the sharpest being whether a later platform pairing needs fresh runtime health evidence or may rely on the retained attestation. That decides whether item 5 is a storage change or also a re-verification change.

Proposal, design, spec deltas and tasks only — no implementation. `openspec validate --strict` passes.
