### PR TITLE
fix(graph): stop a busy boundary latching the epoch that disables incremental repair

### DIFF
--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -3033,13 +3033,36 @@ class EpistemicGraphIndex:
         ).fetchone()
         return _checkpoint_from_value(str(row[0])) if row is not None else None
 
-    def _graph_sync_predecessor_available(
+    def _graph_sync_predecessor_state(
         self, checkpoint: graph_sync.GraphSyncCheckpoint
-    ) -> bool:
-        """Whether this sidecar can atomically advance the exact next epoch."""
+    ) -> str:
+        """Whether this sidecar can atomically advance the exact next epoch, and why not.
+
+        Split out of `_graph_sync_predecessor_available` so the dispatch layer
+        can name the gate. This is the *tenth* door onto a whole-vault rebuild:
+        `_FALLBACK_DISPOSITIONS` declares nine bail-out reasons and `fallback()`
+        logs which one fired, but this gate fires **before** `refresh_paths` is
+        ever called, so a write that rebuilds the whole vault through here
+        emits only "graph rebuild published" and "graph rebuild finished" and
+        never says which condition chose the expensive path.
+
+        The two failing states are operationally opposite and must not collapse
+        into one `False`:
+
+        * `graph_sync_predecessor_unreadable` -- the probe's read snapshot was
+          declined. `freshness.external_pending` alone is enough for that, and
+          `_open_read_snapshot` documents that guard as "an optimization for
+          public readers, not a correctness fence". Nothing about the sidecar's
+          lineage is known, or broken; the same sidecar answers `available` the
+          moment the flag clears. While it is set, every governed write pays a
+          whole-vault rebuild.
+        * `graph_sync_predecessor_mismatch` / `..._absent` -- the sidecar was
+          read and its acknowledgement genuinely is not this checkpoint's
+          predecessor. That is a real lineage gap and a rebuild is the repair.
+        """
         snapshot = self._open_read_snapshot(require_current_projection=False)
         if snapshot is None:
