### PR TITLE
fix: find nvidia-smi where WSL actually puts it

### DIFF
--- a/openspec/changes/detect-co-tenant-gpu-pressure/.openspec.yaml
+++ b/openspec/changes/detect-co-tenant-gpu-pressure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/detect-co-tenant-gpu-pressure/design.md
+++ b/openspec/changes/detect-co-tenant-gpu-pressure/design.md
@@ -1,0 +1,56 @@
+# Design — co-tenant GPU pressure
+
+## Attribution is the core requirement
+
+`--query-gpu=utilization.gpu` returns one number for the whole device with no
+ownership. `nvidia-smi --query-compute-apps=pid,used_memory` attributes VRAM
+per process, which is what lets Exomem subtract itself before deciding whether
+a co-tenant needs the card.
+
+Two candidate mechanisms, to be settled during implementation:
+
+1. **Subtract our own PID** from the compute-apps listing. Direct, but
+   `--query-compute-apps` was measured (2026-09-04, this machine) to list only
+   graphics apps with `[N/A]` memory under WSL, so it may not attribute WSL
+   CUDA usage at all. Verify before relying on it.
+2. **Suppress the utilisation arm while this process holds a CUDA context.**
+   Weaker but robust: if Exomem is itself on the GPU, utilisation cannot be
+   read as a clean co-tenant signal, so fall back to the VRAM arm alone.
+
+Option 2 is the safe default if option 1 cannot be verified on the target
+platform. Either way the invariant is the same: **a mode restore must never
+re-arm the trigger that caused the demotion.**
+
+## Thresholds must bound against real need, not card size
+
+The rejected attempt scaled the pressure floor as 25% of total VRAM. Exomem's
+actual placement need is a constant 2048 MB, so the gap grew without bound: on
+an 80 GB card the floor became 20389 MB, declaring pressure with 20 GB free —
+about ten times what Exomem needs to run. At the other end, a 2 GB card gets a
+floor equal to 100% of its VRAM, making `free_mb < min_free` unsatisfiable and
+latching auto-quiet into permanent quiet.
+
+Any floor must therefore be bounded above by Exomem's real need plus a fixed
+headroom, and clamped strictly below `total_mb`.
+
+## An unreadable signal is not a quiet card
+
+The rejected attempt returned `utilization_pct: None` on an unparseable field
+and then treated `None` as "no pressure", emitting `status: capable,
+reason: None` — byte-identical to a genuinely idle card. Two reachable inputs
+produce it: a driver reporting `[N/A]`, and a GPU name containing a comma
+(the CSV is unquoted, so `name` before `utilization.gpu` shifts every later
+field). Put `name` last in the query, and surface an unread signal explicitly.
+
+## Open questions
+
+- Does `--query-compute-apps` attribute CUDA usage under WSL at all? Measured
+  once as listing only graphics apps with `[N/A]` memory. Decides mechanism 1
+  vs 2.
+- Does `utilization.gpu` inside WSL actually move when a Windows game runs?
+  Never verified with a game running; the card read 1-5% throughout. If it
+  does not track host load, the whole utilisation arm is the wrong sensor and
+  this change needs a different signal.
+- Multi-GPU hosts: `gpu_headroom()` reads `splitlines()[0]` only. A busy GPU 0
+  beside an idle GPU 1 yields `marginal` for the host. In scope for this
+  product or not?

