### PR TITLE
test(state-root): wait for the marker child to exec before scanning for it

### DIFF
--- a/tests/test_state_root_guard.py
+++ b/tests/test_state_root_guard.py
@@ -38,6 +38,7 @@ import contextlib
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -334,6 +335,30 @@ def test_concurrent_scan_excludes_its_own_ancestor_chain_but_not_a_genuine_third
         executable="/bin/sleep",
     )
     try:
+        # `Popen` returns once the fork succeeds, not once the child has exec'd,
+        # so `/proc/<pid>/cmdline` can still be empty (or the parent's argv) when
+        # the scan below reads it. Scanning immediately therefore races the exec
+        # and reports a genuine third party as absent -- observed three times in
+        # CI on a loaded runner, never on an idle one. Wait for the premise, then
+        # assert the contract: the scan is still being asked whether it reports a
+        # process that demonstrably exists with a matching argv, so the wait
+        # cannot make the assertion below vacuous.
+        deadline = time.monotonic() + 10.0
+        marker_argv = b""
+        while time.monotonic() < deadline:
+            try:
+                marker_argv = Path(f"/proc/{marker.pid}/cmdline").read_bytes()
+            except OSError:  # the child may not have a /proc entry yet
+                marker_argv = b""
+            if b"fake-pytest-marker-should-be-reported" in marker_argv:
+                break
+            time.sleep(0.02)
+        assert b"fake-pytest-marker-should-be-reported" in marker_argv, (
+            "precondition: the marker child never exec'd into an argv the scan "
+            f"could match within 10s (pid {marker.pid}); the assertion below "
+            "would prove nothing about the exclusion logic"
+        )
+
         matches = _matching_processes(ancestors | {own_pid})
         matched_pids = {pid for pid, _cmdline in matches}
         assert marker.pid in matched_pids, (


### PR DESCRIPTION
## The flake

`tests/test_state_root_guard.py::test_concurrent_scan_excludes_its_own_ancestor_chain_but_not_a_genuine_third_party` has failed three CI runs, twice blocking a release:

- PR #1059, `core tests (py3.13, shard 2/12)`
- a `main` run the same day, `core tests (py3.13, shard 1/12)` — a different shard, which is what rules out a sharding artefact
- the dispatched release-evidence run on `main`, `core tests (py3.11, shard 2/12)`

Always the same assertion: `genuine third-party marker process (pid ...) was not reported`.

## Why

The test spawns `/bin/sleep` with a marker argv and immediately scans `/proc` for it. `Popen` returns once the fork succeeds, not once the child has exec'd, so `/proc/<pid>/cmdline` can still be empty when the scan reads it. The scan then correctly reports that nothing matches, and the test blames the exclusion logic.

Measured on an idle box, 200 trials, reading `/proc/<pid>/cmdline` immediately after `Popen` exactly as the test did:

```
trials: 200
argv NOT yet visible on the immediate read: 66  (33.0%)
time until visible, ms: min 0.0  median 0.0  max 1.2
```

The window is short, and the scan itself walks `/proc`, which usually hands the child that millisecond. That is why it passes locally and fails on a loaded runner.

## The fix

Wait for the premise, do not weaken the assertion. The test now polls `/proc/<pid>/cmdline` for the marker under a 10 second bound, asserts the child demonstrably exec'd into a matching argv, and only then runs the scan.

This cannot make the assertion vacuous: the scan is still being asked whether it reports a process that genuinely exists with an argv it should match. Waiting establishes that the process exists; the assertion is still about whether the scan finds it. A child that never execs now fails saying the precondition was not met, rather than accusing the code under test.

## Verification

- The named node, five consecutive runs: `1 passed` each, 0.13 to 0.20 s.
- The whole file: `9 passed in 0.24s`.
- Test-only change, one file.
