### PR TITLE
fix: stop a disabled coordinator's status timeout blocking standalone readiness

### DIFF
--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -496,7 +496,15 @@ def _unmeasured_coordination(reason: str) -> dict[str, Any]:
 
     `role` and `coordinator_healthy` derive from `enabled` the same way
     `LeaseManager.status()` derives them, so an unmeasured standalone cell
-    describes itself the way a measured one does. Hardcoding `unknown`/`False`
+    describes itself the way a measured one does. The parity is exact only for
+    the standalone branch: for an enabled cell `LeaseManager.status()` treats
+    `enabled` as an initial default and then overwrites it with a real
+    measurement, which this helper has no way to take — so `enabled=True` here
+    is a deliberate fail-closed approximation, not the same derivation.
+
+    Every read is stripped, matching `LeaseConfig.from_env()`. An unstripped
+    replica id would publish whitespace as an identity and suppress
+    `replica_identity_missing` on a config that `from_env()` rejects outright. Hardcoding `unknown`/`False`
     here made a standalone cell contradict its own successful payload — which
     was invisible while the response was a 503, and is not once it is a 200.
     """
@@ -504,7 +512,9 @@ def _unmeasured_coordination(reason: str) -> dict[str, Any]:
     return {
         "enabled": enabled,
         "role": "unknown" if enabled else "standalone",
-        "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
+        "replica_id": (
+            os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID", "").strip() or None
+        ),
         "coordinator_healthy": not enabled,
         "mutation_boundary": {"state": "unknown", "reason": reason},
     }

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -363,9 +363,16 @@ def build_runtime_readiness(
     reasons: list[str] = []
     if mcp_tool_surface_sha256 is None:
         reasons.append("mcp_tool_surface_unavailable")
-    if coordination.get("status_timed_out") is True:
-        reasons.append("coordination_status_timeout")
     if enabled:
+        # A blocked status probe leaves the lease state unmeasured, and an
+        # unmeasured lease is exactly what takeover must not be attempted on.
+        # It says nothing about a standalone cell: with no coordinator there is
+        # no lease to confirm, and the contract is that standalone stays ready
+        # without multi-host coordination.  `enabled` is safe to trust in the
+        # timed-out payload because it is read from the environment rather than
+        # from the probe that failed.
+        if coordination.get("status_timed_out") is True:
+            reasons.append("coordination_status_timeout")
         if not healthy:
             reasons.append("coordinator_unavailable")
         if role not in {"writer", "follower"}:

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -491,6 +491,25 @@ def _measure_observability() -> dict[str, Any]:
     }
 
 
+def _unmeasured_coordination(reason: str) -> dict[str, Any]:
+    """Coordination state for a probe that did not answer.
+
+    `role` and `coordinator_healthy` derive from `enabled` the same way
+    `LeaseManager.status()` derives them, so an unmeasured standalone cell
+    describes itself the way a measured one does. Hardcoding `unknown`/`False`
+    here made a standalone cell contradict its own successful payload — which
+    was invisible while the response was a 503, and is not once it is a 200.
+    """
+    enabled = bool(os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip())
+    return {
+        "enabled": enabled,
+        "role": "unknown" if enabled else "standalone",
+        "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
+        "coordinator_healthy": not enabled,
+        "mutation_boundary": {"state": "unknown", "reason": reason},
+    }
+
+
 def _bounded_coordination_status(
     vault_root: Path | None,
     probe: Callable[[Path | None], Mapping[str, Any]],
@@ -575,29 +594,14 @@ def runtime_readiness(
             coordination_status,
         )
         if measured is None:
-            coordination = {
-                "enabled": bool(os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip()),
-                "role": "unknown",
-                "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
-                "coordinator_healthy": False,
-                "status_timed_out": True,
-                "mutation_boundary": {
-                    "state": "unknown",
-                    "reason": "status_timeout",
-                },
-            }
+            coordination = _unmeasured_coordination("status_timeout")
+            coordination["status_timed_out"] = True
         else:
             coordination = measured
     except Exception:  # noqa: BLE001 - readiness must return structured 503 state
-        coordination = {
-            "enabled": bool(os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip()),
-            "role": "unknown",
-            "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
-            "coordinator_healthy": False,
-            # The probe failed; the boundary was not measured. Saying "free"
-            # here is what made MUTATION_LOCK_UNAVAILABLE read as healthy.
-            "mutation_boundary": {"state": "unknown", "reason": "status_error"},
-        }
+        # The probe failed; the boundary was not measured. Saying "free"
+        # here is what made MUTATION_LOCK_UNAVAILABLE read as healthy.
+        coordination = _unmeasured_coordination("status_error")
     retrieval = readiness.retrieval_admission(configured_vault)
     if configured_vault is not None:
         try:

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -321,13 +321,14 @@ def test_runtime_readiness_measures_the_configured_vault(
     }
 
 
-def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def _block_coordination_status(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[threading.Event, threading.Event]:
+    """Wire a coordination probe that never answers inside the readiness deadline."""
     from exomem import readiness, session_validation_cache, writer_lease
     from exomem import runtime_readiness as readiness_module
 
-    vault = tmp_path / "blocked-vault"
     entered = threading.Event()
     release = threading.Event()
 
@@ -351,6 +352,22 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
         "retrieval_admission",
         lambda _vault_root=None: {"state": "ready", "admitted": True},
     )
+    return entered, release
+
+
+def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A *coordinated* replica whose probe blocks must fail closed, and fast.
+
+    The lease state is unmeasured, so takeover must not be attempted on it.
+    """
+    from exomem import runtime_readiness as readiness_module
+
+    vault = tmp_path / "blocked-vault"
+    entered, release = _block_coordination_status(vault, monkeypatch)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "http://127.0.0.1:9/lease")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "replica-a")
 
     assert readiness_module.COORDINATION_STATUS_TIMEOUT_SECONDS < 1.0
     started = time.monotonic()
