### PR TITLE
docs(openspec): correct the admission-closed inventory signal

### DIFF
--- a/openspec/changes/make-hosted-admission-self-describing/design.md
+++ b/openspec/changes/make-hosted-admission-self-describing/design.md
@@ -57,14 +57,31 @@ public message stays as it is. Alternative considered: a distinct
 `HOSTED_NO_LIVE_COHORT` code — rejected because it changes a user-visible contract for
 an audience that cannot act on the distinction, and every client would have to learn it.
 
-**Derive the inventory signal, do not store it.** `hosted_fleet_inventory.py:1549`
-computes `status` as `"inconsistent" if issues else "empty" if live_count == 0 else
-"consistent"`. Add `admission_closed` to the issue set when the reconciled fleet has
-zero bound cells and the Substrate observation reports no live cohort. This reuses the
-existing issue machinery, so it automatically blocks the upgrade phase gate at
-`hosted_runtime_upgrade.py:363` — which is correct: an upgrade should not advance into
-a fleet nobody can join. Alternative considered: a separate readiness endpoint —
-rejected as a second source of truth for the same fact.
+**Report admission readiness from the control plane; do not re-derive it in the
+inventory.** `hosted_fleet_inventory.py:1549` computes `status` as `"inconsistent" if
+issues else "empty" if live_count == 0 else "consistent"`, so adding `admission_closed`
+to the issue set reuses the existing machinery and automatically blocks the upgrade
+phase gate at `hosted_runtime_upgrade.py:363` — correct, because an upgrade should not
+advance into a fleet nobody can join.
+
+The readiness fact itself must come from Substrate. This design originally said to
+derive it in the inventory from "zero bound cells and no live cohort", which is not
+implementable: `_SUBSTRATE_FIELDS` (`hosted_fleet_inventory.py:49-61`) is a closed,
+exact-match schema of eleven cell-keyed fields, and every cell-keyed substrate signal
+already contributes to `independently_live`. So whenever `live_count == 0` the whole
+substrate dataset is empty and no field remains to carry the fact — any implementation
+could only invent a proxy that silently disagrees with the real admission path.
+
+The original phrasing was also wrong on its own terms: `hasLiveHostedCohortTarget`
+requires a `bound` cell, so "zero bound cells with a live cohort" is unreachable and
+the scenario asserting it described a state that cannot exist. The reachable case is
+zero bound cells while admission is nonetheless open, which happens under v1 issuance,
+where `redeemInviteAtomic` pins no contract at all (`db.ts:804-809`).
+
+Alternative considered: a separate readiness endpoint — still rejected, for the
+original reason. The fact belongs on the observation Substrate already publishes, and
+must be derived from the same predicate the admission path evaluates so the two cannot
+drift apart.
 
 **Register the candidate from the publication pipeline, not the deployment.** The
 signed candidate already exists as a release artifact with a verified digest, and
@@ -132,5 +149,8 @@ be treated as live and not re-promoted.
   whether step 4 is a storage change or also a re-verification change.
 - Should `admission_closed` block the upgrade phase gate outright, or report as an
   issue the operator can acknowledge for a deliberately empty platform?
-- Is there any legitimate operational state with zero bound cells where admission is
-  expected to stay open, which would make the inventory signal a false positive?
+- ~~Is there any legitimate operational state with zero bound cells where admission is
+  expected to stay open?~~ **Answered: yes.** Under v1 issuance `redeemInviteAtomic`
+  pins no contract (`db.ts:804-809`), so admission is open with zero bound cells. This
+  is exactly why the readiness fact must come from Substrate, which knows its own
+  issuance mode, rather than being inferred from cell counts.

--- a/openspec/changes/make-hosted-admission-self-describing/proposal.md
+++ b/openspec/changes/make-hosted-admission-self-describing/proposal.md
@@ -25,9 +25,12 @@ the recovery from it be retried.
   distinguish "no live cohort" from other closures and MUST carry an operator-facing
   reference to the bootstrap procedure, without leaking tenant or invite detail to the
   invited person.
-- Make the closed state observable before a human hits it. Zero bound cells combined
-  with no live cohort MUST be a reported fleet-inventory issue, not a clean `empty`.
-  An operator MUST be able to see "admission is closed" from the inventory alone.
+- Make the closed state observable before a human hits it. The control plane MUST
+  report whether it would currently admit a tenant, derived from the same authority the
+  admission path uses, and a closed report MUST be a fleet-inventory issue rather than a
+  clean `empty`. The inventory MUST NOT re-derive that fact: its substrate observation
+  is a closed schema of cell-keyed fields, and every such field already forces a cell to
+  count as live, so at zero bound cells there is nothing left to derive from.
 - Register the release with the control plane as part of publishing it. Publishing a
   signed runtime image candidate MUST also record a `pending` agent-contract candidate
   for that release, so the service catalogue cannot silently lag the deployed runtime.