--- a/openspec/changes/detect-co-tenant-gpu-pressure/proposal.md
+++ b/openspec/changes/detect-co-tenant-gpu-pressure/proposal.md
@@ -1,0 +1,48 @@
+# Detect co-tenant GPU pressure
+
+## Why
+
+Auto-quiet exists so Exomem yields the machine when something else needs the
+GPU. It cannot currently see the most common case.
+
+`resource_status.gpu_headroom()` queries only `memory.free,memory.total,name`.
+A game that has finished allocating its buffers sits at steady VRAM while
+pinning the shaders, so free VRAM alone reads that as a quiet card.
+`auto_quiet.pressure_active()` maps `marginal` to `True`, so auto-quiet sleeps
+through exactly the workload it exists to yield to.
+
+The operator's requirement, in their words: *"I just hope that somehow I can
+have WSL on and then game and have it all coexist, not mutually exclusive."*
+
+## What a naive fix gets wrong
+
+A first attempt (PR #1062, rejected on review) added `utilization.gpu` and
+reported `marginal` at or above 90%. That is not sufficient, because
+utilisation does not say *whose* work it is:
+
+- `accel.py` sets `want_cuda=(m == "performance")`, so in performance mode
+  Exomem's own embedding and ASR batches pin the card.
+- `auto_quiet.decide()` restores `previous_mode`, which is `performance`.
+
+The two compose into a self-sustaining limit cycle: pressure → demote to quiet
+→ Exomem's GPU work stops → pressure clears → restore to performance → work
+resumes → pressure. Roughly 100 seconds per cycle, rewriting the user's config
+file on disk twice each time and unloading/reloading every model singleton.
+Performance mode becomes unavailable most of the time, for precisely the users
+who opted into both features.
+
+The lesson is that a pressure signal must be attributable. "The GPU is busy" is
+not a reason to yield if Exomem is what is keeping it busy.
+
+## What changes
+
+Pressure detection distinguishes co-tenant load from Exomem's own, and reports
+an unreadable signal as unreadable rather than as absence of pressure.
+
+## Non-goals
+
+- Changing device placement. `accel.gpu_usable()` and
+  `EXOMEM_GPU_MIN_FREE_GB` keep their current meaning and threshold; this is
+  about when to yield, not where to put a model.
+- Multi-GPU scheduling. Reading only the first device is a known present
+  limitation and is recorded as an open question, not solved here.

--- a/openspec/changes/detect-co-tenant-gpu-pressure/specs/resource-governance/spec.md
+++ b/openspec/changes/detect-co-tenant-gpu-pressure/specs/resource-governance/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: Auto-Quiet Is Optional And Soft-Fail
+
+The system SHALL keep automatic quiet-mode switching disabled by default. When
+enabled, auto-quiet SHALL observe local machine pressure signals such as GPU
+pressure or memory pressure without importing torch or allocating CUDA solely for
+the probe. If probes are unavailable, fail, or are unsupported on the platform,
+auto-quiet SHALL log or report the unavailable signal and continue with manual
+mode behavior. Auto-quiet MUST NOT override an explicit `EXOMEM_MODE` environment
+pin.
+
+A pressure signal SHALL be attributable: load that Exomem itself generates SHALL
+NOT be reported as pressure. Restoring a previously recorded mode SHALL NOT
+re-arm the condition that caused the demotion. A pressure threshold SHALL be
+bounded against what Exomem actually needs to run rather than against total
+device capacity, and SHALL never be unsatisfiable on a supported device.
+
+#### Scenario: Auto-quiet is disabled by default
+
+- **WHEN** no auto-quiet configuration is enabled
+- **THEN** Exomem changes modes only through the existing manual mode controls
+
+#### Scenario: Pressure enters and leaves quiet
+
+- **WHEN** auto-quiet is enabled
+- **AND** the configured pressure signal remains active past the hysteresis window
+- **THEN** Exomem switches the config-file mode to `quiet` and records the prior
+  config-file mode
+- **AND** when pressure clears past the restore window, Exomem restores the prior
+  mode unless the user changed modes manually while pressure was active
+
+#### Scenario: Probe failure does not change mode
+
+- **WHEN** auto-quiet is enabled but every configured pressure probe is unavailable
+  or fails
+- **THEN** Exomem does not crash
+- **AND** Exomem does not change the current mode based on the failed probe
+
+#### Scenario: Exomem's own GPU work is not co-tenant pressure
+
+- **WHEN** auto-quiet is enabled and Exomem runs in a mode that places its own
+  models on the GPU
+- **AND** the device reports high utilization attributable to this process
+- **THEN** auto-quiet does not enter quiet mode
+- **AND** the mode the user selected remains in effect
+
+#### Scenario: A restored mode does not re-arm its own trigger
+
+- **WHEN** auto-quiet has entered quiet mode and the pressure signal clears
+- **AND** the restored mode resumes Exomem's own GPU work
+- **THEN** that work alone does not drive a further demotion
+- **AND** the configured mode remains stable rather than oscillating
+
+#### Scenario: The pressure signal cannot be read
+
+- **WHEN** a GPU pressure probe runs but reports a field it cannot parse
+- **THEN** the status reports the signal as unavailable rather than as absence of
+  pressure
+- **AND** the reported posture is distinguishable from a genuinely idle device
+
+#### Scenario: A pressure threshold stays satisfiable on a small device
+
+- **WHEN** the configured pressure threshold is resolved for a device whose total
+  capacity is at or below Exomem's own placement requirement
+- **THEN** the threshold does not exceed what the device can report as free
+- **AND** auto-quiet does not latch into quiet mode on an otherwise idle device

--- a/openspec/changes/detect-co-tenant-gpu-pressure/tasks.md
+++ b/openspec/changes/detect-co-tenant-gpu-pressure/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+- [ ] Measure whether `nvidia-smi --query-compute-apps=pid,used_memory`
+      attributes WSL CUDA usage. Record the output either way; it selects the
+      attribution mechanism.
+- [ ] Measure `utilization.gpu` from WSL with a Windows game running. If it
+      does not track host load, stop and revisit the sensor before building on
+      it.
+- [ ] Implement attribution so Exomem's own GPU work never reads as co-tenant
+      pressure.
+- [ ] Add a red-first test proving a performance-mode cell with Exomem's own
+      work on the GPU does NOT enter quiet, and that a mode restore cannot
+      re-arm its own trigger.
+- [ ] Bound the pressure floor against Exomem's real need and clamp it strictly
+      below `total_mb`; test at 2 GB, 4 GB, 16 GB and 80 GB, choosing sizes
+      where the bounding arms differ numerically.
+- [ ] Report an unreadable utilisation signal as unreadable, not as `capable`.
+      Reorder the query so `name` is last.
+- [ ] Provide an explicit disable sentinel for the utilisation arm, and reject
+      or clamp values outside `(0, 100]`.
+- [ ] Mutation-test every threshold boundary (`>=` vs `>`, `<` vs `<=`) and the
+      env lookups.

--- a/src/exomem/resource_status.py
+++ b/src/exomem/resource_status.py
@@ -208,8 +208,22 @@ def _min_free_vram_mb() -> int:
     return int(gb * 1024)
 
 
-def _probe_nvidia_smi() -> dict[str, Any]:
+#: WSL exposes the host driver here but does not put it on a login shell's PATH.
+#: Without this fallback `which` misses it, the probe reports `unknown`, and
+#: `auto_quiet.decide()` answers "pressure probe unavailable" forever — the
+#: detector fails silent rather than loud.
+_EXTRA_NVIDIA_SMI_PATHS = ("/usr/lib/wsl/lib/nvidia-smi",)
+
+
+def _find_nvidia_smi() -> str | None:
     exe = shutil.which("nvidia-smi")
+    if exe:
+        return exe
+    return next((p for p in _EXTRA_NVIDIA_SMI_PATHS if os.access(p, os.X_OK)), None)
+
+
+def _probe_nvidia_smi() -> dict[str, Any]:
+    exe = _find_nvidia_smi()
     if not exe:
         return {"status": "unavailable", "reason": "nvidia-smi not found"}
     try:

--- a/tests/test_resource_status.py
+++ b/tests/test_resource_status.py
@@ -175,3 +175,58 @@ def test_status_cli_json_is_resource_status(monkeypatch, capsys, tmp_path: Path)
     assert data["mode"] == "normal"
     assert data["policy"]["retain_cpu_caches"] is False
     assert data["cuda"]["torch_imported"] is False
+
+
+def _hide_from_which(monkeypatch, name: str) -> None:
+    """Make `shutil.which` miss one name only.
+
+    `shutil.which` is a module global that pytest's own error reporting also
+    calls (`which("git", path=...)`). A blanket stub with an incompatible
+    signature turns any failure in these tests into an INTERNALERROR that hides
+    the real assertion.
+    """
+    real = resource_status.shutil.which
+
+    def _which(cmd, *args, **kwargs):
+        return None if cmd == name else real(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(resource_status.shutil, "which", _which)
+
+
+def test_nvidia_smi_is_found_off_path_under_wsl(monkeypatch, tmp_path: Path) -> None:
+    """WSL exposes the host driver but leaves it off a login shell's PATH.
+
+    Missing it makes the probe report `unknown`, which auto_quiet.decide() turns
+    into "pressure probe unavailable" — the detector fails silent, not loud.
+    """
+    shim = tmp_path / "nvidia-smi"
+    shim.write_text("#!/bin/sh\n")
+    shim.chmod(0o755)
+    _hide_from_which(monkeypatch, "nvidia-smi")
+    monkeypatch.setattr(resource_status, "_EXTRA_NVIDIA_SMI_PATHS", (str(shim),))
+
+    assert resource_status._find_nvidia_smi() == str(shim)
+
+
+def test_a_non_executable_fallback_is_not_treated_as_a_probe(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """os.X_OK, not existence: a present-but-unrunnable path is not a probe."""
+    shim = tmp_path / "nvidia-smi"
+    shim.write_text("#!/bin/sh\n")
+    shim.chmod(0o644)
+    _hide_from_which(monkeypatch, "nvidia-smi")
+    monkeypatch.setattr(resource_status, "_EXTRA_NVIDIA_SMI_PATHS", (str(shim),))
+
+    assert resource_status._find_nvidia_smi() is None
+
+
+def test_gpu_headroom_is_unknown_when_no_probe_exists(monkeypatch) -> None:
+    _forbid_torch_import(monkeypatch)
+    _hide_from_which(monkeypatch, "nvidia-smi")
+    monkeypatch.setattr(resource_status, "_EXTRA_NVIDIA_SMI_PATHS", ())
+
+    gpu = resource_status.gpu_headroom()
+
+    assert gpu["status"] == "unknown"
+    assert gpu["usable"] is None


### PR DESCRIPTION
**Rescoped after review.** This PR originally added utilisation-based GPU pressure detection. An independent reviewer rejected that on a BLOCKER, verified and accepted — see below. What remains is the one piece that was sound on its own.

## The fix

`shutil.which("nvidia-smi")` returns nothing in a WSL login shell. The host driver is exposed at `/usr/lib/wsl/lib/nvidia-smi`, and the running service only finds it because `service.env` pins that directory into `PATH`.

Without it, `_probe_nvidia_smi` reports `status: unknown` → `auto_quiet.pressure_active()` returns `None` → `auto_quiet.decide()` answers `"pressure probe unavailable"` indefinitely. Auto-quiet is permanently inert on every WSL host while looking exactly like a working system. Verified both ways on this machine:

```
$ .venv/bin/python -c "from exomem import resource_status; print(resource_status.gpu_headroom())"
{'status': 'unknown', 'usable': None, 'reason': 'nvidia-smi not found', 'min_free_mb': 2048}

$ PATH="/usr/lib/wsl/lib:$PATH" .venv/bin/python -c "..."
{'status': 'capable', 'usable': True, 'free_mb': 12792, 'total_mb': 16303, 'name': 'NVIDIA GeForce RTX 5080', ...}
```

`os.access(p, os.X_OK)` rather than an existence check, so a present-but-unrunnable path is not mistaken for a probe.

## Tests

Three, all mutation-proven:

| mutation | result |
|---|---|
| remove the fallback | **killed** — `test_nvidia_smi_is_found_off_path_under_wsl` |
| `os.access(p, os.X_OK)` → `os.path.exists(p)` | **killed** — `test_a_non_executable_fallback_is_not_treated_as_a_probe` |

The second test exists because the reviewer's mutation matrix showed that check was unpinned in the original submission.

```
72 passed in 2.29s     # test_resource_status.py test_auto_quiet.py test_accel.py
All checks passed!     # ruff
```

`_hide_from_which` narrows the `shutil.which` stub to one name: a blanket stub with an incompatible signature breaks pytest's own error reporting, which calls `which("git", path=...)`, turning any failure in these tests into an `INTERNALERROR` that hides the real assertion.

## Why the rest was dropped

The reviewer found that the utilisation arm makes Exomem read **its own** GPU work as external pressure. `accel.py:188` sets `want_cuda=(m == "performance")`, and `auto_quiet.py:116,135` restores `previous_mode` — which is `performance`. The result is a self-sustaining ~100-second limit cycle: demote to quiet, GPU work stops, pressure clears, restore to performance, work resumes, pressure returns. Each cycle rewrites the user's config file on disk twice and unloads/reloads every model singleton. The hysteresis does not damp it; it only sets the period.

Two further findings stand:

- A `[N/A]` utilisation reading (or a GPU name containing a comma, which shifts every CSV field) silently produced `capable` — byte-identical to an idle card, and the exact silent failure the discovery fix above exists to remove.
- The proportional VRAM floor scaled on card size, while Exomem's real need is a constant 2048 MB. On an 80 GB card it called 20 GB free `marginal`. Its own test picked the one card size where both arms of the `max()` are numerically identical, so it never exercised the behaviour it was named for.

That work returns under its own OpenSpec change, which it owes: it introduces two operator-facing env vars, creates two divergent "configured free-VRAM thresholds" where `resource-governance` says one, and redefines that spec's own word `marginal`.

Nothing in this PR touches `accel.gpu_usable()`, `EXOMEM_GPU_MIN_FREE_GB`, or the `marginal` semantics, so no spec surface moves and no OpenSpec change is owed here.