@@ -366,7 +383,52 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
     assert time.monotonic() - started < 1.25
     assert snapshot["status"] == "not_ready"
     assert snapshot["takeover_eligible"] is False
-    assert snapshot["reasons"] == ["coordination_status_timeout"]
+    assert snapshot["reasons"] == [
+        "coordination_status_timeout",
+        "coordinator_unavailable",
+        "coordination_role_unknown",
+    ]
+    assert snapshot["coordination"]["mutation_boundary"] == {
+        "state": "unknown",
+        "reason": "status_timeout",
+    }
+
+
+def test_standalone_readiness_survives_a_blocked_coordination_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Standalone stays ready when the coordination probe times out.
+
+    "Standalone Exomem SHALL remain ready without multi-host coordination" —
+    with no coordinator configured there is no lease to confirm, so a diagnostic
+    probe that misses its deadline has nothing to report about admission.  The
+    timeout stays visible in the payload for operators; it just no longer pins a
+    single-cell deployment to 503.
+    """
+    from exomem import runtime_readiness as readiness_module
+
+    vault = tmp_path / "standalone-vault"
+    entered, release = _block_coordination_status(vault, monkeypatch)
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_URL", raising=False)
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_REPLICA_ID", raising=False)
+
+    started = time.monotonic()
+    try:
+        snapshot = readiness_module.runtime_readiness(
+            mcp_tool_surface_sha256="a" * 64,
+            traffic={},
+        )
+    finally:
+        release.set()
+
+    assert entered.is_set()
+    assert time.monotonic() - started < 1.25
+    assert snapshot["status"] == "ready"
+    assert snapshot["reasons"] == []
+    assert snapshot["takeover_eligible"] is True
+    assert snapshot["retrieval"]["admitted"] is True
+    # The unmeasured boundary must still be reported, not swallowed.
+    assert snapshot["coordination"]["enabled"] is False
     assert snapshot["coordination"]["mutation_boundary"] == {
         "state": "unknown",
         "reason": "status_timeout",

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -394,6 +394,33 @@ def test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks(
     }
 
 
+def test_coordinated_timeout_without_a_replica_id_names_every_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 4-reason variant: nothing about the replica is knowable either."""
+    from exomem import runtime_readiness as readiness_module
+
+    vault = tmp_path / "no-replica-vault"
+    _, release = _block_coordination_status(vault, monkeypatch)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "http://127.0.0.1:9/lease")
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_REPLICA_ID", raising=False)
+
+    try:
+        snapshot = readiness_module.runtime_readiness(
+            mcp_tool_surface_sha256="a" * 64, traffic={}
+        )
+    finally:
+        release.set()
+
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["reasons"] == [
+        "coordination_status_timeout",
+        "coordinator_unavailable",
+        "coordination_role_unknown",
+        "replica_identity_missing",
+    ]
+
+
 def test_standalone_readiness_survives_a_blocked_coordination_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -433,6 +460,10 @@ def test_standalone_readiness_survives_a_blocked_coordination_probe(
         "state": "unknown",
         "reason": "status_timeout",
     }