@@ -65,7 +68,8 @@ against a requirement that does not exist.
 
 ## Impact
 
-- Substrate: `src/lib/exomem-hosted/errors.ts` (refusal detail),
+- Substrate: `src/lib/exomem-hosted/fleet-observation.ts` (admission-readiness field on
+  the observation), `errors.ts` (refusal detail),
   `hosted-cohort-target.ts` and `db.ts:680,804-809` (closure classification),
   `agent-contract-store.ts` (promotion preconditions, assignment retirement),
   `oauth-store.ts` (bootstrap authority checkpoints), plus database migrations for

--- a/openspec/changes/make-hosted-admission-self-describing/specs/hosted-admission-bootstrap/spec.md
+++ b/openspec/changes/make-hosted-admission-self-describing/specs/hosted-admission-bootstrap/spec.md
@@ -24,23 +24,46 @@ SHALL reference the bootstrap procedure that clears it.
 - **THEN** the classification names that other cause
 - **AND** it does not reference the bootstrap procedure
 
+### Requirement: The fleet observation reports whether admission is open
+
+The control plane SHALL report, as part of its fleet observation, whether it would
+currently admit a new tenant. That report SHALL be derived from the same authority the
+admission path itself uses, so the two cannot disagree. Fleet inventory SHALL NOT
+re-derive admission readiness from cell-keyed observations.
+
+#### Scenario: The observation reports a closed control plane
+
+- **WHEN** the control plane would refuse to admit a new tenant
+- **THEN** its fleet observation reports admission as closed
+
+#### Scenario: The observation reports an open control plane
+
+- **WHEN** the control plane would admit a new tenant
+- **THEN** its fleet observation reports admission as open
+
+#### Scenario: The report cannot disagree with the admission path
+
+- **WHEN** the reported readiness is compared against the predicate the admission path
+  evaluates for the same control-plane state
+- **THEN** the two agree
+- **AND** the readiness is not computed from a second, independently maintained source
+
 ### Requirement: A fleet that cannot admit anyone is reported as an issue
 
-The system SHALL treat a reconciled fleet with zero bound cells and no live cohort as a
-reported inventory issue rather than a clean empty result. Fleet inventory SHALL NOT
-report a status that an operator would read as healthy while no tenant can be admitted.
+The system SHALL raise a reported inventory issue when the fleet observation reports
+admission as closed. Fleet inventory SHALL NOT report a status that an operator would
+read as healthy while no tenant can be admitted.
 
-#### Scenario: Empty fleet with no live cohort
+#### Scenario: Admission is closed
 
-- **WHEN** fleet inventory reconciles a fleet with zero bound cells and the control
-  plane reports no live cohort
+- **WHEN** fleet inventory reconciles an observation that reports admission as closed
 - **THEN** the inventory reports an admission-closed issue
 - **AND** the inventory status is not `empty` or `consistent`
 
-#### Scenario: Empty fleet with a live cohort still available
+#### Scenario: An empty fleet whose control plane would still admit
 
-- **WHEN** fleet inventory reconciles a fleet with zero bound cells while a live cohort
-  target does exist
+- **WHEN** fleet inventory reconciles a fleet with zero bound cells while the
+  observation reports admission as open
 - **THEN** the admission-closed issue is not reported
 
 #### Scenario: Upgrade phases refuse to advance into a closed fleet

--- a/openspec/changes/make-hosted-admission-self-describing/tasks.md
+++ b/openspec/changes/make-hosted-admission-self-describing/tasks.md
@@ -11,16 +11,33 @@
 
 ## 2. Report a fleet nobody can join
 
