### PR TITLE
fix(audit): resolve KB-relative supersession pointers

### DIFF
--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -4550,7 +4550,14 @@ def _check_supersession_integrity(
         target = _supersession_link_target(raw)
         if not target:
             return None
-        for candidate in (target, f"{target}.md"):
+        # `known` holds vault-relative paths, while a supersession pointer is
+        # normally written KB-relative -- `[[Notes/Insights/x]]`, the spelling the
+        # write tools document as tolerated and the one the vault's own pages
+        # use. Without the prefixed candidate every such pointer resolves to
+        # nothing and an intact chain is reported as rot, which is indis-
+        # tinguishable from the rot this check exists to find.
+        prefixed = target if target.startswith(kb_prefix()) else f"{kb_prefix()}{target}"
+        for candidate in (target, f"{target}.md", prefixed, f"{prefixed}.md"):
             if candidate in known:
                 return candidate if candidate.endswith(".md") else f"{candidate}.md"
         # A bare name is a legitimate Obsidian spelling; resolve it only when it
@@ -4563,7 +4570,7 @@ def _check_supersession_integrity(
                 return matches[0]
         # Last resort: the page may live outside the walked set (a curated tree),
         # so believe the filesystem before calling a pointer broken.
-        for candidate in (target, f"{target}.md"):
+        for candidate in (target, f"{target}.md", prefixed, f"{prefixed}.md"):
             if (vault_root / candidate).exists():
                 return candidate if candidate.endswith(".md") else f"{candidate}.md"
         return None

--- a/tests/test_due_state_projection.py
+++ b/tests/test_due_state_projection.py
@@ -1113,3 +1113,42 @@ def test_a_malformed_bucket_does_not_cost_a_page_write_its_delta(vault: Path) ->
     assert updated["emission"]["writes"] == before + 1
     assert due_state_module._unbucket(["not", "a", "bucket"]) == []
     assert due_state_module.load(vault)["emission"]["writes"] == before + 1
+
+
+def test_a_kb_relative_supersession_pointer_resolves(vault: Path) -> None:
+    """`[[Notes/...]]` is the spelling the vault's own pages use.
+
+    Supersession pointers are written as KB-relative wikilinks, without the
+    `Knowledge Base/` prefix — the form the write tools document as tolerated.
+    The resolver tries the raw target, the target plus `.md`, an unambiguous bare
+    stem, and the filesystem at `vault_root / target`, and none of those reach a
+    page stored under the prefix.
+
+    Every other test in this module writes the prefixed spelling, which is why
+    the gap went unmeasured: on a real vault it reported 145 intact chains as
+    broken, and a reader cannot distinguish that from the rot the check exists
+    to find.
+    """
+    real = _prediction(vault, "successor", check_by="2026-12-01")
+    kb_relative = real.removeprefix("Knowledge Base/").removesuffix(".md")
+    assert not kb_relative.startswith("Knowledge Base/")
+
+    _dangling(vault, "old", target=kb_relative)
+    due_state_module.reconcile(vault, today=TODAY)
+
+    served = _served(vault)
+    # `served` is None when nothing is due at all, which is the outcome here:
+    # the chain resolves, so the projection has no row to publish.
+    counted = 0 if served is None else served["categories"].get("supersession_integrity", 0)
+    assert counted == 0, (
+        "a pointer naming an existing page KB-relative was reported as dangling"
+    )
+
+
+def test_a_genuinely_dangling_pointer_is_still_reported(vault: Path) -> None:
+    """The control: accepting the prefix must not blind the check to real rot."""
+    _dangling(vault, "old", target="Notes/Insights/nowhere-at-all")
+    due_state_module.reconcile(vault, today=TODAY)
+
+    served = _served(vault)
+    assert served["categories"]["supersession_integrity"] == 1


### PR DESCRIPTION
## Why

The supersession-integrity check reports intact chains as broken. On the live vault that is **145 of 158 due review items — 92% of the epistemic inbox backlog.**

`_check_supersession_integrity` builds its `known` set from `page.rel_path`, which is vault-relative (`Knowledge Base/Notes/...`). A supersession pointer is normally written KB-relative — `[[Notes/Insights/x]]` — which is the spelling the write tools document as tolerated and the one the vault's own pages actually use.

`_resolve` tries four things, and none of them reach a page stored under the prefix:

1. the raw target — not in `known`
2. the target plus `.md` — not in `known`
3. an unambiguous bare stem — skipped, the target has slashes
4. the filesystem at `vault_root / target` — `vault_root/Notes/...` does not exist

So it returns `None` and the pointer is reported dangling.

## The chains are intact

Sampled pairs resolve in both directions. `…recovery-v2-182-of-362` names `…recovery-v3-211-of-362-rows-with-zero-opaque-i-o` as its successor; that page exists, and its own frontmatter names v2 back as `supersedes`. Both were flagged. The same shape appears in the `Notes/Failures/` pair.

This matters beyond the noise: the check's own message says a reader "cannot tell a page that was never superseded from one whose forward link rotted" — and while 92% of its output is false, neither can a reader tell a real defect from this.

## Why it went unmeasured

Every existing test in `test_due_state_projection.py` writes the **prefixed** spelling (`INSIGHTS = "Knowledge Base/Notes/Insights"`). The form real notes use was never exercised.

This PR adds the KB-relative case and a control asserting genuine rot is still reported, so accepting the prefix cannot blind the check.

## Verification

- Red-first: with the fix reverted, `AssertionError: a pointer naming an existing page KB-relative was reported as dangling`. The control passes before and after.
- `test_due_state_projection.py`, `test_due_state_consumers.py`, `test_audit.py`, `test_epistemic_review_queues.py` — **167 passed, 0 failed.** The 147 errors on this machine are all one environmental guard (`a test touched the real user state root`), tripped by the live exomem service and concurrent sandboxes writing to the machine-global state root; verified as the only error type present, and pristine `origin/main` errors the same way here.
- `uvx ruff check --select F` clean.

## Scope

A restorative fix to a measurement, not a contract change — no OpenSpec change filed, per the repo's rule that routine restorative fixes do not need one. It repairs no data: the pointers were always correct, only the reader was wrong.