+    # An unmeasured standalone cell must describe itself the way a measured one
+    # does (`LeaseManager.status()`), not contradict its own 200 payload.
+    assert snapshot["coordination"]["role"] == "standalone"
+    assert snapshot["coordination"]["coordinator_healthy"] is True
 
 
 def test_runtime_readiness_admits_a_slow_but_bounded_real_vault_snapshot(


### PR DESCRIPTION
`/health/ready` returns HTTP 503 `not_ready` on a standalone cell that has no coordinator, intermittently, whenever the box is under load. Observed on both local cells:

```
"status":"not_ready", "reasons":["coordination_status_timeout"]
"retrieval":{"state":"ready","admitted":true}
"coordination":{"enabled":false,...}
```

## Cause

`build_runtime_readiness` gates every coordination reason on `enabled` — except the status timeout, which was added just outside that block in #776.

The standalone path reaches it easily. `_bounded_coordination_status` gives the probe a 0.75 s deadline and the probe traverses graph state, so a busy vault blows it routinely; the fallback payload then sets `status_timed_out: True` with `enabled` read from `EXOMEM_WRITER_LEASE_URL`, which is unset. A subsystem that is switched off pins the cell to not-ready by timing out.

That contradicts the contract the endpoint was built to, in `openspec/changes/add-runtime-readiness-contract/specs/runtime-readiness-contract/spec.md`:

> Standalone Exomem SHALL remain ready without multi-host coordination.

So this is a restorative fix against an existing requirement, not a contract change, and it needs no new OpenSpec artifact.

## Change

Move the check inside `if enabled:`. A coordinated replica still fails closed and still fails fast — an unmeasured lease is exactly what takeover must not be attempted on. With no coordinator configured there is no lease to confirm and nothing about admission to report. `enabled` is safe to trust in the timed-out payload because it is read from the environment rather than from the probe that failed, and the timeout stays visible in the payload for operators.

## Tests

`test_runtime_readiness_fails_closed_within_a_tight_bound_when_status_blocks` asserted the standalone case the spec requires to stay ready. Its load-bearing assertion is the 1.25 s ceiling, not the reason list, so it is retargeted at the coordinated case where failing closed is correct, keeping the ceiling. The standalone case gets `test_standalone_readiness_survives_a_blocked_coordination_probe`.

Red-first, against the unfixed code:

```
>       assert snapshot["status"] == "ready"
E       AssertionError: assert 'not_ready' == 'ready'
```

Green after: `177 passed, 1 skipped` across `test_runtime_readiness.py test_resource_status.py test_auto_quiet.py test_accel.py test_doctor.py test_resource_envelope.py` (the skip is `test_doctor.py:1068`, no `sentence_transformers` in this venv). `ruff check` clean on the changed files.

## Scope note

This bug misreports to `doctor.py` and to the `writer_lease` takeover check, which are `/health/ready`'s only consumers — it is **not** a request gate. Nothing in the MCP tool-call path reads it, so it does not delay tool calls, and it is not the cause of any slow-recall symptom.

---

## Review

Independently reviewed by a fresh reviewer with no prior context: **ACCEPT**, 0 blockers, 0 high. It re-ran all gates, derived the reason ordering independently, and killed the mutation (moving the check back outside `if enabled:` fails the new standalone test).

It settled the "is gating the right fix or is it masking a slow probe?" question with prior art the original submission did not cite: `tests/test_readiness_honesty.py:100` already pins that a standalone cell whose probe *raises* stays `ready`, with the in-test comment *"a boundary we could not measure is a reporting gap, not a takeover-eligibility failure."* Before this change the **timeout** path contradicted the **error** path on identical facts. This makes them agree.

It also confirmed the blast radius is contained: `takeover_eligible` has two consumers, and `doctor.py:2364` independently requires `coordination.enabled is True`, so no consumer can act on a standalone cell's eligibility.

Two findings were folded in (commits 2 and 3):

- **MEDIUM** — the timeout and error fallbacks hardcoded `role: "unknown"` / `coordinator_healthy: False` regardless of `enabled`, contradicting `LeaseManager.status()`. Invisible behind a 503; not once this PR makes it a 200. Fixed at the source in one shared helper, applied to *both* paths, and pinned by the standalone test so it cannot silently regress.
- **LOW** — `replica_id` was read unstripped while `enabled` was stripped four lines away, so whitespace published as an identity and suppressed `replica_identity_missing`.

Plus coverage for the 4-reason variant (coordinated + timeout + no replica id), which no test exercised.

## Known follow-ups, not fixed here

Both are pre-existing in `_bounded_coordination_status`, untouched by this PR, and the reviewer agreed they can ship as-is:

- **A timed-out probe's result is reused later and published as current.** The registry entry is never reaped on timeout, so the next call returns the completed-but-stale result instantly — readiness can publish `mutation_boundary: free` from a measurement taken seconds earlier. This is the mechanism behind the 503/200 alternation the 0.25→0.75 s ceiling change was meant to fix, and it is the unfinished half of that work. Deserves its own change with its own test.
- **`_COORDINATION_PROBES` entries leak on timeout.** Bounded by vault count in production, so negligible.