-- [ ] 2.1 Add the `admission_closed` issue to `hosted_fleet_inventory.py` when the
-      reconciled fleet has zero bound cells and the Substrate observation reports no
-      live cohort
-- [ ] 2.2 Confirm the issue flows through the existing `status` derivation at
+Ordering note: 2.1 is in Substrate and blocks 2.2-2.5. The exomem-side inventory
+cannot derive admission readiness on its own — `_SUBSTRATE_FIELDS`
+(`hosted_fleet_inventory.py:49-61`) is a closed, exact-match schema of eleven
+cell-keyed fields, and every cell-keyed substrate signal already forces a cell to count
+as live. So whenever `live_count == 0`, the entire substrate dataset is empty and no
+field remains to carry the fact. Attempting 2.2 first can only produce a proxy that
+silently disagrees with the real admission path.
+
+- [ ] 2.1 Add an admission-readiness field to Substrate's fleet observation
+      (`src/lib/exomem-hosted/fleet-observation.ts`), derived from the same predicate
+      the admission path uses (`hosted-cohort-target.ts`) plus the effective issuance
+      protocol, so the two cannot disagree
+- [ ] 2.2 Widen `_SUBSTRATE_FIELDS` in `hosted_fleet_inventory.py` to accept the new
+      field, keeping the closed exact-match schema
+- [ ] 2.3 Raise the `admission_closed` issue when the observation reports admission
+      closed, following the existing issue-accumulation shape at `:1375-1450`
+- [ ] 2.4 Confirm the issue flows through the existing `status` derivation at
       `hosted_fleet_inventory.py:1549` so the result is not `empty` or `consistent`
-- [ ] 2.3 Make the upgrade phase gate at `hosted_runtime_upgrade.py:363` name
-      `admission_closed` as the blocking condition when it refuses
-- [ ] 2.4 Test the three cases: zero bound cells with no live cohort (issue raised),
-      zero bound cells with a live cohort (no issue), and a populated fleet (no issue)
-- [ ] 2.5 Resolve the open question on whether an operator may acknowledge the issue for
+- [ ] 2.5 Widen `_INVENTORY_FIELDS` (`hosted_runtime_upgrade.py:71`) so the execution
+      record can carry a blocking reason, then make the phase gate at `:363` name
+      `admission_closed` when it refuses
+- [ ] 2.6 Test: observation reports closed (issue raised, status not empty/consistent);
+      observation reports open with zero bound cells (no issue — reachable under v1
+      issuance); populated healthy fleet (no issue); phase gate names the issue
+- [ ] 2.7 Test that the reported readiness agrees with the admission predicate for the
+      same control-plane state, so a second source of truth cannot drift in
+- [ ] 2.8 Resolve the open question on whether an operator may acknowledge the issue for
       a deliberately empty platform, and implement whichever answer is chosen
 
 ## 3. Keep the catalogue current with the deployed runtime


### PR DESCRIPTION
## What was wrong

The requirement merged in #1056 asked fleet inventory to derive admission readiness from *"zero bound cells and no live cohort"*. **It is not implementable, and one of its scenarios described a state that cannot exist.**

Found by the implementation lane for those very tasks, which stopped on its packet's own stop condition rather than inventing a proxy that would have looked green.

## Why it can't be derived

`_SUBSTRATE_FIELDS` (`infra/scripts/hosted_fleet_inventory.py:49-61`) is a **closed, exact-match** schema of eleven fields — ten cell-keyed lists plus `capacityActiveCellCount`. Every cell-keyed substrate signal (`routable`, `capacityClaim`, `reviewerAuthority`, `reviewerTenant`, assignments, unfinished operations) already contributes to `independently_live`, which forces `live_count`.

So whenever `live_count == 0`, the entire substrate dataset is necessarily empty and **no field remains to carry the fact**. Any implementation could only invent a proxy — abusing `capacityActiveCellCount` staleness, say — that silently disagrees with the real admission path the moment it's queried live.

## And one scenario was unreachable

`hasLiveHostedCohortTarget` requires a cell with `routing_state = 'bound'`. So *"empty fleet with a live cohort still available"* cannot happen: zero bound cells always means no live target.

The genuinely reachable case is the opposite one — zero bound cells while admission is nonetheless **open**, which is exactly what happens under **v1 issuance**, where `redeemInviteAtomic` pins no contract at all (`db.ts:804-809`). That is now the scenario.

## The correction

Substrate reports admission readiness on the fleet observation it already publishes, derived from the same predicate the admission path evaluates so the two cannot drift. The inventory consumes that fact instead of guessing at it. A third scenario pins the agreement, so a second source of truth can't creep in.

Task ordering corrected to match: the Substrate field (2.1) blocks the exomem work, and `_INVENTORY_FIELDS` (`hosted_runtime_upgrade.py:71`) must widen before the phase gate can name a blocking reason — it currently persists only `status`/`sha256`/`cellCount`/`legacyCellCount`, with no room for one.

The `design.md` decision that was wrong is corrected in place and says why it changed, rather than being quietly rewritten. One open question is now answered and struck through with its answer.

`openspec validate --strict` passes.
