### PR TITLE
fix(recall): preserve write custody during reconciliation

### DIFF
--- a/.github/workflows/release-evidence-automation.yml
+++ b/.github/workflows/release-evidence-automation.yml
@@ -35,6 +35,10 @@ permissions:
   contents: read
   pull-requests: read
 
+# These jobs deliberately have no checkout for gh to infer a repository from.
+env:
+  GH_REPO: ${{ github.repository }}
+
 # A disable/re-enable pair (or a double-click) fires auto_merge_enabled twice;
 # without serialization both jobs can pass the eligibility check before either
 # dispatch is visible, yielding two full-tier runs. Queue, don't cancel — a

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -75,9 +75,9 @@ def _load_golden(path: Path) -> list[dict]:
             continue
         relevant = {p for p, g in relevance.items() if g > 0}
         # Per-query retrieval scope. Defaults to "kb-only" so every existing entry
-        # scores exactly as before (KB-only, no auto-widen). An entry whose target
-        # lives OUTSIDE Knowledge Base/ sets `scope: kb` to exercise the auto-widen
-        # reserve (the out-of-KB slots find() reserves under the default kb scope).
+        # scores exactly as before (KB-only, no widening). The golden format's
+        # historical `scope: kb` explicitly requests the outside-KB reserve;
+        # find() now requires that opt-in separately from the scope.
         scope = entry.get("scope", "kb-only")
         out.append({
             "query": query, "relevance": relevance, "relevant": relevant, "scope": scope,
@@ -106,11 +106,10 @@ def _evaluate(
             query=g["query"],
             limit=k_max,
             mode=mode,
-            # Per-query scope (default "kb-only"): most golden targets are KB paths,
-            # so KB-only skips the auto-widen scan over the wider vault that would
-            # dominate eval wall-time. An entry targeting an out-of-KB page sets
-            # `scope: kb` to deliberately exercise that auto-widen reserve.
+            # Preserve the golden format's reserve cases without changing
+            # find()'s KB-only product default or the golden relevance labels.
             scope=g.get("scope", "kb-only"),
+            widen_outside_kb=g.get("scope", "kb-only") == "kb",
             rerank=rerank,
             config=config,
         )
@@ -149,7 +148,7 @@ def rank_queries(
     for q in queries:
         hits = find_module.find(
             vault_root, query=q, limit=k, mode="hybrid",
-            scope="kb-only",  # mined-pair targets are KB paths; skip the auto-widen scan
+            scope="kb-only",  # mined-pair targets are KB paths; no outside-KB reserve
             rerank=rerank, config=config,
         )
         out[q] = [_canon(h.path) for h in hits]
@@ -264,6 +263,7 @@ def _sample_latencies(
             find_module.find(
                 vault_root, query=g["query"], limit=k, mode=mode,
                 scope=g.get("scope", "kb-only"), rerank=rerank, config=config,
+                widen_outside_kb=g.get("scope", "kb-only") == "kb",
             )
             latencies.append((time.perf_counter() - t0) * 1000.0)
     return latencies

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -2166,8 +2166,15 @@ class EpistemicGraphIndex:
             (str(path), freshness.stat_signature(path))
             for path in vault_module.walk_vault_md(self.vault_root)
         )
-        freshness.reconcile(self.vault_root, "vault", entries)
-        if pending is not None:
+        result = freshness.reconcile(
+            self.vault_root,
+            "vault",
+            entries,
+            publication_guard=self._mutation_coordinator.hold(
+                operation="epistemic_graph_reconcile_recall", holder_kind="graph"
+            ),
+        )
+        if result.published and pending is not None:
             freshness.clear_external_pending(self.vault_root, through=pending)
 
     @staticmethod

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -352,7 +352,12 @@ class FileWatcher:
     """Watch Knowledge Base/ for `.md` changes and re-embed them, debounced."""
 
     def __init__(self, vault_root: Path, *, debounce_seconds: float | None = None) -> None:
+        from .writer_lease import active_manager
+
         self._vault_root = vault_root
+        # Retain the invoking manager: background threads do not inherit its
+        # ContextVar, and publication must contend with that same writer.
+        self._freshness_manager = active_manager()
         self._kb_root = vault_root / kb_dirname()
         self._debounce_override = debounce_seconds
         self._lock = threading.Lock()
@@ -601,7 +606,18 @@ class FileWatcher:
                 if seed:
                     freshness.seed(self._vault_root, scope, self._walk_entries(scope))
                 else:
-                    delta = freshness.reconcile(self._vault_root, scope, self._walk_entries(scope))
+                    delta = freshness.reconcile(
+                        self._vault_root,
+                        scope,
+                        self._walk_entries(scope),
+                        publication_guard=self._freshness_manager.consistency_guard(
+                            self._vault_root,
+                            operation="watcher_reconcile_freshness",
+                            holder_kind="background",
+                        ),
+                    )
+                    if not delta.published:
+                        baselines_current = False
                     if delta.drifted:
                         drifted = True
                         # vault ⊇ kb, so a KB file lands in both deltas — dedupe

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -64,6 +64,7 @@ import threading
 import uuid
 from collections import deque
 from collections.abc import Callable, Iterable, Mapping
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple, overload
@@ -88,6 +89,9 @@ class ReconcileDelta(NamedTuple):
     drifted: bool
     changed: list[str]
     deleted: list[str]
+    # A walk superseded by invalidation did not establish a new baseline and
+    # must not acknowledge an external event merely because it found no drift.
+    published: bool = True
 
 
 FileSignature = tuple[int, int, int]
@@ -1104,7 +1108,11 @@ def seed(vault_root: Path, scope: str, entries: Iterable[tuple[str, SignatureLik
 
 
 def reconcile(
-    vault_root: Path, scope: str, entries: Iterable[tuple[str, SignatureLike]]
+    vault_root: Path,
+    scope: str,
+    entries: Iterable[tuple[str, SignatureLike]],
+    *,
+    publication_guard: AbstractContextManager[object] | None = None,
 ) -> ReconcileDelta:
     """Replace the map from a fresh walk; return the drift delta.
 
@@ -1114,15 +1122,25 @@ def reconcile(
     changed/deleted paths (this function holds both the old map and the fresh
     walk) so the caller can dispatch them through the event fan-out; the map is
     always fully replaced regardless of what the caller does with the delta.
+
+    Production callers supply the canonical writer's publication guard. The
+    walk and policy projection stay off-boundary; only the final map swap waits
+    for an in-flight writer's event. Its retained target state then wins over
+    any observation made between canonical replacement and event publication.
     """
+    from . import recall_policy
+
     key = _key(vault_root, scope)
     replacement_lock, replacement_epoch = _begin_replacement(key)
     try:
         fresh = {sp: _normalize_signature(signature) for sp, signature in entries}
         recall_fresh, recall_identity = _project_recall_entries(vault_root, fresh.items())
-        with _lock:
-            if not _replacement_is_current(key, replacement_epoch):
-                return ReconcileDelta(drifted=False, changed=[], deleted=[])
+        with (publication_guard if publication_guard is not None else nullcontext()), _lock:
+            if (
+                not _replacement_is_current(key, replacement_epoch)
+                or recall_policy.recall_policy_identity(vault_root) != recall_identity
+            ):
+                return ReconcileDelta(drifted=False, changed=[], deleted=[], published=False)
             _merge_replacement_pending(key, fresh, recall_fresh)
             old = _maps.get(key)
             # The map swap and the drift generation/history transition happen in ONE

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -814,6 +814,66 @@ def test_release_evidence_automation_removes_both_manual_cranks() -> None:
     }
 
 
+@pytest.mark.parametrize("job_name", ["dispatch-evidence", "rerun-evidence-check"])
+@pytest.mark.skipif(os.name != "posix", reason="executes the Ubuntu workflow's Bash step")
+def test_release_evidence_commands_work_without_a_checkout(tmp_path: Path, job_name: str) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/release-evidence-automation.yml").read_text(encoding="utf-8")
+    )
+    job = workflow["jobs"][job_name]
+    step = next(step for step in job["steps"] if "run" in step)
+    executable = tmp_path / "gh"
+    executable.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "args = sys.argv[1:]\n"
+        "if args[0] == 'api':\n"
+        "    endpoint = args[1]\n"
+        "    if endpoint.endswith('/commits/main'):\n"
+        "        print('tested-base')\n"
+        "    elif '/pulls?' in endpoint:\n"
+        "        print(json.dumps({'base': {'sha': 'tested-base'}, 'head': {'sha': 'release-head'}}))\n"
+        "    elif 'event=pull_request' in endpoint:\n"
+        "        print('123')\n"
+        "    else:\n"
+        "        print('0')\n"
+        "elif args[:2] in (['workflow', 'run'], ['run', 'rerun']):\n"
+        "    if os.environ.get('GH_REPO') != 'example/project':\n"
+        "        sys.exit('fatal: not a git repository; explicit repository context is missing')\n"
+        "    print('submitted: ' + ' '.join(args))\n"
+        "else:\n"
+        "    sys.exit('unexpected gh command')\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+
+    def render(value: str) -> str:
+        return value.replace("${{ github.repository }}", "example/project").replace(
+            "${{ github.repository_owner }}", "example"
+        )
+
+    env = dict(os.environ)
+    env.pop("GH_REPO", None)
+    for scope in (workflow, job, step):
+        env.update({key: render(str(value)) for key, value in scope.get("env", {}).items()})
+    env.update({
+        "PATH": str(tmp_path) + os.pathsep + env["PATH"],
+        "BASE_SHA": "tested-base",
+        "EVIDENCE_SHA": "tested-base",
+    })
+    result = subprocess.run(
+        ["bash", "-e", "-c", render(step["run"])],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    expected = (
+        "workflow run ci.yml --ref main"
+        if job_name == "dispatch-evidence"
+        else "run rerun 123 --failed"
+    )
+    assert "submitted: " + expected in result.stdout
+
+
 #: The worst cross-platform session observed, in seconds. A floor rather than a
 #: maximum: three six-way Windows shards were censored at the 2700s cap they hit,
 #: so the true worst is at least this.

--- a/tests/test_deferred_work_drain.py
+++ b/tests/test_deferred_work_drain.py
@@ -549,7 +549,7 @@ def test_zero_live_cap_periodic_drain_progresses_without_overspending_drift(
     monkeypatch.setattr(
         file_watcher.freshness,
         "reconcile",
-        lambda *_a, **_kw: SimpleNamespace(drifted=True, changed=(), deleted=()),
+        lambda *_a, **_kw: file_watcher.freshness.ReconcileDelta(True, [], []),
     )
     monkeypatch.setattr(
         watcher,
@@ -674,7 +674,7 @@ def test_reconcile_drift_spends_budget_before_deferred_drain(
     monkeypatch.setattr(
         file_watcher.freshness,
         "reconcile",
-        lambda *_a, **_kw: SimpleNamespace(drifted=True, changed=(), deleted=()),
+        lambda *_a, **_kw: file_watcher.freshness.ReconcileDelta(True, [], []),
     )
     monkeypatch.setattr(
         file_watcher.media_processing, "reconcile_all_media", lambda *_a, **_kw: 0

--- a/tests/test_eval_retrieval_scope.py
+++ b/tests/test_eval_retrieval_scope.py
@@ -1,0 +1,73 @@
+"""The historical golden scopes keep their meaning after opt-in widening."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def evaluator(monkeypatch: pytest.MonkeyPatch):
+    spec = importlib.util.spec_from_file_location(
+        "eval_retrieval_scope_test", ROOT / "scripts" / "eval_retrieval.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    # The standalone evaluator enables embeddings on import. Keep that change
+    # local to the import so a lean test cannot alter later tests' environment.
+    with monkeypatch.context() as env:
+        env.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+        spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("scope", [None, "kb-only", "kb", "vault"])
+@pytest.mark.parametrize("operation", ["quality", "latency"])
+def test_golden_scope_explicitly_requests_its_historical_reserve(
+    evaluator, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, scope, operation
+) -> None:
+    calls = []
+
+    def find(_root, **kwargs):
+        calls.append(kwargs)
+        return [SimpleNamespace(path="Knowledge Base/Notes/example.md")]
+
+    monkeypatch.setattr(evaluator.find_module, "find", find)
+    entry = {
+        "query": "example",
+        "relevance": {"notes/example": 1.0},
+        "relevant": {"notes/example"},
+    }
+    if scope is not None:
+        entry["scope"] = scope
+    config = evaluator.find_module.DEFAULT_RANKING
+    if operation == "quality":
+        result = evaluator._evaluate(tmp_path, [entry], config, rerank=False)
+        assert result["recall10"] == 1.0
+    else:
+        assert len(evaluator._sample_latencies(
+            tmp_path, [entry], config, mode="hybrid", rerank=False, repeat=2
+        )) == 2
+
+    assert calls
+    for call in calls:
+        assert call["scope"] == (scope or "kb-only")
+        assert call.get("widen_outside_kb", False) is (scope == "kb")
+
+
+def test_existing_outside_kb_golden_target_is_still_retrieved(evaluator, vault: Path) -> None:
+    from exomem import lexstore
+
+    golden = evaluator._load_golden(ROOT / "tests" / "golden" / "queries.yaml")
+    reserve_cases = [entry for entry in golden if entry["scope"] == "kb"]
+    assert reserve_cases, "the golden corpus must retain its outside-KB reserve case"
+    lexstore.ensure_fresh(vault)
+    result = evaluator._evaluate(
+        vault, reserve_cases, evaluator.find_module.DEFAULT_RANKING,
+        rerank=False, mode="keyword",
+    )
+    assert all(row["recall10"] > 0 for row in result["rows"])

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -270,6 +271,36 @@ def test_scope_boundary_schema_dir_updates_neither(vault: Path) -> None:
 
 
 # ---------------- reconcile() ----------------
+
+
+def test_policy_change_before_publication_supersedes_the_off_boundary_projection(
+    vault: Path,
+) -> None:
+    from exomem import recall_policy
+
+    _seed_both_scopes(vault)
+    before = freshness.consumer_checkpoint(vault, "kb")
+    old_identity = recall_policy.recall_policy_identity(vault)
+    entries = [
+        (str(path), freshness.stat_signature(path))
+        for path in find_module._walk_md(vault / "Knowledge Base")
+    ]
+
+    @contextmanager
+    def policy_writer_finishes():
+        # The projection is already prepared when the publication guard is
+        # entered. Model a policy-tightening writer completing during that wait.
+        (vault / "Knowledge Base" / "_access.yaml").write_text(
+            "excluded:\n  - Notes\n", encoding="utf-8"
+        )
+        assert recall_policy.recall_policy_identity(vault) != old_identity
+        yield
+
+    result = freshness.reconcile(
+        vault, "kb", entries, publication_guard=policy_writer_finishes()
+    )
+    assert result.published is False
+    assert freshness.consumer_checkpoint(vault, "kb") == before
 
 
 def test_reconcile_detects_and_heals_a_missed_event(vault: Path) -> None:

--- a/tests/test_graph_rebuild_locking.py
+++ b/tests/test_graph_rebuild_locking.py
@@ -585,6 +585,10 @@ def test_graph_swap_waits_for_a_real_lease_manager_writer(
     )
     monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
     index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    # This test targets the private build/final sidecar swap. Establish its
+    # recall baseline first: cold registry publication itself now correctly
+    # waits for a writer's canonical-bytes/freshness-event boundary.
+    index._reconcile_recall_publication()
     writer_entered = threading.Event()
     release_writer = threading.Event()
     private_build_finished = threading.Event()

--- a/tests/test_recall_read_cache_custody.py
+++ b/tests/test_recall_read_cache_custody.py
@@ -31,6 +31,7 @@ import os
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -252,6 +253,134 @@ def test_a_burst_of_distinct_writes_leaves_every_cache_row_current(
     )
     for rel in (_ALPHA, _BETA, _GAMMA):
         assert lexstore.page_content_hashes(vault, [rel])[rel] == _digest(vault, rel)
+
+
+@pytest.mark.parametrize("reconciler", ["graph", "watcher"])
+def test_reconciliation_waits_for_a_governed_writes_freshness_publication(
+    vault: Path, warm_managed_cell, monkeypatch: pytest.MonkeyPatch, reconciler: str
+) -> None:
+    """The disk/event gap is not evidence of a receipt-less external edit."""
+    from exomem import epistemic_graph, mutation_lock
+    from exomem import vault as vault_module
+
+    _seed(vault, _ALPHA, "Custody alpha", "alpha-seed")
+    _warm(vault, warm_managed_cell)
+    graph = epistemic_graph.EpistemicGraphIndex(vault)
+    watcher = file_watcher.FileWatcher(vault)
+    advanced = threading.Event()
+    registry_published = threading.Event()
+    errors: list[BaseException] = []
+    phases: list[str] = []
+    published_inside_write: list[bool] = []
+    worker: threading.Thread | None = None
+    writer_thread = threading.current_thread()
+    original_hold = mutation_lock.VaultMutationCoordinator.hold
+    original_walk = vault_module.walk_vault_md
+    original_watcher_walk = watcher._walk_entries
+    original_reconcile = freshness.reconcile
+    original_publish = index_sync.publish_corpus_delta
+
+    def our_thread() -> bool:
+        return threading.current_thread() is worker
+
+    @contextmanager
+    def hold(coordinator, **kwargs):
+        if our_thread() and kwargs.get("operation") in {
+            "epistemic_graph_reconcile_recall", "watcher_reconcile_freshness"
+        }:
+            phases.append("publication_attempt")
+            advanced.set()
+        with original_hold(coordinator, **kwargs):
+            yield
+
+    def walk(root):
+        yield from original_walk(root)
+        if our_thread():
+            phases.append("walk_complete")
+
+    def watcher_walk(scope):
+        yield from original_watcher_walk(scope)
+        if our_thread():
+            phases.append("walk_complete")
+
+    def reconcile_registry(*args, **kwargs):
+        result = original_reconcile(*args, **kwargs)
+        if our_thread():
+            phases.append("registry_published")
+            registry_published.set()
+            advanced.set()
+        return result
+
+    def publish_delta(root, **kwargs):
+        result = original_publish(root, **kwargs)
+        if threading.current_thread() is writer_thread and vault / _ALPHA in kwargs.get("changed", ()):
+            phases.append("receipt_published")
+        return result
+
+    def reconcile():
+        try:
+            if reconciler == "graph":
+                graph._reconcile_recall_publication()
+            else:
+                watcher._reconcile_once(seed=False)
+        except BaseException as error:  # noqa: BLE001 - assert thread failures in the parent
+            errors.append(error)
+        finally:
+            advanced.set()
+
+    def after_destination(path):
+        nonlocal worker
+        if path != vault / _ALPHA:
+            return
+        # The real writer still owns canonical authority and has not called
+        # publish_corpus_delta. Advance the other thread all the way through
+        # its walk to either publication contention or (incorrect) completion.
+        worker = threading.Thread(target=reconcile, daemon=True)
+        worker.start()
+        assert advanced.wait(10), "reconciliation did not reach its publication boundary"
+        published_inside_write.append(registry_published.is_set())
+
+    monkeypatch.setattr(mutation_lock.VaultMutationCoordinator, "hold", hold)
+    monkeypatch.setattr(vault_module, "walk_vault_md", walk)
+    monkeypatch.setattr(watcher, "_walk_entries", watcher_walk)
+    monkeypatch.setattr(freshness, "reconcile", reconcile_registry)
+    monkeypatch.setattr(index_sync, "publish_corpus_delta", publish_delta)
+    monkeypatch.setattr(vault_module, "_after_batch_destination_published", after_destination)
+    freshness.reset_custody_telemetry()
+    try:
+        _govern(vault, _ALPHA, "Custody alpha", "alpha-racing-reconcile")
+    finally:
+        if worker is not None:
+            worker.join(15)
+    assert worker is not None and not worker.is_alive()
+    assert errors == []
+    assert published_inside_write == [False], "reconcile published inside the disk/event gap"
+    assert phases.index("walk_complete") < phases.index("publication_attempt"), (
+        "the whole-vault walk must stay outside canonical authority"
+    )
+    assert phases.index("receipt_published") < phases.index("registry_published")
+    assert freshness.custody_scope_invalidations() == ()
+    assert freshness.custody_rebuilds() == {}
+    assert freshness.audit_custody(vault, [_ALPHA], reason="reconcile-race").mismatches == ()
+
+
+def test_superseded_graph_reconciliation_keeps_the_external_epoch_pending(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+    from exomem import vault as vault_module
+
+    _seed(vault, _ALPHA, "Custody alpha", "alpha-seed")
+    pending = freshness.mark_external_pending(vault)
+    original_walk = vault_module.walk_vault_md
+
+    def invalidated_walk(root):
+        yield from original_walk(root)
+        freshness.invalidate(root)
+
+    monkeypatch.setattr(vault_module, "walk_vault_md", invalidated_walk)
+    epistemic_graph.EpistemicGraphIndex(vault)._reconcile_recall_publication()
+    assert freshness.external_pending_epoch(vault) == pending
 
 
 def test_a_move_retires_the_old_row_and_creates_the_new_one(


### PR DESCRIPTION
## What changed

Background reconciliation could observe a governed file replacement before its freshness event, mistake it for an untracked edit, and rebuild the recall caches. Graph and watcher reconciliation now scan outside writer authority and acquire that authority only for final publication. Pending write events win over the scan; superseded scans and changed access policies cannot publish or clear a pending external-edit marker.

This also repairs two release checks: the retrieval evaluator explicitly requests the historical outside-KB golden reserve, and checkout-free release automation supplies its repository to GitHub CLI. Product recall defaults, golden relevance labels, and quality thresholds are unchanged.

## Verification

- Repository CI [33927610492](https://github.com/Artexis10/exomem/actions/runs/33927610492) passed at `0822fb5332dde3ff904e6b2a87615ebdd325b1c7`.
- Recall, freshness, graph, evaluator and CI-contract suites (12 modules, `umask 022`): 412 passed, 3 platform-specific skips.
- Deferred-work-drain suite: 36 passed.
- Deterministic graph/watcher race, superseded-epoch, policy-change, and sidecar-swap regressions: 5 passed.
- Evaluator scope and checkout-free workflow regressions: 11 passed.
- Independent review passed; built-wheel behavioral checks passed (5 tests).
- Ruff and public-artifact privacy checks passed.
- Strict OpenSpec validation: 181 passed.

Release publication remains gated on a successful full CI run at the release PR's exact main-branch base revision.
