### PR TITLE
fix(acceptance): measure the product, not the acceptance harness

### DIFF
--- a/scripts/live_write_acceptance.py
+++ b/scripts/live_write_acceptance.py
@@ -48,12 +48,15 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import managed_recall  # noqa: E402
 
 from exomem import (  # noqa: E402
     deferred_index,
     derived_drain,
     derived_receipts,
-    lexstore,
     memory_refs,
     pending_recall,
     readiness,
@@ -235,32 +238,134 @@ def _reconciliation_demanded(vault_root: Path) -> int:
     return derived_receipts.recoverable_batch_count(vault_root)
 
 
+def _drain_observation(vault_root: Path) -> dict[str, int]:
+    """What the store says about components a burst has not settled yet.
+
+    Content-free by construction: three counts read straight off the receipt
+    store, no batch id, component name, path or failure text. `stuck` is the
+    one that matters -- a component that has already been attempted and is
+    either backing off into the future or carrying a failure code is not
+    something more draining will clear, and reporting it as backlog is how a
+    run that needs a person gets read as a run that needs more time.
+
+    An unreadable store reports -1 rather than zero, because a counter that
+    cannot be read has not proved anything.
+    """
+    try:
+        due = int(derived_receipts.due_component_count(vault_root))
+    except Exception:  # noqa: BLE001 - an unreadable counter cannot prove zero
+        due = -1
+
+    stuck = 0
+    failed = 0
+    max_attempt_count = 0
+    rows: list[tuple[Any, Any, Any]] = []
+    try:
+        if deferred_index.store_path(vault_root).exists():
+            connection = deferred_index._connect_readonly(vault_root)
+            try:
+                rows = connection.execute(
+                    "SELECT c.attempt_count, c.next_attempt_at, c.failure_code "
+                    "FROM derived_batch_components AS c "
+                    "JOIN derived_batches AS b ON b.batch_id = c.batch_id "
+                    "WHERE b.state = 'ready' "
+                    "AND c.state IN ('ready', 'claimed', 'retryable')"
+                ).fetchall()
+            finally:
+                connection.close()
+    except Exception:  # noqa: BLE001 - same
+        return {"due": due, "stuck": -1, "failed": -1, "max_attempt_count": -1}
+
+    now = time.time()
+    for attempt_count, next_attempt_at, failure_code in rows:
+        attempts = int(attempt_count or 0)
+        max_attempt_count = max(max_attempt_count, attempts)
+        if failure_code is not None:
+            failed += 1
+        if attempts > 0 and (
+            failure_code is not None or float(next_attempt_at or 0.0) > now
+        ):
+            stuck += 1
+    return {
+        "due": due,
+        "stuck": stuck,
+        "failed": failed,
+        "max_attempt_count": max_attempt_count,
+    }
+
+
 def _converge(
     vault_root: Path, *, bound_seconds: float = CONVERGENCE_BOUND_SECONDS
-) -> tuple[float, bool]:
-    """Drain the burst on the wall clock and report whether it settled.
+) -> tuple[float, bool, dict[str, Any]]:
+    """Drain the burst in bounded passes and report what the drain did.
 
     The wall clock is the point: the store's retry backoff is a wall-clock
     deadline, so a burst's real convergence window is a real wait. Between
     passes it yields rather than spinning, because a hot loop competes with the
     very workers it is waiting on.
+
+    A pass claims `derived_drain.progress_limit()` -- the scheduler's own
+    allowance for this mode -- rather than a number this script invented. The
+    invented one was 32, which is the performance-mode ceiling and not the
+    default in any mode this runs in; on a real corpus one component dispatch
+    takes 18-88 seconds, so a pass of 32 is a block of up to three quarters of
+    an hour inside which no deadline exists. Measured: 99 seconds of drain
+    against a 30-second bound, and 315 against the design's 300. The bound was
+    being reported, not enforced.
+
+    What the drain saw is reported alongside whether it finished, because
+    "did not converge" cannot distinguish the two outcomes an operator acts on
+    differently -- a deep backlog that is draining and wants a longer window,
+    and a drain that is stuck and wants a person.
     """
     dispatch = derived_drain.component_dispatcher()
     observe = derived_drain.canonical_generation_observer()
     started = time.monotonic()
     deadline = started + float(bound_seconds)
+    passes = 0
+    completed = 0
+    stalled_passes = 0
     while True:
-        derived_drain.drain_once(
+        passes += 1
+        moved = derived_drain.drain_once(
             vault_root,
             dispatch=dispatch,
             observe_current_generation=observe,
             visibility_publisher=pending_recall.publish,
-            limit=32,
+            limit=derived_drain.progress_limit(),
         )
-        if not derived_receipts.due_component_count(vault_root):
-            return round(time.monotonic() - started, 3), True
+        completed += int(moved)
+        stalled_passes = 0 if moved else stalled_passes + 1
+        elapsed = time.monotonic() - started
+        observation = _drain_observation(vault_root)
+        drain = {
+            "passes": passes,
+            "completed": completed,
+            "failed": observation["failed"],
+            "stuck": observation["stuck"],
+            "stalled_passes": stalled_passes,
+            "rate_components_per_min": (
+                round(completed / elapsed * 60.0, 2) if elapsed > 0 else 0.0
+            ),
+            "projected_seconds_to_converge": None,
+        }
+        due = observation["due"]
+        if due > 0 and completed > 0 and elapsed > 0:
+            drain["projected_seconds_to_converge"] = round(
+                due * elapsed / completed, 1
+            )
+        if due == 0:
+            return round(elapsed, 3), True, drain
+        # Each of these is a reported failure with its own name, and the loop
+        # stops at the first one: a stuck or failed claim will not clear by
+        # waiting, two passes that moved nothing are not draining, and a
+        # crossed deadline is the answer the bound exists to give.
+        if observation["stuck"] or observation["failed"]:
+            return round(elapsed, 3), False, drain
+        if stalled_passes >= 2:
+            return round(elapsed, 3), False, drain
         if time.monotonic() >= deadline:
-            return round(time.monotonic() - started, 3), False
+            return round(elapsed, 3), False, drain
         time.sleep(min(0.25, max(0.0, deadline - time.monotonic())))
 
 
@@ -289,22 +394,27 @@ def measure(
 
     os.environ["EXOMEM_FAST_DURABLE_ACK"] = "1"
     # Managed admission, because the pending overlay is scoped to managed
-    # recall and an offline caller keeps its source-walk fallback. Whether the
-    # catalogue proof is actually admitted is recorded rather than asserted:
-    # `warming` is a truthful outcome under the contract, and a reader has to
-    # be able to tell a real warm answer from a harness that never had an
-    # admitted catalogue to answer from.
-    lexstore.ensure_fresh(root)
-    readiness.manage_runtime()
-    readiness.begin_warm()
-    readiness.finish_warm()
-    admission = readiness.retrieval_admission(root)
-    recall_admission = str(admission.get("state", "unknown"))
-
-    full_receipts_before = _full_receipt_count(root)
+    # recall and an offline caller keeps its source-walk fallback -- and
+    # asserted, not merely recorded. `warming` is a truthful outcome of the
+    # read contract, but a harness that never had an admitted catalogue answers
+    # `warming` to everything and measures an unwarmed corpus-context build on
+    # every write. Measured on a 3,789-page copy, that was the difference
+    # between a 377ms edit median with exact reads and a 2,623ms one with a
+    # 27.7s first sample and no exact read at all. The acceptance would have
+    # been reporting the harness.
+    #
+    # This is the served process's own warm-up, shared with the deterministic
+    # gate as one object: see `scripts/managed_recall.py`.
     durations: dict[str, list[float]] = {name: [] for name in OPERATIONS}
     outcomes = {"exact": 0, "warming": 0, "stale": 0}
+    # The warm-up manages the runtime, so it belongs inside the same `finally`
+    # that gives it back: a warm-up that raises after managing would otherwise
+    # leave this process managed for good.
     try:
+        recall_admission = str(
+            managed_recall.enter_managed_recall(root).get("state", "unknown")
+        )
+        full_receipts_before = _full_receipt_count(root)
         for index in range(samples_per_operation):
             identity = str(uuid.UUID(int=index + 1))
             # An entity page belongs under Entities/: the semantic contract
@@ -333,7 +443,7 @@ def measure(
     finally:
         readiness.unmanage_runtime()
 
-    convergence_seconds, converged = _converge(
+    convergence_seconds, converged, drain = _converge(
         root, bound_seconds=convergence_bound_seconds
     )
     full_receipts_after = _full_receipt_count(root)
@@ -361,9 +471,62 @@ def measure(
         "read_your_write": outcomes,
         "uncovered_full_receipts": uncovered,
         "post_burst_convergence_seconds": convergence_seconds,
+        "post_burst_convergence_bound_seconds": round(
+            float(convergence_bound_seconds), 1
+        ),
         "post_burst_converged": converged,
+        "drain": drain,
         "reconciliation_demanded": _reconciliation_demanded(root),
     }
+
+
+def _convergence_failure(report: dict[str, Any]) -> str:
+    """Say which non-convergence this was, because they are not one thing.
+
+    A deep backlog that is draining wants a longer window and a look at what a
+    single dispatch costs. A stuck drain wants a person: a claim already
+    attempted and backing off, or one carrying a failure code, will not clear
+    by waiting. "Did not converge" is true of both and actionable for neither,
+    and it is what the first live run said.
+    """
+    bound = float(
+        report.get(
+            "post_burst_convergence_bound_seconds", CONVERGENCE_BOUND_SECONDS
+        )
+    )
+    headline = f"the post-burst backlog did not converge within {bound:.0f}s"
+    drain = report.get("drain")
+    if not isinstance(drain, dict):
+        return headline
+    passes = int(drain.get("passes", 0))
+    stuck = int(drain.get("stuck", 0))
+    failed = int(drain.get("failed", 0))
+    if stuck < 0 or failed < 0:
+        return f"{headline}: the drain observation was unreadable"
+    if stuck or failed:
+        return (
+            f"{headline}: drain stuck ({stuck} component(s) held back, "
+            f"{failed} failed) after {passes} pass(es)"
+        )
+    if int(drain.get("stalled_passes", 0)) >= 2:
+        return (
+            f"{headline}: drain stuck (no component completed in the last "
+            f"2 of {passes} pass(es))"
+        )
+    rate = float(drain.get("rate_components_per_min") or 0.0)
+    if rate <= 0.0:
+        return (
+            f"{headline}: drain stuck (no component completed in "
+            f"{passes} pass(es))"
+        )
+    projected = drain.get("projected_seconds_to_converge")
+    projection = (
+        "" if projected is None else f", projected {float(projected):.0f}s to drain"
+    )
+    return (
+        f"{headline}: deep backlog draining at {rate:g} component(s)/min"
+        f"{projection}"
+    )
 
 
 def check(report: dict[str, Any]) -> None:
@@ -394,10 +557,7 @@ def check(report: dict[str, Any]) -> None:
             + ("unreadable" if uncovered < 0 else f"{uncovered} above zero")
         )
     if not report["post_burst_converged"]:
-        failures.append(
-            "the post-burst backlog did not converge within "
-            f"{CONVERGENCE_BOUND_SECONDS:.0f}s"
-        )
+        failures.append(_convergence_failure(report))
     demanded = int(report.get("reconciliation_demanded", 0))
     if demanded:
         failures.append(
@@ -423,6 +583,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--state-dir", type=Path)
     parser.add_argument("--connector-url")
+    parser.add_argument(
+        "--convergence-bound",
+        type=float,
+        default=CONVERGENCE_BOUND_SECONDS,
+        help="seconds the post-burst backlog is given to drain; the design's "
+        "own oldest-required-component alarm is the default, and a shorter "
+        "one narrows the window rather than the assertion -- the run still "
+        "fails, and still says which non-convergence it was",
+    )
     args = parser.parse_args(argv)
 
     if args.vault is None:
@@ -444,6 +613,7 @@ def main(argv: list[str] | None = None) -> int:
         state_dir=args.state_dir or (args.vault.parent / "acceptance-state"),
         connector_url=connector_url,
         connector_token=os.environ.get("EXOMEM_CONNECTOR_TOKEN"),
+        convergence_bound_seconds=args.convergence_bound,
     )
     print(json.dumps(report, sort_keys=True))
     if args.check:

--- a/scripts/live_write_acceptance.py
+++ b/scripts/live_write_acceptance.py
@@ -58,6 +58,7 @@ from exomem import (  # noqa: E402
     derived_drain,
     derived_receipts,
     memory_refs,
+    mode,
     pending_recall,
     readiness,
     semantic_writes,
@@ -238,15 +239,43 @@ def _reconciliation_demanded(vault_root: Path) -> int:
     return derived_receipts.recoverable_batch_count(vault_root)
 
 
+#: A component this many attempts deep has stopped being a transient retry.
+#: `retry_component` backs off 5s * 2**(attempts-1) capped at 120s, so the
+#: third attempt is the first one whose next window is a minute away; below it
+#: the drain is retrying, which is ordinary, not held back.
+STUCK_ATTEMPT_THRESHOLD = 3
+
+
 def _drain_observation(vault_root: Path) -> dict[str, int]:
     """What the store says about components a burst has not settled yet.
 
-    Content-free by construction: three counts read straight off the receipt
-    store, no batch id, component name, path or failure text. `stuck` is the
-    one that matters -- a component that has already been attempted and is
-    either backing off into the future or carrying a failure code is not
-    something more draining will clear, and reporting it as backlog is how a
-    run that needs a person gets read as a run that needs more time.
+    Content-free by construction: counts, a mode name and ages -- no batch id,
+    component name, path or failure text.
+
+    The dueness test is the product's own, character for character
+    (`derived_receipts.due_component_count`), because the two counters must not
+    disagree about a row. They did: `retry_component` stamps a `failure_code`
+    and bumps `attempt_count` on every transient retry and leaves the row
+    `retryable`, and nothing clears that code until the component completes. A
+    predicate reading "attempted, and carrying a code" therefore called the
+    ordinary first retry of a lease that outlived its dispatch *stuck* -- while
+    `due_component_count` counted the same row as due and
+    `claim_ready_components` would have claimed it on the very next pass.
+
+    So the counters are split by what an operator would do about them:
+
+    * `retrying` -- due, and attempted before. The drain will pick it up. This
+      is the common case on a real corpus and it is not a fault.
+    * `stuck` -- NOT due (backing off into the future, or held under an
+      unexpired claim) and at least `STUCK_ATTEMPT_THRESHOLD` attempts deep.
+      More draining will not clear this inside any window worth waiting.
+    * `failed` -- carrying a failure code while not due. Reported, but not on
+      its own a reason to stop: the backoff is exactly the mechanism that
+      clears it.
+    * `claimed` -- held under a live lease. `drain_once` leaves one behind when
+      a batch's committed proof is not `ready`, and neither `due` nor `stuck`
+      can see it, so a run could otherwise report "converged" with work
+      parked under a claim nobody is working.
 
     An unreadable store reports -1 rather than zero, because a counter that
     cannot be read has not proved anything.
@@ -256,38 +285,66 @@ def _drain_observation(vault_root: Path) -> dict[str, int]:
     except Exception:  # noqa: BLE001 - an unreadable counter cannot prove zero
         due = -1
 
-    stuck = 0
-    failed = 0
-    max_attempt_count = 0
-    rows: list[tuple[Any, Any, Any]] = []
+    unreadable = {
+        "due": due,
+        "claimed": -1,
+        "retrying": -1,
+        "stuck": -1,
+        "failed": -1,
+        "max_attempt_count": -1,
+    }
+    rows: list[tuple[Any, ...]] = []
     try:
         if deferred_index.store_path(vault_root).exists():
             connection = deferred_index._connect_readonly(vault_root)
             try:
+                # `is_due` is `due_component_count`'s WHERE clause verbatim,
+                # evaluated per row and against the same `now`.
                 rows = connection.execute(
-                    "SELECT c.attempt_count, c.next_attempt_at, c.failure_code "
+                    "SELECT c.state, c.attempt_count, c.claim_expires_at, "
+                    "c.failure_code, "
+                    "(CASE WHEN (c.state = 'ready' OR "
+                    "(c.state = 'retryable' AND c.next_attempt_at <= :now) OR "
+                    "(c.state = 'claimed' AND c.claim_expires_at <= :now)) "
+                    "AND NOT EXISTS (SELECT 1 FROM pending_recall_rows AS p "
+                    "WHERE p.batch_id = c.batch_id AND p.state = 'prepared') "
+                    "THEN 1 ELSE 0 END) AS is_due "
                     "FROM derived_batch_components AS c "
                     "JOIN derived_batches AS b ON b.batch_id = c.batch_id "
                     "WHERE b.state = 'ready' "
-                    "AND c.state IN ('ready', 'claimed', 'retryable')"
+                    "AND c.state IN ('ready', 'claimed', 'retryable')",
+                    {"now": time.time()},
                 ).fetchall()
             finally:
                 connection.close()
     except Exception:  # noqa: BLE001 - same
-        return {"due": due, "stuck": -1, "failed": -1, "max_attempt_count": -1}
+        return unreadable
 
     now = time.time()
-    for attempt_count, next_attempt_at, failure_code in rows:
+    claimed = 0
+    retrying = 0
+    stuck = 0
+    failed = 0
+    max_attempt_count = 0
+    for state, attempt_count, claim_expires_at, failure_code, is_due in rows:
         attempts = int(attempt_count or 0)
         max_attempt_count = max(max_attempt_count, attempts)
+        if state == "claimed" and (
+            claim_expires_at is None or float(claim_expires_at) > now
+        ):
+            claimed += 1
+        if int(is_due or 0):
+            if attempts > 0:
+                retrying += 1
+            continue
+        if attempts >= STUCK_ATTEMPT_THRESHOLD:
+            stuck += 1
         if failure_code is not None:
             failed += 1
-        if attempts > 0 and (
-            failure_code is not None or float(next_attempt_at or 0.0) > now
-        ):
-            stuck += 1
     return {
         "due": due,
+        "claimed": claimed,
+        "retrying": retrying,
         "stuck": stuck,
         "failed": failed,
         "max_attempt_count": max_attempt_count,
@@ -304,22 +361,33 @@ def _converge(
     passes it yields rather than spinning, because a hot loop competes with the
     very workers it is waiting on.
 
-    A pass claims `derived_drain.progress_limit()` -- the scheduler's own
-    allowance for this mode -- rather than a number this script invented. The
-    invented one was 32, which is the performance-mode ceiling and not the
-    default in any mode this runs in; on a real corpus one component dispatch
-    takes 18-88 seconds, so a pass of 32 is a block of up to three quarters of
-    an hour inside which no deadline exists. Measured: 99 seconds of drain
-    against a 30-second bound, and 315 against the design's 300. The bound was
-    being reported, not enforced.
+    A pass claims `derived_drain.progress_limit()` -- whatever the scheduler's
+    own allowance for this cell's mode is, which is what a served drain would
+    use. That is a per-machine number, not a constant: `mode.resolve_mode()`
+    reads `EXOMEM_MODE`, then `~/.exomem/config.json` (or `EXOMEM_CONFIG_PATH`),
+    so a box configured `performance` claims 32 and a default one claims 16.
+    Both the mode and the limit are reported, because a convergence number
+    measured at 32 and a convergence number measured at 16 are not comparable
+    and nothing else in the report would say which was which.
+
+    **The bound is a checkpoint between passes, not a hard stop.** There is no
+    intra-pass timeout: `drain_once` dispatches its whole claim synchronously,
+    so a bound of 120s is routinely overrun by a pass that takes 200 -- the
+    reported `bound_overrun_seconds` says by how much. A `drain_once` that
+    wedges outright is therefore not survivable here; the caller's own
+    `timeout` is the only thing that ends such a run.
 
     What the drain saw is reported alongside whether it finished, because
     "did not converge" cannot distinguish the two outcomes an operator acts on
     differently -- a deep backlog that is draining and wants a longer window,
-    and a drain that is stuck and wants a person.
+    and a drain that is stuck and wants a person. It stops early only on the
+    second of those: `stuck` (not due and several attempts deep) or two
+    consecutive passes that completed nothing. An ordinary retry is neither.
     """
     dispatch = derived_drain.component_dispatcher()
     observe = derived_drain.canonical_generation_observer()
+    limit = derived_drain.progress_limit()
+    mode_name = mode.resolve_mode()
     started = time.monotonic()
     deadline = started + float(bound_seconds)
     passes = 0
@@ -332,35 +400,48 @@ def _converge(
             dispatch=dispatch,
             observe_current_generation=observe,
             visibility_publisher=pending_recall.publish,
-            limit=derived_drain.progress_limit(),
+            limit=limit,
         )
         completed += int(moved)
         stalled_passes = 0 if moved else stalled_passes + 1
-        elapsed = time.monotonic() - started
         observation = _drain_observation(vault_root)
+        last_pass = derived_drain.last_pass_observation(vault_root)
+        # After the observation reads, not before: they are part of the pass a
+        # rate is being computed over.
+        elapsed = time.monotonic() - started
+        due = observation["due"]
         drain = {
+            "mode": mode_name,
+            "limit": limit,
             "passes": passes,
             "completed": completed,
+            "due": due,
+            "claimed": observation["claimed"],
+            "retrying": observation["retrying"],
             "failed": observation["failed"],
             "stuck": observation["stuck"],
+            "max_attempt_count": observation["max_attempt_count"],
             "stalled_passes": stalled_passes,
             "rate_components_per_min": (
                 round(completed / elapsed * 60.0, 2) if elapsed > 0 else 0.0
             ),
             "projected_seconds_to_converge": None,
+            "bound_overrun_seconds": round(
+                max(0.0, elapsed - float(bound_seconds)), 3
+            ),
+            "oldest_due_age_seconds": last_pass.get("oldest_due_age_seconds"),
         }
-        due = observation["due"]
         if due > 0 and completed > 0 and elapsed > 0:
             drain["projected_seconds_to_converge"] = round(
                 due * elapsed / completed, 1
             )
         if due == 0:
             return round(elapsed, 3), True, drain
-        # Each of these is a reported failure with its own name, and the loop
-        # stops at the first one: a stuck or failed claim will not clear by
-        # waiting, two passes that moved nothing are not draining, and a
-        # crossed deadline is the answer the bound exists to give.
-        if observation["stuck"] or observation["failed"]:
+        # Stopping early is for the two states more waiting cannot fix: work
+        # that is neither due nor shallow, and passes that move nothing. A row
+        # backing off after one failed attempt is not either of them -- it is
+        # what a drain doing its job looks like.
+        if observation["stuck"] or observation["stuck"] < 0:
             return round(elapsed, 3), False, drain
         if stalled_passes >= 2:
             return round(elapsed, 3), False, drain
@@ -484,10 +565,12 @@ def _convergence_failure(report: dict[str, Any]) -> str:
     """Say which non-convergence this was, because they are not one thing.
 
     A deep backlog that is draining wants a longer window and a look at what a
-    single dispatch costs. A stuck drain wants a person: a claim already
-    attempted and backing off, or one carrying a failure code, will not clear
-    by waiting. "Did not converge" is true of both and actionable for neither,
-    and it is what the first live run said.
+    single dispatch costs. A drain that is stuck wants a person: a component
+    that is not due and is several attempts deep will not clear by waiting. A
+    counter that could not be read is a third thing and must never be rendered
+    as either -- "the backlog is draining" is a claim, and an unreadable store
+    has not earned it. "Did not converge" is true of all of them and
+    actionable for none, and it is what the first live run said.
     """
     bound = float(
         report.get(
@@ -501,13 +584,17 @@ def _convergence_failure(report: dict[str, Any]) -> str:
     passes = int(drain.get("passes", 0))
     stuck = int(drain.get("stuck", 0))
     failed = int(drain.get("failed", 0))
-    if stuck < 0 or failed < 0:
+    due = int(drain.get("due", 0))
+    if stuck < 0 or failed < 0 or due < 0:
         return f"{headline}: the drain observation was unreadable"
-    if stuck or failed:
-        return (
-            f"{headline}: drain stuck ({stuck} component(s) held back, "
-            f"{failed} failed) after {passes} pass(es)"
+    if stuck:
+        held = (
+            f"{stuck} component(s) held back at "
+            f"{int(drain.get('max_attempt_count', 0))} attempt(s)"
         )
+        if failed:
+            held += f", {failed} carrying a failure code"
+        return f"{headline}: drain stuck ({held}) after {passes} pass(es)"
     if int(drain.get("stalled_passes", 0)) >= 2:
         return (
             f"{headline}: drain stuck (no component completed in the last "
@@ -520,12 +607,17 @@ def _convergence_failure(report: dict[str, Any]) -> str:
             f"{passes} pass(es))"
         )
     projected = drain.get("projected_seconds_to_converge")
-    projection = (
+    detail = (
         "" if projected is None else f", projected {float(projected):.0f}s to drain"
     )
+    retrying = int(drain.get("retrying", 0))
+    if retrying:
+        # Ordinary, and worth saying: it is the visible half of a lease that
+        # did not outlive its dispatch.
+        detail += f", {retrying} retrying"
     return (
         f"{headline}: deep backlog draining at {rate:g} component(s)/min"
-        f"{projection}"
+        f"{detail}"
     )
 
 

--- a/scripts/live_write_acceptance.py
+++ b/scripts/live_write_acceptance.py
@@ -405,7 +405,10 @@ def _converge(
         completed += int(moved)
         stalled_passes = 0 if moved else stalled_passes + 1
         observation = _drain_observation(vault_root)
-        last_pass = derived_drain.last_pass_observation(vault_root)
+        try:
+            last_pass = derived_drain.last_pass_observation(vault_root)
+        except Exception:  # noqa: BLE001 - a report is worth more than a crash
+            last_pass = {}
         # After the observation reads, not before: they are part of the pass a
         # rate is being computed over.
         elapsed = time.monotonic() - started
@@ -435,13 +438,20 @@ def _converge(
             drain["projected_seconds_to_converge"] = round(
                 due * elapsed / completed, 1
             )
-        if due == 0:
+        # Convergence is an empty queue, not merely an empty DUE queue. A final
+        # pass in which every remaining component fails transiently leaves
+        # `due == 0` for the length of the backoff, and a row parked under a
+        # live lease is invisible to `due` entirely. Reporting "converged" over
+        # either is the exact outcome these counters exist to prevent, so they
+        # gate the verdict rather than only appearing in the report.
+        if due == 0 and observation["stuck"] == 0 and observation["claimed"] == 0:
             return round(elapsed, 3), True, drain
         # Stopping early is for the two states more waiting cannot fix: work
         # that is neither due nor shallow, and passes that move nothing. A row
         # backing off after one failed attempt is not either of them -- it is
-        # what a drain doing its job looks like.
-        if observation["stuck"] or observation["stuck"] < 0:
+        # what a drain doing its job looks like. An unreadable count (-1) stops
+        # too, because a counter that cannot be read has proved nothing.
+        if observation["stuck"] > 0 or observation["stuck"] < 0:
             return round(elapsed, 3), False, drain
         if stalled_passes >= 2:
             return round(elapsed, 3), False, drain

--- a/scripts/managed_recall.py
+++ b/scripts/managed_recall.py
@@ -1,0 +1,90 @@
+"""The managed-recall admission a served process has, for a measured phase.
+
+Both benchmark entry points need the same thing: the retrieval admission the
+product grants itself at boot, standing for the duration of a sampling run, so
+the numbers describe managed recall rather than the offline source-walk
+fallback a bare caller gets.
+
+They need it to be the *same* thing, which is why this module exists rather
+than a second implementation next to each script. `semantic_write_latency.py`
+once shipped an abbreviation of this that opened and closed the warm window
+without publishing the catalogue proof, and had to be repaired in place.
+`live_write_acceptance.py` was written later, carried its own abbreviation of
+the same shape, and reproduced the identical defect on its first live run:
+managed recall `unavailable`, every read after a write answering `warming`, and
+an edit median seven times the product's real one because each write rebuilt
+corpus context from cold. Two copies that agree today are how one of them
+drifts. There is one now, imported by both.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from exomem import lexstore, readiness  # noqa: E402
+
+
+def enter_managed_recall(vault_root: Path) -> dict[str, Any]:
+    """Stand up the admission a served process has, for this phase only.
+
+    The warm window is not the admission. `begin_warm`/`finish_warm` only open
+    and close the window; what actually admits retrieval is the *catalogue
+    proof* published inside it -- `readiness.admit_retrieval_proof`, which is
+    the sole writer of the `retrieval_catalog` event that
+    `readiness.retrieval_admission` reads. An earlier version of this function
+    opened and closed the window without ever publishing that proof, so it left
+    `_warm_finished` set with the event unset, which is precisely the
+    `unavailable` state, and the gate died at the assertion below within a
+    minute of starting.
+
+    So this delegates to `warmup.warm_retrieval_catalog`, the function the
+    served process itself calls, rather than restating an abbreviation of it.
+    That keeps the rebaseline, the live-projection requirement, the maintained
+    versus reference index distinction and the proof CAS in one place, and it
+    means this warm-up cannot drift away from the product's.
+
+    `EXOMEM_EAGER_BOOT` is set for the call because a benchmark needs the
+    synchronous contract: without it, an incomplete catalogue is delegated to
+    the background repair worker and the function returns False, leaving the
+    sampling loop to race a rebuild. With it, the repair is awaited and proven,
+    and a failure to converge raises here instead of quietly measuring the
+    wrong thing.
+
+    Returns the granted admission, so a caller that reports its state does not
+    have to ask a second time and risk reporting a different answer than the
+    one that was asserted. The caller owns `readiness.unmanage_runtime()`: the
+    runtime is left managed on purpose, because the phase being measured is the
+    one that needs it.
+    """
+    from exomem import warmup
+
+    lexstore.ensure_fresh(vault_root)
+    readiness.manage_runtime()
+    previous_eager = os.environ.get("EXOMEM_EAGER_BOOT")
+    os.environ["EXOMEM_EAGER_BOOT"] = "1"
+    readiness.begin_warm()
+    try:
+        warmup.warm_retrieval_catalog(vault_root)
+    finally:
+        readiness.finish_warm()
+        if previous_eager is None:
+            os.environ.pop("EXOMEM_EAGER_BOOT", None)
+        else:
+            os.environ["EXOMEM_EAGER_BOOT"] = previous_eager
+
+    admission = readiness.retrieval_admission(vault_root)
+    if not admission.get("admitted"):
+        # A benchmark that silently measured the offline walk instead of
+        # managed recall would report the wrong capability entirely.
+        raise RuntimeError(
+            f"managed recall admission was not granted: {admission}"
+        )
+    return admission

--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -23,6 +23,7 @@ if str(SRC) not in sys.path:
 if str(Path(__file__).resolve().parent) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import managed_recall  # noqa: E402
 import scratch_root  # noqa: E402
 from synth_vault import gen_dense_vault  # noqa: E402
 
@@ -378,55 +379,13 @@ def _measure_fts5_visibility(
         return (time.perf_counter() - visible_started) * 1_000.0
 
 
-def _enter_managed_recall(vault_root: Path) -> None:
-    """Stand up the admission a served process has, for this phase only.
-
-    The warm window is not the admission. `begin_warm`/`finish_warm` only open
-    and close the window; what actually admits retrieval is the *catalogue
-    proof* published inside it -- `readiness.admit_retrieval_proof`, which is
-    the sole writer of the `retrieval_catalog` event that
-    `readiness.retrieval_admission` reads. An earlier version of this function
-    opened and closed the window without ever publishing that proof, so it left
-    `_warm_finished` set with the event unset, which is precisely the
-    `unavailable` state, and the gate died at the assertion below within a
-    minute of starting.
-
-    So this delegates to `warmup.warm_retrieval_catalog`, the function the
-    served process itself calls, rather than restating an abbreviation of it.
-    That keeps the rebaseline, the live-projection requirement, the maintained
-    versus reference index distinction and the proof CAS in one place, and it
-    means this warm-up cannot drift away from the product's.
-
-    `EXOMEM_EAGER_BOOT` is set for the call because a benchmark needs the
-    synchronous contract: without it, an incomplete catalogue is delegated to
-    the background repair worker and the function returns False, leaving the
-    sampling loop to race a rebuild. With it, the repair is awaited and proven,
-    and a failure to converge raises here instead of quietly measuring the
-    wrong thing.
-    """
-    from exomem import warmup
-
-    lexstore.ensure_fresh(vault_root)
-    readiness.manage_runtime()
-    previous_eager = os.environ.get("EXOMEM_EAGER_BOOT")
-    os.environ["EXOMEM_EAGER_BOOT"] = "1"
-    readiness.begin_warm()
-    try:
-        warmup.warm_retrieval_catalog(vault_root)
-    finally:
-        readiness.finish_warm()
-        if previous_eager is None:
-            os.environ.pop("EXOMEM_EAGER_BOOT", None)
-        else:
-            os.environ["EXOMEM_EAGER_BOOT"] = previous_eager
-
-    admission = readiness.retrieval_admission(vault_root)
-    if not admission.get("admitted"):
-        # A gate that silently measured the offline walk instead of managed
-        # recall would report the wrong capability entirely.
-        raise RuntimeError(
-            f"managed recall admission was not granted: {admission}"
-        )
+#: The admission a served process has, standing for a measured phase.
+#: Shared with `live_write_acceptance.py` as one object rather than two
+#: agreeing copies -- the abbreviation this replaced was written twice and
+#: shipped the same unadmitted-catalogue defect twice. `managed_recall`
+#: carries the reasoning; this name stays because it is what this script's
+#: own nodes drive.
+_enter_managed_recall = managed_recall.enter_managed_recall
 
 
 def _drain_derived_custody(vault_root: Path, *, passes: int = 64) -> None:

--- a/tests/test_live_write_acceptance_harness.py
+++ b/tests/test_live_write_acceptance_harness.py
@@ -1,0 +1,297 @@
+"""The live-acceptance harness has to measure the product, not itself.
+
+A first live run of `scripts/live_write_acceptance.py` failed on numbers the
+product does not actually produce. Three harness defects, each measured on a
+disposable 3,789-page copy of a real vault, and each pinned here:
+
+* The warm-up opened and closed the readiness window without ever publishing
+  the catalogue proof, so managed recall was never admitted. Every write then
+  paid an unwarmed corpus-context build and every following read answered
+  `warming`. Same corpus, same host, ten samples each: the harness warm-up gave
+  an edit median of 2,623ms with a 27,662ms first sample and 20/20 `warming`
+  reads; the product's own warm-up (`warmup.warm_retrieval_catalog` under
+  `EXOMEM_EAGER_BOOT`) gave 377ms, a 6,613ms first sample and 20/20 `exact`
+  reads. The gate script next door had already been bitten by exactly this and
+  had the fix; the harness carried a second, abbreviated copy. So the two now
+  share one object, because two copies of a warm-up is how one of them drifts.
+
+* Convergence drained in unbounded passes of 32 and only looked at the wall
+  clock between them. A single component dispatch on that corpus runs 18-88
+  seconds, so one pass ran 99 seconds against a 30-second bound and 315 seconds
+  against the design's 300. The bound was not enforced; it was reported after
+  the fact.
+
+* A run that failed to converge said only "did not converge". That is the one
+  sentence that cannot distinguish the two outcomes an operator has to act on
+  differently: a deep backlog that is draining and needs a longer window, and a
+  drain that is stuck and needs someone. Convergence now reports what it saw.
+
+None of this is the product's write path, which is why none of it is fixed
+here. The product defects the runs exposed -- a claim lease shorter than a
+dispatch, the linear component chain, the whole-corpus graph refresh per
+fan-out -- are named in the lane's result, not smuggled in as harness changes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+def _load(stem: str, alias: str):
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(alias, SCRIPTS / f"{stem}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _acceptance():
+    return _load("live_write_acceptance", "live_write_acceptance_under_test")
+
+
+def _latency():
+    return _load("semantic_write_latency", "semantic_write_latency_under_test")
+
+
+def _drain(
+    *,
+    passes: int = 1,
+    completed: int = 0,
+    failed: int = 0,
+    stuck: int = 0,
+    stalled_passes: int = 0,
+    rate: float = 0.0,
+    projected: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "passes": passes,
+        "completed": completed,
+        "failed": failed,
+        "stuck": stuck,
+        "stalled_passes": stalled_passes,
+        "rate_components_per_min": rate,
+        "projected_seconds_to_converge": projected,
+    }
+
+
+def _report(*, converged: bool = True, drain: dict[str, Any] | None = None) -> dict:
+    """A report that passes every assertion except the one under test."""
+    return {
+        "transport": "direct",
+        "samples_per_operation": 30,
+        "fast_durable_ack": "active",
+        "operations": {
+            name: {
+                "samples": 30,
+                "p50_ms": 900.0,
+                "p90_ms": 1_800.0,
+                "max_ms": 1_900.0,
+            }
+            for name in ("remember", "edit")
+        },
+        "recall_admission": "ready",
+        "read_your_write": {"exact": 60, "warming": 0, "stale": 0},
+        "uncovered_full_receipts": 0,
+        "post_burst_convergence_seconds": 12.0,
+        "post_burst_convergence_bound_seconds": 300.0,
+        "post_burst_converged": converged,
+        "reconciliation_demanded": 0,
+        "drain": _drain() if drain is None else drain,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# The warm-up
+# --------------------------------------------------------------------------- #
+
+
+def test_acceptance_warm_up_publishes_the_catalogue_proof(
+    vault: Path, tmp_path: Path
+) -> None:
+    """Admission is the catalogue proof, not a finished warm window.
+
+    `begin_warm`/`finish_warm` only bracket the window. What admits retrieval
+    is `readiness.admit_retrieval_proof`, the sole writer of the
+    `retrieval_catalog` event. A harness that brackets without publishing
+    leaves `_warm_finished` set and the event unset -- which is exactly the
+    `unavailable` state, and it is the state the first live run reported while
+    answering `warming` to every read it had just written.
+    """
+    module = _acceptance()
+    try:
+        report = module.measure(
+            vault,
+            transport="direct",
+            samples_per_operation=1,
+            state_dir=tmp_path / "acceptance-state",
+            convergence_bound_seconds=60.0,
+        )
+    finally:
+        module.readiness.unmanage_runtime()
+
+    assert report["recall_admission"] == "ready"
+    # The proof itself, not merely a window that closed.
+    assert module.readiness.is_ready("retrieval_catalog")
+    # An admitted catalogue is what makes the read after a write exact. Warming
+    # stays a truthful answer under the contract; it is not a truthful answer
+    # for a harness that never had a catalogue to answer from.
+    assert report["read_your_write"] == {"exact": 2, "warming": 0, "stale": 0}
+
+
+def test_shared_warm_up_is_the_same_object_in_both_scripts() -> None:
+    """One warm-up, imported twice -- not two warm-ups that agree today.
+
+    The gate script had already been bitten by a warm-up that could not admit
+    and had fixed it in place. The acceptance harness carried its own shorter
+    version and shipped the identical defect months later. Agreeing copies is
+    the condition that produced that, so the invariant is object identity.
+    """
+    acceptance = _acceptance()
+    latency = _latency()
+    shared = acceptance.managed_recall.enter_managed_recall
+    assert latency._enter_managed_recall is shared
+    assert shared.__module__ == "managed_recall"
+
+
+# --------------------------------------------------------------------------- #
+# Convergence
+# --------------------------------------------------------------------------- #
+
+
+def test_converge_checks_the_deadline_after_every_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pass is bounded by the product's own allowance and then re-checked.
+
+    Draining 32 blind is not the scheduler's number in any mode; it was the
+    harness's. On the measured corpus one component runs 18-88s, so a pass of
+    32 is a 10-to-45-minute block during which no deadline exists. The bound is
+    only a bound if the loop stops at the first pass that crosses it.
+    """
+    module = _acceptance()
+    limits: list[int] = []
+    # A drain that keeps making progress against a backlog that never empties
+    # is the shape a missing deadline check runs forever in, so the fake stops
+    # it and says so rather than hanging the suite.
+    overrun: list[str] = []
+
+    def fake_drain_once(vault_root, **kwargs):
+        limits.append(int(kwargs["limit"]))
+        if len(limits) > 3:
+            overrun.append("kept draining past the deadline")
+            return 0
+        # One pass outliving the whole window is the measured case, not a
+        # contrived one: 99s of drain against a 30s bound.
+        time.sleep(0.35)
+        return 1
+
+    monkeypatch.setattr(module.derived_drain, "drain_once", fake_drain_once)
+    monkeypatch.setattr(
+        module.derived_receipts, "due_component_count", lambda root, **kw: 7
+    )
+
+    seconds, converged, drain = module._converge(tmp_path, bound_seconds=0.1)
+
+    assert converged is False
+    assert not overrun, overrun
+    assert limits == [module.derived_drain.progress_limit()]
+    assert limits != [32], "32 is the performance-mode ceiling, not a default"
+    assert drain["passes"] == 1, "the deadline had already passed after pass 1"
+    assert seconds >= 0.35
+
+
+def test_converge_reports_a_stuck_claim_distinct_from_a_deep_backlog() -> None:
+    """"Did not converge" is the one answer an operator cannot act on.
+
+    A deep backlog that is draining wants a longer window and a note about
+    dispatch cost. A stuck drain wants a person. The failure has to say which.
+    """
+    module = _acceptance()
+
+    stuck = _report(
+        converged=False,
+        drain=_drain(
+            passes=4,
+            completed=3,
+            failed=1,
+            stuck=2,
+            rate=1.5,
+            projected=1_760.0,
+        ),
+    )
+    with pytest.raises(SystemExit) as stuck_exit:
+        module.check(stuck)
+    stuck_message = str(stuck_exit.value)
+    assert "drain stuck" in stuck_message
+    assert "2 component(s)" in stuck_message and "1 failed" in stuck_message
+    assert "deep backlog" not in stuck_message
+
+    backlog = _report(
+        converged=False,
+        drain=_drain(passes=4, completed=9, rate=2.4, projected=2_700.0),
+    )
+    with pytest.raises(SystemExit) as backlog_exit:
+        module.check(backlog)
+    backlog_message = str(backlog_exit.value)
+    assert "deep backlog draining at 2.4 component(s)/min" in backlog_message
+    assert "2700" in backlog_message
+    assert "stuck" not in backlog_message
+
+    # Zero progress across two passes is its own stuck: nothing failed, nothing
+    # is holding a lease, and nothing is moving either.
+    stalled = _report(
+        converged=False,
+        drain=_drain(passes=2, completed=0, stalled_passes=2),
+    )
+    with pytest.raises(SystemExit, match="drain stuck"):
+        module.check(stalled)
+
+    # And a report from before this block existed still fails, and still says
+    # the plain thing -- the acceptance never silently passes for want of a key.
+    legacy = _report(converged=False)
+    legacy.pop("drain")
+    with pytest.raises(SystemExit, match="did not converge"):
+        module.check(legacy)
+
+
+def test_the_drain_block_is_content_free(
+    vault: Path, tmp_path: Path
+) -> None:
+    """Counts, codes and rates -- the drain block names no batch and no path."""
+    module = _acceptance()
+    try:
+        report = module.measure(
+            vault,
+            transport="direct",
+            samples_per_operation=1,
+            state_dir=tmp_path / "acceptance-state",
+            convergence_bound_seconds=60.0,
+        )
+    finally:
+        module.readiness.unmanage_runtime()
+
+    drain = report["drain"]
+    assert set(drain) == {
+        "passes",
+        "completed",
+        "failed",
+        "stuck",
+        "stalled_passes",
+        "rate_components_per_min",
+        "projected_seconds_to_converge",
+    }
+    rendered = json.dumps(report, sort_keys=True, default=str)
+    for token in ("Knowledge Base", str(vault), "acceptance-", ".md"):
+        assert token not in rendered, (token, rendered)

--- a/tests/test_live_write_acceptance_harness.py
+++ b/tests/test_live_write_acceptance_harness.py
@@ -15,16 +15,26 @@ disposable 3,789-page copy of a real vault, and each pinned here:
   had the fix; the harness carried a second, abbreviated copy. So the two now
   share one object, because two copies of a warm-up is how one of them drifts.
 
-* Convergence drained in unbounded passes of 32 and only looked at the wall
+* Convergence drained in passes of a hard-coded 32 and only looked at the wall
   clock between them. A single component dispatch on that corpus runs 18-88
   seconds, so one pass ran 99 seconds against a 30-second bound and 315 seconds
-  against the design's 300. The bound was not enforced; it was reported after
-  the fact.
+  against the design's 300. The pass size is now the scheduler's own
+  `progress_limit()` for this cell's mode, and both the mode and the limit are
+  reported -- a convergence number measured at 32 and one measured at 16 are
+  not comparable, and nothing else in the report would say which it was.
 
 * A run that failed to converge said only "did not converge". That is the one
-  sentence that cannot distinguish the two outcomes an operator has to act on
-  differently: a deep backlog that is draining and needs a longer window, and a
-  drain that is stuck and needs someone. Convergence now reports what it saw.
+  sentence that cannot distinguish the outcomes an operator has to act on
+  differently: a deep backlog that is draining and needs a longer window, a
+  drain that is stuck and needs someone, and a store whose counters could not
+  be read at all. Convergence now reports what it saw.
+
+And one defect this file's first version introduced and a reviewer caught:
+counting every attempted-and-coded row as `stuck` aborted the whole drain on
+the ordinary first retry, because `retry_component` stamps a failure code on
+every transient retry and nothing clears it before the component completes --
+while `due_component_count` counted the same row as due and the next pass would
+have claimed it. The dueness test is now the product's own, verbatim.
 
 None of this is the product's write path, which is why none of it is fixed
 here. The product defects the runs exposed -- a claim lease shorter than a
@@ -36,6 +46,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -65,29 +76,60 @@ def _latency():
     return _load("semantic_write_latency", "semantic_write_latency_under_test")
 
 
-def _drain(
-    *,
-    passes: int = 1,
-    completed: int = 0,
-    failed: int = 0,
-    stuck: int = 0,
-    stalled_passes: int = 0,
-    rate: float = 0.0,
-    projected: float | None = None,
-) -> dict[str, Any]:
-    return {
-        "passes": passes,
-        "completed": completed,
-        "failed": failed,
-        "stuck": stuck,
-        "stalled_passes": stalled_passes,
-        "rate_components_per_min": rate,
-        "projected_seconds_to_converge": projected,
+DRAIN_KEYS = {
+    "mode",
+    "limit",
+    "passes",
+    "completed",
+    "due",
+    "claimed",
+    "retrying",
+    "failed",
+    "stuck",
+    "max_attempt_count",
+    "stalled_passes",
+    "rate_components_per_min",
+    "projected_seconds_to_converge",
+    "bound_overrun_seconds",
+    "oldest_due_age_seconds",
+}
+
+
+def _drain(**overrides: Any) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "mode": "normal",
+        "limit": 16,
+        "passes": 1,
+        "completed": 0,
+        "due": 0,
+        "claimed": 0,
+        "retrying": 0,
+        "failed": 0,
+        "stuck": 0,
+        "max_attempt_count": 0,
+        "stalled_passes": 0,
+        "rate_components_per_min": 0.0,
+        "projected_seconds_to_converge": None,
+        "bound_overrun_seconds": 0.0,
+        "oldest_due_age_seconds": None,
     }
+    assert set(overrides) <= DRAIN_KEYS, set(overrides) - DRAIN_KEYS
+    block.update(overrides)
+    return block
 
 
-def _report(*, converged: bool = True, drain: dict[str, Any] | None = None) -> dict:
-    """A report that passes every assertion except the one under test."""
+def _report(
+    *,
+    converged: bool = True,
+    drain: dict[str, Any] | None = None,
+    bound: float = 120.0,
+) -> dict:
+    """A report that passes every assertion except the one under test.
+
+    The bound defaults to something that is NOT `CONVERGENCE_BOUND_SECONDS`, so
+    a failure message that quotes the constant instead of the bound the run was
+    actually given is visible rather than accidentally correct.
+    """
     return {
         "transport": "direct",
         "samples_per_operation": 30,
@@ -105,11 +147,62 @@ def _report(*, converged: bool = True, drain: dict[str, Any] | None = None) -> d
         "read_your_write": {"exact": 60, "warming": 0, "stale": 0},
         "uncovered_full_receipts": 0,
         "post_burst_convergence_seconds": 12.0,
-        "post_burst_convergence_bound_seconds": 300.0,
+        "post_burst_convergence_bound_seconds": bound,
         "post_burst_converged": converged,
         "reconciliation_demanded": 0,
         "drain": _drain() if drain is None else drain,
     }
+
+
+# --------------------------------------------------------------------------- #
+# A real receipt store, seeded row by row
+# --------------------------------------------------------------------------- #
+
+
+def _seeded_store(vault_root: Path, rows: list[tuple[str, str, int, float, str | None]]):
+    """Create the store and put exact component rows in it.
+
+    rows: (component, state, attempt_count, next_attempt_at, failure_code).
+    A `claimed` row gets a live lease, which is the state that is neither due
+    nor stuck and has to be visible some other way.
+    """
+    from exomem import deferred_index
+
+    vault_root.mkdir(parents=True, exist_ok=True)
+    deferred_index._connect(vault_root, create=True).close()
+    path = deferred_index.store_path(vault_root)
+    now = time.time()
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "INSERT OR REPLACE INTO derived_batches (schema_version, batch_id, "
+            "mutation_attempt_digest, canonical_generation, checkpoint_id, "
+            "state, created_at, updated_at) "
+            "VALUES (1, 'b1', ?, 'gen1', 'ck1', 'ready', ?, ?)",
+            ("a" * 64, now, now),
+        )
+        for component, state, attempts, next_at, code in rows:
+            connection.execute(
+                "INSERT OR REPLACE INTO derived_batch_components (batch_id, "
+                "component, revision, state, lease_revision, claim_owner, "
+                "claim_expires_at, attempt_count, next_attempt_at, created_at, "
+                "updated_at, failure_code) "
+                "VALUES ('b1', ?, 1, ?, 0, NULL, ?, ?, ?, ?, ?, ?)",
+                (
+                    component,
+                    state,
+                    (now + 600.0) if state == "claimed" else None,
+                    attempts,
+                    next_at,
+                    now,
+                    now,
+                    code,
+                ),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+    return path
 
 
 # --------------------------------------------------------------------------- #
@@ -150,6 +243,44 @@ def test_acceptance_warm_up_publishes_the_catalogue_proof(
     assert report["read_your_write"] == {"exact": 2, "warming": 0, "stale": 0}
 
 
+def test_a_warm_up_that_cannot_admit_fails_the_measure(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The assertion is the whole point of sharing the warm-up.
+
+    A helper that warms and then reports whatever admission it happens to find
+    is the defect this change exists to remove, one level down: the run would
+    proceed, measure the offline source-walk fallback, and print a report whose
+    `recall_admission` quietly said `unavailable` -- which is what the first
+    live run did. So the failure must be loud, and the runtime must still be
+    given back on the way out.
+    """
+    from exomem import readiness, warmup
+
+    module = _acceptance()
+    monkeypatch.setattr(warmup, "warm_retrieval_catalog", lambda root: False)
+    monkeypatch.setattr(
+        readiness,
+        "retrieval_admission",
+        lambda root: {"state": "unavailable", "admitted": False},
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="admission was not granted"):
+            module.measure(
+                vault,
+                transport="direct",
+                samples_per_operation=1,
+                state_dir=tmp_path / "acceptance-state",
+                convergence_bound_seconds=5.0,
+            )
+        # A warm-up that raises after managing the runtime would otherwise
+        # leave this process managed for good.
+        assert readiness.runtime_managed() is False
+    finally:
+        readiness.unmanage_runtime()
+
+
 def test_shared_warm_up_is_the_same_object_in_both_scripts() -> None:
     """One warm-up, imported twice -- not two warm-ups that agree today.
 
@@ -166,6 +297,79 @@ def test_shared_warm_up_is_the_same_object_in_both_scripts() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# What the store is asked, and what it is asked with
+# --------------------------------------------------------------------------- #
+
+
+def test_an_ordinary_retry_is_retrying_not_stuck(tmp_path: Path) -> None:
+    """The harness and the product must not disagree about the same row.
+
+    `retry_component` stamps a `failure_code` and bumps `attempt_count` on
+    every transient retry -- including the ordinary one a claim lease shorter
+    than its dispatch produces -- and leaves the row `retryable`. Nothing
+    clears that code until the component completes. Once the backoff elapses,
+    `due_component_count` counts the row as due and `claim_ready_components`
+    will claim it on the very next pass. A predicate reading "attempted, and
+    carrying a code" therefore condemned the healthy common case.
+    """
+    from exomem import derived_receipts
+
+    module = _acceptance()
+    now = time.time()
+
+    due_again = tmp_path / "due-again"
+    _seeded_store(due_again, [("graph", "retryable", 1, now - 30.0, "dispatch_failed")])
+    observed = module._drain_observation(due_again)
+    assert derived_receipts.due_component_count(due_again) == 1, (
+        "the product says this row is due and claimable"
+    )
+    assert observed["due"] == 1
+    assert observed["retrying"] == 1
+    assert observed["stuck"] == 0 and observed["failed"] == 0, observed
+
+    backing_off = tmp_path / "backing-off"
+    _seeded_store(
+        backing_off, [("graph", "retryable", 1, now + 60.0, "dispatch_failed")]
+    )
+    shallow = module._drain_observation(backing_off)
+    assert shallow["due"] == 0 and shallow["retrying"] == 0
+    assert shallow["failed"] == 1, "not due and carrying a code, so reported"
+    assert shallow["stuck"] == 0, (
+        "one attempt deep is a retry, not a component held back"
+    )
+
+    deep = tmp_path / "deep"
+    _seeded_store(
+        deep,
+        [("graph", "retryable", module.STUCK_ATTEMPT_THRESHOLD, now + 900.0, None)],
+    )
+    held = module._drain_observation(deep)
+    assert held["stuck"] == 1 and held["failed"] == 0, held
+    assert held["max_attempt_count"] == module.STUCK_ATTEMPT_THRESHOLD
+
+
+def test_a_live_claim_is_visible_rather_than_silently_converged(
+    tmp_path: Path,
+) -> None:
+    """`drain_once` parks a claim when a batch's proof is not `ready`.
+
+    That row is invisible to `due_component_count` (its lease has not expired)
+    and to `stuck` (it has never been attempted), so a run would otherwise
+    report a clean convergence over work nobody is doing.
+    """
+    from exomem import derived_receipts
+
+    module = _acceptance()
+    vault_root = tmp_path / "parked"
+    _seeded_store(vault_root, [("graph", "claimed", 0, time.time(), None)])
+
+    observed = module._drain_observation(vault_root)
+    assert derived_receipts.due_component_count(vault_root) == 0
+    assert observed["stuck"] == 0 and observed["failed"] == 0
+    assert observed["claimed"] == 1, observed
+
+
+# --------------------------------------------------------------------------- #
 # Convergence
 # --------------------------------------------------------------------------- #
 
@@ -175,10 +379,11 @@ def test_converge_checks_the_deadline_after_every_pass(
 ) -> None:
     """A pass is bounded by the product's own allowance and then re-checked.
 
-    Draining 32 blind is not the scheduler's number in any mode; it was the
-    harness's. On the measured corpus one component runs 18-88s, so a pass of
-    32 is a 10-to-45-minute block during which no deadline exists. The bound is
-    only a bound if the loop stops at the first pass that crosses it.
+    The allowance is per-machine -- `mode.resolve_mode()` reads `EXOMEM_MODE`,
+    then `~/.exomem/config.json` -- so this asserts the harness uses whatever
+    the scheduler would use here and *reports* it, rather than pinning a number
+    that is only true on the box the test happens to run on. A hard-coded 32
+    was neither.
     """
     module = _acceptance()
     limits: list[int] = []
@@ -193,7 +398,7 @@ def test_converge_checks_the_deadline_after_every_pass(
             overrun.append("kept draining past the deadline")
             return 0
         # One pass outliving the whole window is the measured case, not a
-        # contrived one: 99s of drain against a 30s bound.
+        # contrived one: 208s of drain against a 120s bound.
         time.sleep(0.35)
         return 1
 
@@ -206,17 +411,95 @@ def test_converge_checks_the_deadline_after_every_pass(
 
     assert converged is False
     assert not overrun, overrun
-    assert limits == [module.derived_drain.progress_limit()]
-    assert limits != [32], "32 is the performance-mode ceiling, not a default"
     assert drain["passes"] == 1, "the deadline had already passed after pass 1"
     assert seconds >= 0.35
+    # The limit is the product's, and the report says which one it was.
+    assert limits == [module.derived_drain.progress_limit()]
+    assert drain["limit"] == module.derived_drain.progress_limit()
+    assert drain["mode"] == module.mode.resolve_mode()
+
+
+def test_the_bound_is_a_checkpoint_between_passes_and_the_overrun_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """There is no intra-pass timeout, so the overrun has to be a number.
+
+    `drain_once` dispatches its whole claim synchronously. A bound of 120s was
+    overrun by 88s in one pass on the real corpus, and a report that only says
+    "did not converge within 120s" hides that the window was never enforced.
+    """
+    module = _acceptance()
+
+    def slow_pass(vault_root, **kwargs):
+        time.sleep(0.6)
+        return 1
+
+    monkeypatch.setattr(module.derived_drain, "drain_once", slow_pass)
+    monkeypatch.setattr(
+        module.derived_receipts, "due_component_count", lambda root, **kw: 9
+    )
+
+    seconds, converged, drain = module._converge(tmp_path, bound_seconds=0.15)
+
+    assert converged is False
+    assert drain["passes"] == 1
+    assert seconds > 0.15
+    assert drain["bound_overrun_seconds"] > 0.3, drain
+    assert drain["bound_overrun_seconds"] == pytest.approx(seconds - 0.15, abs=0.05)
+
+
+def test_converge_does_not_abort_on_an_ordinary_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retry in flight is a drain doing its job, not a reason to give up.
+
+    This is the reviewer's finding: the first version returned after one pass
+    on any row `retry_component` had touched, which on a real corpus is the
+    common case -- and then told the operator a person was needed.
+    """
+    module = _acceptance()
+    passes: list[int] = []
+
+    def fake_drain_once(vault_root, **kwargs):
+        passes.append(1)
+        return 4
+
+    monkeypatch.setattr(module.derived_drain, "drain_once", fake_drain_once)
+    monkeypatch.setattr(
+        module.derived_receipts, "due_component_count", lambda root, **kw: 30
+    )
+    monkeypatch.setattr(
+        module,
+        "_drain_observation",
+        lambda root: {
+            "due": 30,
+            "claimed": 0,
+            "retrying": 1,
+            "stuck": 0,
+            "failed": 1,
+            "max_attempt_count": 1,
+        },
+    )
+
+    seconds, converged, drain = module._converge(tmp_path, bound_seconds=0.4)
+
+    assert converged is False
+    assert len(passes) > 1, "the drain gave up on an ordinary retry"
+    assert drain["retrying"] == 1 and drain["stuck"] == 0
+    message = module._convergence_failure(_report(converged=False, drain=drain))
+    assert "deep backlog draining" in message, message
+    assert "1 retrying" in message, message
+    assert "drain stuck" not in message, message
 
 
 def test_converge_reports_a_stuck_claim_distinct_from_a_deep_backlog() -> None:
     """"Did not converge" is the one answer an operator cannot act on.
 
-    A deep backlog that is draining wants a longer window and a note about
-    dispatch cost. A stuck drain wants a person. The failure has to say which.
+    A deep backlog that is draining wants a longer window and a look at what a
+    single dispatch costs. A stuck drain wants a person. An unreadable store is
+    a third thing and must not be rendered as either. The failure has to say
+    which -- and it has to quote the bound the run was actually given, not the
+    constant, or `--convergence-bound` is decoration.
     """
     module = _acceptance()
 
@@ -225,22 +508,34 @@ def test_converge_reports_a_stuck_claim_distinct_from_a_deep_backlog() -> None:
         drain=_drain(
             passes=4,
             completed=3,
+            due=12,
             failed=1,
             stuck=2,
-            rate=1.5,
-            projected=1_760.0,
+            max_attempt_count=4,
+            rate_components_per_min=1.5,
+            projected_seconds_to_converge=1_760.0,
         ),
     )
     with pytest.raises(SystemExit) as stuck_exit:
         module.check(stuck)
     stuck_message = str(stuck_exit.value)
     assert "drain stuck" in stuck_message
-    assert "2 component(s)" in stuck_message and "1 failed" in stuck_message
+    assert "2 component(s) held back at 4 attempt(s)" in stuck_message
+    assert "1 carrying a failure code" in stuck_message
     assert "deep backlog" not in stuck_message
+    # The bound the run was given, not CONVERGENCE_BOUND_SECONDS.
+    assert "within 120s" in stuck_message
+    assert "300s" not in stuck_message
 
     backlog = _report(
         converged=False,
-        drain=_drain(passes=4, completed=9, rate=2.4, projected=2_700.0),
+        drain=_drain(
+            passes=4,
+            completed=9,
+            due=108,
+            rate_components_per_min=2.4,
+            projected_seconds_to_converge=2_700.0,
+        ),
     )
     with pytest.raises(SystemExit) as backlog_exit:
         module.check(backlog)
@@ -248,12 +543,13 @@ def test_converge_reports_a_stuck_claim_distinct_from_a_deep_backlog() -> None:
     assert "deep backlog draining at 2.4 component(s)/min" in backlog_message
     assert "2700" in backlog_message
     assert "stuck" not in backlog_message
+    assert "within 120s" in backlog_message
 
     # Zero progress across two passes is its own stuck: nothing failed, nothing
     # is holding a lease, and nothing is moving either.
     stalled = _report(
         converged=False,
-        drain=_drain(passes=2, completed=0, stalled_passes=2),
+        drain=_drain(passes=2, completed=0, due=40, stalled_passes=2),
     )
     with pytest.raises(SystemExit, match="drain stuck"):
         module.check(stalled)
@@ -266,10 +562,40 @@ def test_converge_reports_a_stuck_claim_distinct_from_a_deep_backlog() -> None:
         module.check(legacy)
 
 
-def test_the_drain_block_is_content_free(
-    vault: Path, tmp_path: Path
+def test_an_unreadable_counter_is_never_reported_as_a_draining_backlog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Counts, codes and rates -- the drain block names no batch and no path."""
+    """A store that could not be read has not earned the word "draining".
+
+    `due` going unreadable used to leave `stuck` and `failed` at zero and a
+    positive rate, so the message invented a backlog nobody had measured.
+    """
+    module = _acceptance()
+
+    def unreadable(vault_root, **kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(module.derived_receipts, "due_component_count", unreadable)
+    monkeypatch.setattr(module.derived_drain, "drain_once", lambda root, **kw: 1)
+
+    seconds, converged, drain = module._converge(tmp_path, bound_seconds=0.3)
+
+    assert converged is False
+    assert drain["due"] == -1, drain
+    message = module._convergence_failure(_report(converged=False, drain=drain))
+    assert "the drain observation was unreadable" in message, message
+    assert "draining" not in message, message
+
+    # The same for an unreadable component scan.
+    for counter in ("stuck", "failed"):
+        message = module._convergence_failure(
+            _report(converged=False, drain=_drain(**{counter: -1}))
+        )
+        assert "unreadable" in message, (counter, message)
+
+
+def test_the_drain_block_is_content_free(vault: Path, tmp_path: Path) -> None:
+    """Counts, codes, a mode name and ages -- no batch, no path, no message."""
     module = _acceptance()
     try:
         report = module.measure(
@@ -283,15 +609,9 @@ def test_the_drain_block_is_content_free(
         module.readiness.unmanage_runtime()
 
     drain = report["drain"]
-    assert set(drain) == {
-        "passes",
-        "completed",
-        "failed",
-        "stuck",
-        "stalled_passes",
-        "rate_components_per_min",
-        "projected_seconds_to_converge",
-    }
+    assert set(drain) == DRAIN_KEYS
+    assert drain["mode"] == module.mode.resolve_mode()
+    assert drain["limit"] == module.derived_drain.progress_limit()
     rendered = json.dumps(report, sort_keys=True, default=str)
     for token in ("Knowledge Base", str(vault), "acceptance-", ".md"):
         assert token not in rendered, (token, rendered)

--- a/tests/test_live_write_acceptance_harness.py
+++ b/tests/test_live_write_acceptance_harness.py
@@ -612,6 +612,76 @@ def test_the_drain_block_is_content_free(vault: Path, tmp_path: Path) -> None:
     assert set(drain) == DRAIN_KEYS
     assert drain["mode"] == module.mode.resolve_mode()
     assert drain["limit"] == module.derived_drain.progress_limit()
+    # Key names alone are not the content-free rule: a value could carry a path
+    # the token grep below never sees, because it lives outside the vault. Every
+    # drain value is therefore a count, a duration, an age or None, and `mode`
+    # is the single string, constrained to the mode vocabulary.
+    for key, value in drain.items():
+        if key == "mode":
+            assert value in module.mode.CANON, (key, value)
+            continue
+        assert value is None or isinstance(value, (int, float)), (key, value)
+        assert not isinstance(value, str), (key, value)
     rendered = json.dumps(report, sort_keys=True, default=str)
     for token in ("Knowledge Base", str(vault), "acceptance-", ".md"):
         assert token not in rendered, (token, rendered)
+
+
+def test_convergence_is_not_declared_over_stuck_or_claimed_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`due == 0` is not convergence while work is stuck or parked.
+
+    A final pass in which every remaining component fails transiently leaves
+    `due` at zero for the length of the backoff, and a row held under a live
+    lease is invisible to `due` at all. Either one used to satisfy the verdict,
+    so the acceptance could report converged over work that had not drained.
+    """
+    module = _acceptance()
+    observations = iter(
+        [
+            {
+                "due": 0,
+                "claimed": 0,
+                "retrying": 0,
+                "stuck": 2,
+                "failed": 2,
+                "max_attempt_count": 4,
+            },
+            {
+                "due": 0,
+                "claimed": 1,
+                "retrying": 0,
+                "stuck": 0,
+                "failed": 0,
+                "max_attempt_count": 0,
+            },
+            {
+                "due": 0,
+                "claimed": 0,
+                "retrying": 0,
+                "stuck": 0,
+                "failed": 0,
+                "max_attempt_count": 0,
+            },
+        ]
+    )
+    monkeypatch.setattr(module, "_drain_observation", lambda _root: next(observations))
+    monkeypatch.setattr(module.derived_drain, "drain_once", lambda *a, **k: 1)
+    monkeypatch.setattr(module.derived_drain, "progress_limit", lambda: 16)
+    monkeypatch.setattr(
+        module.derived_drain, "last_pass_observation", lambda _root: {}
+    )
+    monkeypatch.setattr(
+        module.derived_drain, "component_dispatcher", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        module.derived_drain, "canonical_generation_observer", lambda *a, **k: None
+    )
+
+    _elapsed, converged, drain = module._converge(tmp_path, bound_seconds=30.0)
+
+    # The stuck pass stops the loop; it never reaches the clean third reading.
+    assert converged is False
+    assert drain["stuck"] == 2
+    assert drain["passes"] == 1


### PR DESCRIPTION
## What this is

The stage-one live acceptance run for the fast durable write path (`EXOMEM_FAST_DURABLE_ACK`, still off) failed on the harness, not the product. This fixes `scripts/live_write_acceptance.py` so it measures the served cell instead of its own warm-up, and reports the drain honestly.

## What changed

- `scripts/managed_recall.py` (new): one shared warm-up used by both the acceptance script and `scripts/semantic_write_latency.py`. The acceptance script previously warmed nothing the recall path uses, so its first reads paid the catalogue build and were reported as product latency.
- `_converge` is drain-aware: it uses the product's own pass size, checkpoints between passes against `--convergence-bound`, and stops early only on rows the product itself will not retry (`stuck`), an unreadable queue, or two zero-progress passes. Transient retries are counted as `retrying`, never as failures.
- The `drain` block reports `mode`, `limit`, `due`, `claimed`, `retrying`, `stuck`, `failed`, `max_attempt_count`, `passes`, `stalled_passes`, `rate_components_per_min`, `projected_seconds_to_converge`, `oldest_due_age_seconds`, `bound_overrun_seconds`. Every key is a count, age, mode name or limit; the output stays content-free and a test pins that.
- Known limit, documented in the docstring: a wedged `drain_once` has no intra-pass timeout.

No product code changed.

## Verification

- `uv run --frozen pytest -q tests/test_live_write_acceptance_harness.py tests/test_semantic_write_latency_gate.py`: 117 passed.
- Ruff, `scripts/validate-public-artifacts.py --repository`, `git diff --check`: clean.
- Eleven mutants (M1–M11) each killed by a named test, restored byte-equal.
- End-to-end on a fresh 3,789-page vault copy with a fresh state root, flag off, `--convergence-bound 120`:

| measure | p50 | p90 |
|---|---|---|
| edit_memory | 373 ms | 441 ms |
| remember | 143 ms | 155 ms |

Read-your-write: 20 exact, 0 warming, 0 stale. Uncovered receipts: 0. Drain: 10 due, 0 stuck, 3.02 components/min, projected 199 s (the bound of 120 s is too short for a 60-write burst on this corpus; the derived fan-out cost is a product follow-up, not a harness defect).


Reviewed by an independent lane: REQUEST_CHANGES on the first commit, both HIGH findings confirmed and fixed in the second, then ACCEPT on the recheck. The recheck left one MEDIUM and four LOW residuals, all folded into the third commit rather than deferred, because this script is what decides whether the flag is safe to enable.

One correctness fix came out of the review rather than the original defect: `_converge` used to report converged as soon as the due count reached zero, ahead of its own stuck guard. A final pass in which every remaining component fails transiently leaves the due count at zero for the length of the backoff, and a row held under a live lease never appears in it at all, so the acceptance could pass over work that had not drained. Convergence is now an empty queue rather than an empty due queue, pinned by a red-first test.

Known limit, documented in the code: the convergence bound is a between-pass checkpoint with no intra-pass timeout, so a wedged drain pass would hang the script. Bounding that needs a cooperative deadline inside product code. The script is operator-run under an external timeout and reports its overrun.

## Follow-ups (product, not this PR)

- `derived_drain.CLAIM_LEASE_SECONDS` (60 s) is shorter than a fan-out dispatch (62–87 s measured).
- One full `upsert_after_write` fan-out per non-advisory component; the graph refresh is O(corpus) per fan-out (`converge-graph-incrementally`).
- `scripts/semantic_write_latency.py` still hard-codes `limit=32` at its drain call.