-            return False
+            return "graph_sync_predecessor_unreadable"
         try:
             values = dict(
                 snapshot.execute(
@@ -3051,12 +3074,24 @@ class EpistemicGraphIndex:
             snapshot.close()
         predecessor = checkpoint.generation - 1
         if predecessor == 0:
-            return (
+            if (
                 "graph_sync_generation" not in values
                 and "graph_sync_digest" not in values
-            )
+            ):
+                return "available"
+            return "graph_sync_predecessor_present_at_genesis"
         acknowledged = _graph_sync_acknowledgement(values)
-        return acknowledged is not None and acknowledged.generation == predecessor
+        if acknowledged is None:
+            return "graph_sync_acknowledgement_absent"
+        if acknowledged.generation != predecessor:
+            return "graph_sync_predecessor_mismatch"
+        return "available"
+
+    def _graph_sync_predecessor_available(
+        self, checkpoint: graph_sync.GraphSyncCheckpoint
+    ) -> bool:
+        """Whether this sidecar can atomically advance the exact next epoch."""
+        return self._graph_sync_predecessor_state(checkpoint) == "available"
 
     def _delta_target_still_current(self, delta: freshness.RecallDelta) -> bool:
         """Prove files parsed for a bounded refresh still name ``delta.to``."""
@@ -5315,7 +5350,22 @@ def upsert_after_write(
             )
             return GraphDispatchResult("deferred", "graph_scheduling_disabled", required)
         if required is not None and not index.available():
-            if not index._graph_sync_predecessor_available(required):
+            predecessor_state = index._graph_sync_predecessor_state(required)
+            if predecessor_state != "available":
+                # #576 F3, applied to the gate the incremental table does not
+                # cover. `fallback()` logs which of the nine bail-out reasons
+                # fired; this door precedes `refresh_paths` entirely, so
+                # without this line a cell rebuilding its whole graph on every
+                # ordinary write reports only that a rebuild ran, never which
+                # condition chose it -- the same silence that made the last
+                # incident take a code read instead of a log read.
+                log.info(
+                    "graph dispatch registered a whole-vault rebuild reason=%s "
+                    "external_pending=%s generation=%s",
+                    predecessor_state,
+                    freshness.external_pending(vault_root),
+                    required.generation,
+                )
                 result = _registered_or_failure(
                     vault_root, required, index, mutation_coordinator
                 )

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -100,6 +100,17 @@ RECONCILE_MAX_MEDIA_FILES = media_processing.DEFAULT_RECONCILE_LIMIT
 # Bounded rather than unbounded because this runs on the debounce thread, and a
 # boundary that stays busy this long is sustained contention -- a different
 # condition, which periodic recovery and the exhaustion log below both report.
+#
+# This is the retry budget, NOT the wall-clock bound a caller waits. The
+# deadline is only consulted after an attempt has already been refused, and
+# each attempt first spends the mutation coordinator's own timeout waiting for
+# the lock (`_DEFAULT_TIMEOUT_SECONDS`, 5.0 s today). So the real bound is this
+# budget plus one coordinator timeout -- about 20 s at today's defaults, and
+# measured at 20.00 s. `suspend_reads()` takes no timeout parameter to pass a
+# shortened one through, so the honest thing is to state the number rather than
+# imply a tighter one. Size this against watcher latency accordingly, and note
+# that `test_a_permanently_busy_boundary_gives_up_within_a_bounded_wall_time`
+# pins the bound against an absolute ceiling that does not scale with it.
 GRAPH_WITHDRAWAL_RETRY_SECONDS = 15.0
 
 
@@ -917,6 +928,12 @@ class FileWatcher:
         budget still leaves the epoch pending for periodic recovery -- but it
         says so, because sustained contention is a different condition from
         losing one race and should not look like it in a log.
+
+        The wall-clock bound is `GRAPH_WITHDRAWAL_RETRY_SECONDS` plus one
+        mutation-coordinator timeout, roughly 20 s at today's defaults, because
+        the deadline is checked only after an attempt has already spent that
+        timeout being refused. See the constant for why it is stated rather
+        than tightened.
         """
         from .cli_ops import OpError
 

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -80,6 +80,27 @@ RECONCILE_INTERVAL_SECONDS = 300.0
 # explicit `reconcile`.
 RECONCILE_MAX_EMBED_FILES = 500
 RECONCILE_MAX_MEDIA_FILES = media_processing.DEFAULT_RECONCILE_LIMIT
+# How long the compare-and-ack withdrawal keeps asking a busy mutation boundary
+# before giving the epoch back to periodic recovery.
+#
+# The withdrawal contends with `epistemic_graph_drain_paths` -- the incremental
+# drain, holding the same vault boundary while it repairs the very pages this
+# dispatch is reacting to. Losing that race is the *expected* outcome on a cell
+# whose queue is working, and it is explicitly retryable: the refusal carries
+# `status: "retryable"` and a `retry_after_ms`.
+#
+# Abandoning it on the first refusal is what made a healthy drain disable the
+# incremental path. `ack_ready` goes false, `clear_external_pending` is skipped,
+# and the in-memory flag stays set -- which declines the graph read snapshot,
+# which fails the dispatch's predecessor probe, which sends *every* subsequent
+# write down a whole-vault rebuild until a reconcile cycle finds the boundary
+# free. Measured on a live cell: a 4.9 s drain hold cost 43 s rebuilds on every
+# write for the rest of the window.
+#
+# Bounded rather than unbounded because this runs on the debounce thread, and a
+# boundary that stays busy this long is sustained contention -- a different
+# condition, which periodic recovery and the exhaustion log below both report.
+GRAPH_WITHDRAWAL_RETRY_SECONDS = 15.0
 
 
 def _background_deferred_limit(
@@ -873,6 +894,67 @@ class FileWatcher:
             policy=policy,
         )
 
+    def _suspend_reads_for_acknowledgement(self, candidate) -> None:
+        """Withdraw graph availability for compare-and-ack, waiting out a busy boundary.
+
+        The withdrawal has to happen before `clear_external_pending`: a
+        same-metadata edit can leave the projection identity unchanged, so the
+        epoch must not be retired while stale edges are still publicly
+        readable. That ordering is correct and is not what is being changed
+        here -- a failed withdrawal must still keep the epoch pending.
+
+        What changes is treating a *retryable* refusal as a refusal at all. The
+        boundary this contends for is usually held by
+        `epistemic_graph_drain_paths`, the incremental drain repairing the very
+        pages this dispatch is reacting to, and the refusal says so: it carries
+        `status: "retryable"` and a `retry_after_ms` that nothing was reading.
+        Honouring it costs a few seconds on a background thread; abandoning it
+        cost every subsequent write a whole-vault rebuild, because the epoch
+        stayed pending, the flag declined the graph's read snapshot, and the
+        dispatch's predecessor probe could no longer prove anything.
+
+        A non-retryable failure still propagates unchanged, and exhausting the
+        budget still leaves the epoch pending for periodic recovery -- but it
+        says so, because sustained contention is a different condition from
+        losing one race and should not look like it in a log.
+        """
+        from .cli_ops import OpError
+
+        deadline = time.monotonic() + GRAPH_WITHDRAWAL_RETRY_SECONDS
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                candidate.suspend_reads()
+                if attempts > 1:
+                    log.info(
+                        "file watcher: graph availability withdrawal succeeded after "
+                        "waiting out a busy boundary attempts=%s",
+                        attempts,
+                    )
+                return
+            except OpError as error:
+                if error.details.get("status") != "retryable":
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    holder = error.details.get("holder") or {}
+                    log.warning(
+                        "file watcher: graph availability withdrawal gave up on a busy "
+                        "boundary attempts=%s holder=%s; epoch stays pending for "
+                        "periodic recovery",
+                        attempts,
+                        holder.get("operation") if isinstance(holder, dict) else None,
+                    )
+                    raise
+                advised_ms = error.details.get("retry_after_ms")
+                advised = (
+                    float(advised_ms) / 1000.0
+                    if isinstance(advised_ms, (int, float))
+                    else 0.25
+                )
+                time.sleep(max(0.01, min(remaining, advised)))
+
     def _dispatch_batch(
         self,
         ups: list[Path],
@@ -992,7 +1074,7 @@ class FileWatcher:
             candidate = epistemic_graph.EpistemicGraphIndex(self._vault_root)
             if candidate.path.exists():
                 try:
-                    candidate.suspend_reads()
+                    self._suspend_reads_for_acknowledgement(candidate)
                 except Exception:  # noqa: BLE001 - retain pending for periodic recovery
                     ack_ready = False
                     log.exception("file watcher: graph availability withdrawal failed")

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -981,6 +981,138 @@ def test_watcher_drain_still_marks_unclassified_graph_incompleteness(
     assert clock_after == clock_before + 3
 
 
+def test_a_busy_boundary_does_not_latch_the_external_pending_epoch(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient lock refusal must not leave the graph on the whole-vault path.
+
+    The compare-and-ack withdrawal contends for the vault mutation boundary
+    with `epistemic_graph_drain_paths` -- the incremental drain, repairing the
+    very pages this dispatch is reacting to. On a cell whose queue is working,
+    losing that race is the expected outcome, and the refusal says it is
+    survivable: `status: "retryable"`, with a `retry_after_ms`.
+
+    Abandoning the withdrawal on that first refusal is what made the
+    incremental path disable itself. `ack_ready` goes false,
+    `clear_external_pending` is skipped, and the in-memory epoch stays set --
+    which declines the graph read snapshot, which fails
+    `_graph_sync_predecessor_state`, which sends every subsequent write down a
+    whole-vault rebuild until a reconcile cycle happens to find the boundary
+    free. Measured on a live cell: one 4.9 s drain hold, then 43 s rebuilds on
+    every write for the rest of the window.
+
+    The refusal here is real, not synthetic: a second thread holds the actual
+    boundary under the actual holder name, and the withdrawal is refused by
+    `mutation_lock` itself. The hold is transient, exactly as a drain's is, so
+    a withdrawal that waits at all clears the epoch and one that gives up
+    immediately does not.
+    """
+    import threading
+
+    from exomem import mutation_lock
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    # Refuse fast so the test spends its time on the retry, not the first wait.
+    monkeypatch.setattr(mutation_lock, "_DEFAULT_TIMEOUT_SECONDS", 0.3)
+    coordinator = epistemic_graph.EpistemicGraphIndex(root)._mutation_coordinator
+
+    holding = threading.Event()
+    attempted = threading.Event()
+    released = threading.Event()
+    attempts: list[int] = []
+
+    # Release the boundary only once the withdrawal has actually been refused
+    # once, so the contention is deterministic rather than a sleep race.
+    real_suspend = epistemic_graph.EpistemicGraphIndex.suspend_reads
+
+    def counting_suspend(self) -> None:
+        attempts.append(1)
+        try:
+            return real_suspend(self)
+        except Exception:
+            # Only now has the boundary actually refused. Releasing before this
+            # would let the first attempt win and prove nothing.
+            attempted.set()
+            raise
+
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex, "suspend_reads", counting_suspend
+    )
+
+    def drain_holds_the_boundary() -> None:
+        with coordinator.hold(
+            operation="epistemic_graph_drain_paths", holder_kind="graph"
+        ):
+            holding.set()
+            attempted.wait(20)
+        released.set()
+
+    holder = threading.Thread(target=drain_holds_the_boundary, daemon=True)
+    holder.start()
+    assert holding.wait(10), "the contending drain never took the boundary"
+
+    watcher = FileWatcher(root)
+    edited = root / INSIGHT_A
+    edited.write_text(_page("Contract A", "A revised under contention."), encoding="utf-8")
+    pending_epoch = freshness.mark_external_pending(root)
+
+    watcher._dispatch_batch(
+        [edited], [INSIGHT_A], [], cap=False, pending_epoch=pending_epoch
+    )
+
+    assert attempts, "the withdrawal was never attempted, so nothing was contended"
+    assert released.wait(10), "the contending drain never let go"
+    assert freshness.external_pending(root) is False, (
+        "a transient, explicitly retryable boundary refusal latched the external "
+        "pending epoch; every write until the next reconcile now pays a "
+        "whole-vault rebuild"
+    )
+
+
+def test_a_non_retryable_withdrawal_failure_is_not_retried_and_keeps_the_epoch(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of the carve-out above, and the one that keeps it narrow.
+
+    Waiting out a busy boundary is right because the refusal declares itself
+    survivable. A failure that makes no such claim is the fail-closed case the
+    epoch must survive: it is retried zero times, and the epoch stays pending
+    for periodic recovery exactly as before.
+
+    Without this, widening the retry to "any exception" would swallow a genuine
+    withdrawal failure by waiting on it, and the suite would stay green.
+    """
+    from exomem.file_watcher import FileWatcher
+
+    root = contract_vault
+    attempts: list[int] = []
+
+    def refuse_hard(self) -> None:
+        attempts.append(1)
+        raise OpError("GRAPH_SIDECAR_UNAVAILABLE", "sidecar cannot be opened")
+
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex, "suspend_reads", refuse_hard
+    )
+
+    watcher = FileWatcher(root)
+    edited = root / INSIGHT_A
+    edited.write_text(_page("Contract A", "A revised, hard failure."), encoding="utf-8")
+    pending_epoch = freshness.mark_external_pending(root)
+
+    watcher._dispatch_batch(
+        [edited], [INSIGHT_A], [], cap=False, pending_epoch=pending_epoch
+    )
+
+    assert attempts == [1], (
+        "a withdrawal failure that never claimed to be retryable was retried anyway"
+    )
+    assert freshness.external_pending(root) is True, (
+        "a genuine withdrawal failure must still keep the epoch pending"
+    )
+
+
 def test_refused_publication_is_memoized_instead_of_retried_at_full_cost(
     contract_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_freshness_liveness_contract.py
+++ b/tests/test_freshness_liveness_contract.py
@@ -1009,18 +1009,22 @@ def test_a_busy_boundary_does_not_latch_the_external_pending_epoch(
     """
     import threading
 
-    from exomem import mutation_lock
+    from exomem import file_watcher as file_watcher_module
     from exomem.file_watcher import FileWatcher
 
     root = contract_vault
-    # Refuse fast so the test spends its time on the retry, not the first wait.
-    monkeypatch.setattr(mutation_lock, "_DEFAULT_TIMEOUT_SECONDS", 0.3)
+    # No timeout shortening here: `VaultMutationCoordinator.timeout_seconds`
+    # defaults from `_DEFAULT_TIMEOUT_SECONDS` as a *default argument*, bound at
+    # function definition, so patching the module global does nothing. This test
+    # therefore pays the coordinator's real refusal wait (5.0 s today), which is
+    # also what the live cell paid -- its traceback reports `wait_ms: 5000.46`.
     coordinator = epistemic_graph.EpistemicGraphIndex(root)._mutation_coordinator
 
     holding = threading.Event()
     attempted = threading.Event()
     released = threading.Event()
     attempts: list[int] = []
+    advised_ms: list[float] = []
 
     # Release the boundary only once the withdrawal has actually been refused
     # once, so the contention is deterministic rather than a sleep race.
@@ -1030,15 +1034,33 @@ def test_a_busy_boundary_does_not_latch_the_external_pending_epoch(
         attempts.append(1)
         try:
             return real_suspend(self)
-        except Exception:
+        except OpError as error:
+            value = error.details.get("retry_after_ms")
+            if isinstance(value, (int, float)):
+                advised_ms.append(float(value))
             # Only now has the boundary actually refused. Releasing before this
             # would let the first attempt win and prove nothing.
+            attempted.set()
+            raise
+        except Exception:
             attempted.set()
             raise
 
     monkeypatch.setattr(
         epistemic_graph.EpistemicGraphIndex, "suspend_reads", counting_suspend
     )
+
+    # Honouring the advertised backoff is this change's headline mechanism, so
+    # it is asserted rather than assumed: a retry that slept an arbitrary
+    # constant, or spun, would still clear the epoch here and look identical.
+    slept: list[float] = []
+    real_sleep = file_watcher_module.time.sleep
+
+    def recording_sleep(seconds: float) -> None:
+        slept.append(seconds)
+        return real_sleep(seconds)
+
+    monkeypatch.setattr(file_watcher_module.time, "sleep", recording_sleep)
 
     def drain_holds_the_boundary() -> None:
         with coordinator.hold(
@@ -1067,6 +1089,116 @@ def test_a_busy_boundary_does_not_latch_the_external_pending_epoch(
         "a transient, explicitly retryable boundary refusal latched the external "
         "pending epoch; every write until the next reconcile now pays a "
         "whole-vault rebuild"
+    )
+
+    assert advised_ms, "the refusal carried no retry_after_ms to honour"
+    expected = advised_ms[0] / 1000.0
+    assert any(abs(value - expected) < 0.2 for value in slept), (
+        "the retry did not sleep the interval the refusal advertised "
+        f"(retry_after_ms={advised_ms[0]}, expected ~{expected:.3f}s, slept={slept}); "
+        "ignoring the advice is a busy spin as soon as the coordinator timeout shortens"
+    )
+
+
+def test_a_permanently_busy_boundary_gives_up_within_a_bounded_wall_time(
+    contract_vault: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The bound is load-bearing, so it is pinned against an absolute ceiling.
+
+    Waiting a busy boundary out runs on the debounce thread, so "wait longer"
+    is not free and "wait forever" is a hang: a permanently busy boundary would
+    stop the watcher dispatching anything at all. The budget is what stops
+    that, and the previous round pinned only the `= 0.0` direction -- nothing
+    stopped an edit, or an operator tuning under pressure, from raising it
+    without limit.
+
+    The ceiling here is therefore a constant that does NOT derive from
+    `GRAPH_WITHDRAWAL_RETRY_SECONDS`. A ceiling expressed in terms of the
+    budget would scale with any mutation of it and prove nothing, which is
+    exactly how a large-value mutant survives.
+
+    The helper runs on its own thread and is joined, so an unbounded wait fails
+    the assertion rather than hanging the suite.
+    """
+    import threading
+
+    from exomem import file_watcher as file_watcher_module
+    from exomem.file_watcher import FileWatcher
+
+    # Independent of the budget on purpose, and bounded twice over. Today's
+    # real wall-clock bound is the budget plus one coordinator timeout; with
+    # the 0.2 s coordinator below that is about 15 s, so this leaves ample
+    # headroom while still failing an unbounded or absurdly-raised budget.
+    #
+    # It must also stay under the suite's own per-test `timeout = 60`
+    # (pyproject `[tool.pytest.ini_options]`), or a raised-budget mutant dies
+    # by harness timeout instead of by this assertion -- which kills the mutant
+    # but reports the wrong reason and gives the next reader nothing to read.
+    absolute_ceiling_seconds = 35.0
+
+    from exomem import mutation_lock
+
+    root = contract_vault
+    # A short-timeout coordinator so each refused attempt costs a fraction of a
+    # second: the budget, not the lock wait, is what this test is measuring. It
+    # takes the real coordinator's state root, so it resolves the same lock and
+    # the contention below is genuine rather than two unrelated locks.
+    real_state_root = epistemic_graph.EpistemicGraphIndex(root)._mutation_coordinator.state_root
+    fast_coordinator = mutation_lock.VaultMutationCoordinator(
+        real_state_root, root, timeout_seconds=0.2
+    )
+    index = epistemic_graph.EpistemicGraphIndex(root, mutation_coordinator=fast_coordinator)
+
+    holding = threading.Event()
+    stop_holding = threading.Event()
+
+    def drain_holds_the_boundary_forever() -> None:
+        with fast_coordinator.hold(
+            operation="epistemic_graph_drain_paths", holder_kind="graph"
+        ):
+            holding.set()
+            stop_holding.wait(absolute_ceiling_seconds + 5)
+
+    holder = threading.Thread(target=drain_holds_the_boundary_forever, daemon=True)
+    holder.start()
+    assert holding.wait(10), "the contending drain never took the boundary"
+
+    watcher = FileWatcher(root)
+    outcome: list[object] = []
+
+    def withdraw() -> None:
+        try:
+            watcher._suspend_reads_for_acknowledgement(index)
+        except BaseException as error:  # noqa: BLE001 - the outcome is the assertion
+            outcome.append(error)
+        else:
+            outcome.append(None)
+
+    caplog.set_level("WARNING", logger="exomem.file_watcher")
+    worker = threading.Thread(target=withdraw, daemon=True)
+    started = time.monotonic()
+    worker.start()
+    worker.join(absolute_ceiling_seconds)
+    elapsed = time.monotonic() - started
+    stop_holding.set()
+    holder.join(10)
+
+    assert not worker.is_alive(), (
+        "the withdrawal never gave up on a permanently busy boundary; the "
+        f"debounce thread would be blocked indefinitely (waited {elapsed:.1f}s)"
+    )
+    assert isinstance(outcome[0], OpError), (
+        f"a budget-exhausted withdrawal must propagate its refusal, got {outcome[0]!r}"
+    )
+    assert elapsed < absolute_ceiling_seconds, f"gave up only after {elapsed:.1f}s"
+    assert "gave up on a busy boundary" in caplog.text, (
+        "sustained contention must be reported as its own condition rather than "
+        "looking like one lost race"
+    )
+    # The failure above is what matters; this keeps the reason legible when a
+    # future edit raises the budget rather than removing the bound outright.
+    assert 0 < file_watcher_module.GRAPH_WITHDRAWAL_RETRY_SECONDS <= 60.0, (
+        "the retry budget must stay a bound a debounce thread can afford"
     )
 
 

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1444,6 +1444,33 @@ def test_dispatch_names_the_gate_that_sent_a_write_to_a_whole_vault_rebuild(
     )
     assert "external_pending=True" in caplog.text
 
+    # The genesis arm, both ways. `generation=1` has predecessor 0, so the
+    # answer is provable from the sidecar alone: a sidecar carrying no
+    # `graph_sync` acknowledgement can take it, and one that already carries an
+    # acknowledgement cannot. Collapsing the second into `available` is a
+    # False-to-True flip against the pre-fix predicate, and the rest of this
+    # suite does not notice it -- `refresh_paths` re-checks lineage downstream,
+    # which contains the blast radius but does not hold the seam.
+    freshness.clear_external_pending(tmp_path, through=freshness.external_pending_epoch(tmp_path))
+    genesis = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="0" * 24,
+        paths=(("Knowledge Base/Notes/Insights/gate.md", "d" * 64),),
+        created_paths=(),
+    )
+    fresh = epistemic_graph.EpistemicGraphIndex(tmp_path / "unbuilt")
+    (tmp_path / "unbuilt/Knowledge Base/Notes/Insights").mkdir(parents=True)
+    fresh.rebuild_all()
+    assert fresh._graph_sync_predecessor_state(genesis) == "available", (
+        "a sidecar with no graph_sync acknowledgement can take generation 1"
+    )
+    assert index._graph_sync_predecessor_state(genesis) == (
+        "graph_sync_predecessor_present_at_genesis"
+    ), (
+        "a sidecar that already carries a graph_sync acknowledgement cannot take "
+        "generation 1, and saying it can is a lineage claim the sidecar disproves"
+    )
+
 
 def test_single_flight_retries_for_new_checkpoint_and_never_releases_stale_waiter(
     tmp_path: Path,

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1109,8 +1109,10 @@ def test_a_queued_repair_is_not_rescheduled_as_a_whole_vault_rebuild(
     )
     monkeypatch.setattr(
         EpistemicGraphIndex,
-        "_graph_sync_predecessor_available",
-        lambda _self, _checkpoint: True,
+        # The dispatch reads the reason-carrying seam, so that is what a stub
+        # asserting "the predecessor is fine" has to answer.
+        "_graph_sync_predecessor_state",
+        lambda _self, _checkpoint: "available",
     )
     monkeypatch.setattr(
         EpistemicGraphIndex,
@@ -1159,8 +1161,10 @@ def test_a_standalone_caller_still_gets_a_converged_graph(
     )
     monkeypatch.setattr(
         EpistemicGraphIndex,
-        "_graph_sync_predecessor_available",
-        lambda _self, _checkpoint: True,
+        # The dispatch reads the reason-carrying seam, so that is what a stub
+        # asserting "the predecessor is fine" has to answer.
+        "_graph_sync_predecessor_state",
+        lambda _self, _checkpoint: "available",
     )
     monkeypatch.setattr(
         EpistemicGraphIndex,
@@ -1359,6 +1363,86 @@ def test_incremental_predecessor_requires_a_valid_checkpoint_lineage(tmp_path: P
         )
 
     assert index._graph_sync_predecessor_available(current_checkpoint) is False
+
+
+def test_dispatch_names_the_gate_that_sent_a_write_to_a_whole_vault_rebuild(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The whole-vault rebuild door that `_FALLBACK_DISPOSITIONS` does not cover.
+
+    `converge-graph-incrementally` made the *incremental* bail-outs a declared
+    nine-way table, and `fallback()` logs which reason fired -- "#576 F3. The
+    single most-wanted number in the incident, and the one nothing logged".
+
+    But `upsert_after_write` can register a whole-vault rebuild **before**
+    `refresh_paths` is ever called, at the `_graph_sync_predecessor_available`
+    gate. That door is outside the table and logs nothing at all, so a cell
+    rebuilding its entire graph on every ordinary write produces exactly two
+    log lines -- `graph rebuild published` and `graph rebuild finished` -- and
+    neither says which gate chose the expensive path. A nine-way classification
+    whose chosen branch cannot be read after the fact is not diagnosable in
+    production, and this is the tenth branch.
+
+    The gate must also say *why* it could not prove the predecessor. It refuses
+    for two very different reasons: the probe's read snapshot was declined (for
+    which `freshness.external_pending` alone is enough -- an in-memory liveness
+    hint that `_open_read_snapshot` documents as "an optimization for public
+    readers, not a correctness fence"), or the sidecar was read and its
+    acknowledgement genuinely is not the predecessor. The first is a liveness
+    condition costing a whole-vault rebuild per write; the second is a real
+    lineage gap that has to rebuild. Collapsing them into one silent `False` is
+    what made this take a code read rather than a log read.
+    """
+    from exomem import find as find_module
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/gate.md"
+    note.parent.mkdir(parents=True)
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "---\ntype: insight\nstatus: active\n---\n# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    freshness.seed(
+        tmp_path,
+        "vault",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in vault_module.walk_vault_md(tmp_path)
+        ),
+    )
+    freshness.seed(
+        tmp_path,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in find_module._walk_md(tmp_path / "Knowledge Base")
+        ),
+    )
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    assert index.available() is True
+
+    # The state the watcher's fail-closed default leaves behind when it cannot
+    # classify a fan-out incompleteness (`file_watcher.py`, "graph fan-out
+    # incomplete; periodic recovery re-armed"). Nothing on disk changes.
+    freshness.mark_external_pending(tmp_path)
+    assert index.available() is False
+
+    caplog.set_level("INFO", logger="exomem.epistemic_graph")
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "---\ntype: insight\nstatus: active\n---\n# After\n")],
+        vault_root=tmp_path,
+    )
+
+    assert "whole-vault rebuild" in caplog.text, (
+        "a write that registered a whole-vault rebuild must say so; the two "
+        "lines it does emit report that a rebuild ran, never which gate chose it"
+    )
+    assert "graph_sync_predecessor_unreadable" in caplog.text, (
+        "the gate must distinguish a declined probe from a genuine lineage gap"
+    )
+    assert "external_pending=True" in caplog.text
 
 
 def test_single_flight_retries_for_new_checkpoint_and_never_releases_stale_waiter(


### PR DESCRIPTION
## The symptom

On a live cell, ordinary single-page writes were costing a whole-vault graph rebuild. Measured on the personal cell running 0.69.0: `graph rebuild finished outcome=published elapsed_ms=43453` for one note, with two earlier attempts finishing `outcome=failed` first, and reads in that window refused with `catalog_outcome status=warming` and `resolver_checkpoint_stale`.

The incremental repair from `converge-graph-incrementally` is present and working. It was being bypassed.

## The mechanism

There is a path to the whole-vault rebuild that the nine-way `_FALLBACK_DISPOSITIONS` table does not cover, in `upsert_after_write`:

```python
if required is not None and not index.available():
    if not index._graph_sync_predecessor_available(required):
        result = _registered_or_failure(...)   # whole-vault rebuild
```

`refresh_paths`, where the table and its logging live, is never reached, so which branch was taken was recorded nowhere: not in state, not in the log, not inferable.

That gate opens when `freshness.external_pending` is set, which is indistinguishable from a genuine lineage gap. The flag latches like this:

1. The file watcher calls `suspend_reads()`, which takes the vault mutation boundary.
2. The boundary is held by `epistemic_graph_drain_paths` — the incremental drain doing its job.
3. After 5 seconds the coordinator refuses with `status: retryable` and `retry_after_ms: 2458`, which nothing reads.
4. The failure sets `ack_ready = False`, skipping `clear_external_pending`.

From then on every write takes the whole-vault path. The 300-second recovery pass is not an escape, because it clears the flag by calling `withdraw_availability()`, which takes the same boundary and is refused under the same contention. Measured: contended reconcile leaves the flag set after 5.00 s; uncontended clears it.

So the incremental repair's own success is what disabled the incremental repair, for at least one recovery interval and longer while contention persists, self-sustaining because each 43-second rebuild is more contention for the next withdrawal.

## The fix

`_suspend_reads_for_acknowledgement` waits the boundary out using the refusal's own `retry_after_ms`, under a bounded budget, and distinguishes a retryable refusal from a hard failure. A non-retryable failure propagates on the first attempt and still keeps the epoch pending; budget exhaustion logs as its own condition. The first commit names the gate in the log so this is readable next time.

Clearing the flag unconditionally in a `finally` was considered and rejected, because the withdraw-before-clear ordering is load-bearing. Verified: with a content edit that preserves size and mtime, the projection signature does not change, `exact_live_checkpoint` skips the byte proof, and 3 stale edges are served including a removed wikilink.

The freshness guard and the fail-closed marking default are untouched.

## Verification

- `tests/test_freshness_liveness_contract.py` and `tests/test_file_watcher.py`: 99 passed.
- Six graph suites: 240 passed, 5 skipped.
- Ruff, mypy on the changed module, and `git diff --check`: clean.
- Eight mutants, all killed, each restored byte-identically. They cover the log line, the reason string, the genesis arm, both directions of the retry budget, the retryable carve-out, honouring the advertised backoff, and clearing the epoch regardless of outcome.
- Red-first proven against the pre-fix file, with a real `MUTATION_BUSY` refusal whose payload matches the live traceback closely (`retry_after_ms` 2502 against 2458, `wait_ms` 5000.19 against 5000.46).

Reviewed by an independent lane over two rounds. The first returned REQUEST_CHANGES on five findings, the largest being that the advertised bound had no test and a mutant setting it to effectively infinite passed everything. The recheck returned ACCEPT and confirmed the mutant now dies by the assertion rather than by the harness timeout.

## Known limits, recorded rather than fixed

- The advertised budget is the constant plus one coordinator timeout, about 20 seconds at today's defaults, because the remaining budget is only checked after a refusal returns. Stated in the code rather than tightened, since `suspend_reads()` takes no timeout parameter.
- `_reconcile_access_policy` delegates to the same recovery path and so shares its weakness under sustained contention past the budget.
- A third disposition carve-out, "a drain holds the boundary right now", would be the cleaner fix. It edits a fail-closed default and belongs in its own change.
- Each contended dispatch now records three boundary refusals instead of one, which inflates the busy counters in the readiness endpoint.
