### PR TITLE
fix(hosted): let a first provision answer "no retarget needed"

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -365,9 +365,7 @@ class KubernetesProviderRegistry:
         )
         if stateful_set is not None:
             self._require_not_terminating(stateful_set)
-        desired_replicas = int(
-            getattr(getattr(stateful_set, "spec", None), "replicas", 0) or 0
-        )
+        desired_replicas = int(getattr(getattr(stateful_set, "spec", None), "replicas", 0) or 0)
         runtime_pod_list = await asyncio.to_thread(
             self._core.list_namespaced_pod,
             current.resource_name,
@@ -459,9 +457,7 @@ class KubernetesProviderRegistry:
                 "exomem.io/resource-name": metadata.resource_name,
                 "exomem.io/pvc-name": metadata.resource_name + "-data",
                 "exomem.io/credentials-secret-name": "exomem-cell-credentials",
-                "exomem.io/authorization-session-secret-name": (
-                    "exomem-authorization-session"
-                ),
+                "exomem.io/authorization-session-secret-name": ("exomem-authorization-session"),
                 "exomem.io/init-request-configmap-name": metadata.resource_name + "-init-request",
                 "exomem.io/provision-mode": provision_mode,
             }
@@ -782,15 +778,13 @@ class LiveLifecyclePlane:
                     "runtime attestation authority is unavailable",
                     reason=ConflictReason.RUNTIME_ATTESTATION_AUTHORITY_UNAVAILABLE,
                 )
-            runtime_attestation = (
-                await self._runtime.attest_authorization_session_membership(
-                    owned,
-                    credential=runtime_credential,
-                    protocol_version=runtime_protocol_version,
-                    target_epoch=source.epoch + 1,
-                    previous_epoch_digest=source.membership_digest,
-                    ttl_seconds=DEFAULT_ATTESTATION_TTL_SECONDS,
-                )
+            runtime_attestation = await self._runtime.attest_authorization_session_membership(
+                owned,
+                credential=runtime_credential,
+                protocol_version=runtime_protocol_version,
+                target_epoch=source.epoch + 1,
+                previous_epoch_digest=source.membership_digest,
+                ttl_seconds=DEFAULT_ATTESTATION_TTL_SECONDS,
             )
         successor = transition_hosted_authorization_bundle(
             files,
@@ -971,6 +965,40 @@ class LiveLifecyclePlane:
     ) -> bool:
         if request.get("provisionMode") != "serve":
             return False
+        desired = _fixed_helm_values(self._owner(metadata), request, config)
+        current = await self._helm.current_release_values(self._owner(metadata))
+        for key in ("image", "expectedRelease", "expectedProtocol"):
+            if not isinstance(current.get(key), str):
+                raise MetadataConflict(
+                    "current Helm runtime selection is invalid",
+                    reason=ConflictReason.CURRENT_HELM_RUNTIME_SELECTION_INVALID,
+                )
+        changed = any(
+            current[key] != desired[key] for key in ("image", "expectedRelease", "expectedProtocol")
+        )
+        operation_digest = hashlib.sha256(metadata.operation_id.encode("utf-8")).hexdigest()
+        upgrade = current.get("runtimeUpgrade")
+        transition_owned = (
+            isinstance(upgrade, dict)
+            and upgrade.get("schemaVersion") == 1
+            and upgrade.get("operationDigest") == operation_digest
+            and isinstance(upgrade.get("priorRevision"), int)
+            and not isinstance(upgrade.get("priorRevision"), bool)
+            and upgrade["priorRevision"] >= 1
+        )
+        if not changed and not transition_owned:
+            return False
+
+        # A retarget is genuinely indicated, so an operator must have committed
+        # one. The recovery receipt is written by exactly one caller -- the
+        # operator-driven retarget recovery command in `operation_recovery` --
+        # so requiring it here is what proves this move was authorised.
+        #
+        # It is deliberately checked AFTER the question above is answered. A
+        # cell being provisioned for the first time has never been retargeted
+        # and so can never hold a receipt; demanding one before asking whether
+        # a retarget is needed made "no" unreachable and killed every first
+        # provision at `volume-owned`.
         internal_operation_id = self._operation_ids.get(self._key(metadata))
         if internal_operation_id is None:
             raise MetadataConflict(
@@ -978,8 +1006,8 @@ class LiveLifecyclePlane:
                 reason=ConflictReason.RETARGET_OPERATION_UNAVAILABLE,
             )
         operation = await self._repository.get_by_id(internal_operation_id)
-        marker = operation.progress.get("_runtime_retarget_recovery_v1") if operation else None
-        marker_keys = {
+        receipt = operation.progress.get("_runtime_retarget_recovery_v1") if operation else None
+        receipt_keys = {
             "schema",
             "preflight_sha256",
             "source_request_sha256",
@@ -1006,18 +1034,18 @@ class LiveLifecyclePlane:
             or operation.tenant_id != metadata.tenant_id
             or operation.cell_id != metadata.subject_id
             or operation.fence_generation != metadata.fence_generation
-            or not isinstance(marker, dict)
-            or set(marker) != marker_keys
-            or marker.get("schema") != 1
-            or marker.get("target_request_sha256") != operation.canonical_request_sha256
-            or marker.get("target_runtime_sha256") != target_runtime_sha256
-            or marker.get("source_request_sha256") == marker.get("target_request_sha256")
-            or not isinstance(marker.get("claim_generation"), int)
-            or marker["claim_generation"] < 0
-            or not isinstance(marker.get("committed_at"), str)
+            or not isinstance(receipt, dict)
+            or set(receipt) != receipt_keys
+            or receipt.get("schema") != 1
+            or receipt.get("target_request_sha256") != operation.canonical_request_sha256
+            or receipt.get("target_runtime_sha256") != target_runtime_sha256
+            or receipt.get("source_request_sha256") == receipt.get("target_request_sha256")
+            or not isinstance(receipt.get("claim_generation"), int)
+            or receipt["claim_generation"] < 0
+            or not isinstance(receipt.get("committed_at"), str)
             or any(
-                not isinstance(marker.get(key), str) or len(marker[key]) != 64
-                for key in marker_keys
+                not isinstance(receipt.get(key), str) or len(receipt[key]) != 64
+                for key in receipt_keys
                 if key.endswith("sha256")
             )
         ):
@@ -1025,29 +1053,6 @@ class LiveLifecyclePlane:
                 "retargeted provision recovery receipt is invalid",
                 reason=ConflictReason.RETARGET_RECOVERY_RECEIPT_INVALID,
             )
-        desired = _fixed_helm_values(self._owner(metadata), request, config)
-        current = await self._helm.current_release_values(self._owner(metadata))
-        for key in ("image", "expectedRelease", "expectedProtocol"):
-            if not isinstance(current.get(key), str):
-                raise MetadataConflict(
-                    "current Helm runtime selection is invalid",
-                    reason=ConflictReason.CURRENT_HELM_RUNTIME_SELECTION_INVALID,
-                )
-        changed = any(
-            current[key] != desired[key] for key in ("image", "expectedRelease", "expectedProtocol")
-        )
-        operation_digest = hashlib.sha256(metadata.operation_id.encode("utf-8")).hexdigest()
-        marker = current.get("runtimeUpgrade")
-        transition_owned = (
-            isinstance(marker, dict)
-            and marker.get("schemaVersion") == 1
-            and marker.get("operationDigest") == operation_digest
-            and isinstance(marker.get("priorRevision"), int)
-            and not isinstance(marker.get("priorRevision"), bool)
-            and marker["priorRevision"] >= 1
-        )
-        if not changed and not transition_owned:
-            return False
         snapshot = self._snapshot(metadata)
         if snapshot.runtime_admitted or snapshot.routes != (False, False):
             raise MetadataConflict(

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -20,6 +20,7 @@ from exomem_provisioner.config import (
     load_deployment_lock,
     load_hosted_release_manifest,
 )
+from exomem_provisioner.conflict_reason import ConflictReason
 from exomem_provisioner.driver import DriverPending, EffectContext
 from exomem_provisioner.lifecycle import (
     CellLifecycleDriver,
@@ -2007,3 +2008,149 @@ async def test_live_plane_publishes_authorization_custody_before_helm_and_reuses
         "helm",
     ]
     assert len(set(helm.revisions)) == 1
+
+
+def _retarget_config(target: dict[str, object], **overrides: object) -> LifecycleConfig:
+    values: dict[str, object] = {
+        "image": "ghcr.io/artexis10/exomem@sha256:" + "d" * 64,
+        "chart_path": "chart",
+        "chart_version": "0.1.0",
+        "helm_version": "3.19.4",
+        "control_hostname": "control.example.invalid",
+        "transfer_hostname": "transfer.example.invalid",
+        "browser_origin": "https://substratesystems.io",
+        "release_version": "0.68.3",
+        "protocol_version": "1",
+        "contract_digest": "a" * 64,
+        "location": "fsn1",
+        "runtime_target": target,
+        "compatibility_digest": "e" * 64,
+        "migration_mode": "state-root-v1",
+    }
+    values.update(overrides)
+    return LifecycleConfig(**values)  # type: ignore[arg-type]
+
+
+def _retarget_plane(
+    metadata: OpaqueProviderMetadata,
+    request: dict[str, object],
+    config: LifecycleConfig,
+    current_values: dict[str, object],
+    *,
+    progress: dict[str, object],
+) -> LiveLifecyclePlane:
+    """A live plane whose cell already carries `current_values` in Helm.
+
+    The operation row is the one the reconciler is actually working: same
+    action, external id, tenant, cell and fence, and a canonical request digest
+    computed the way the repository computes it -- so the only thing under test
+    is the retarget decision itself.
+    """
+
+    class Helm:
+        async def current_release_values(self, owner: OpaqueProviderMetadata) -> dict[str, object]:
+            return dict(current_values)
+
+    class Repository:
+        async def get_by_id(self, operation_id: str) -> object:
+            assert operation_id == "internal-operation-alpha"
+            return SimpleNamespace(
+                action=SimpleNamespace(value="provision"),
+                external_operation_id=metadata.operation_id,
+                tenant_id=metadata.tenant_id,
+                cell_id=metadata.subject_id,
+                fence_generation=metadata.fence_generation,
+                canonical_request_sha256=canonical_request_sha256(request),
+                progress=dict(progress),
+            )
+
+    plane = LiveLifecyclePlane(
+        repository=Repository(),  # type: ignore[arg-type]
+        registry=SimpleNamespace(),  # type: ignore[arg-type]
+        cell=SimpleNamespace(),  # type: ignore[arg-type]
+        helm=Helm(),  # type: ignore[arg-type]
+        runtime=SimpleNamespace(),  # type: ignore[arg-type]
+        routes=SimpleNamespace(),  # type: ignore[arg-type]
+        maintenance=SimpleNamespace(),  # type: ignore[arg-type]
+        capacity=SimpleNamespace(),  # type: ignore[arg-type]
+        identity_verifier=IDENTITY_CODEC.verifier(),
+        config=config,
+        now=lambda: 1_900_000_030,
+    )
+    plane._operation_ids[plane._key(metadata)] = "internal-operation-alpha"
+    return plane
+
+
+@pytest.mark.asyncio
+async def test_first_provision_answers_no_retarget_without_a_recovery_receipt() -> None:
+    """A cell provisioned for the first time has never been retargeted.
+
+    `_provision` installs the release with `_fixed_helm_values` and only then
+    reaches `volume-owned`, where it asks whether a retarget is required. The
+    honest answer is "no". Demanding a `_runtime_retarget_recovery_v1` receipt
+    to reach that answer makes it unreachable, because the only writer of that
+    marker is the operator-driven retarget recovery command: a cell that has
+    never been retargeted cannot have one, so every first provision dies.
+    """
+
+    from exomem_provisioner.lifecycle import _fixed_helm_values
+
+    metadata = OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "operation-alpha", 7)
+    target = {
+        "releaseVersion": "0.68.3",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v4",
+        "gatewayContractDigest": "a" * 64,
+        "commandFingerprint": "b" * 64,
+        "schemaDigest": "c" * 64,
+        "compatibilityDigest": "e" * 64,
+    }
+    config = _retarget_config(target)
+    request = {
+        "provisionMode": "serve",
+        "workerPolicy": {"workerCount": 2, "semantic": True, "media": False},
+        "runtimeTarget": target,
+    }
+    # Exactly what `_provision` applied at `release-applied`, so the cell is
+    # already running the runtime this request asks for.
+    installed = _fixed_helm_values(metadata, request, config)
+    plane = _retarget_plane(metadata, request, config, installed, progress={})
+
+    assert await plane.provision_retarget_required(metadata, request, config) is False
+
+
+@pytest.mark.asyncio
+async def test_genuine_retarget_still_requires_the_operator_recovery_receipt() -> None:
+    """The guard must survive the fix that lets a first provision through.
+
+    When the cell is running a different image from the one the request now
+    asks for, a retarget really is required -- and that is exactly when an
+    operator-committed recovery receipt must be present. Absent one, this must
+    still refuse, or the reordering has deleted the guard rather than moved it.
+    """
+
+    from exomem_provisioner.lifecycle import _fixed_helm_values
+
+    metadata = OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "operation-alpha", 7)
+    target = {
+        "releaseVersion": "0.68.3",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v4",
+        "gatewayContractDigest": "a" * 64,
+        "commandFingerprint": "b" * 64,
+        "schemaDigest": "c" * 64,
+        "compatibilityDigest": "e" * 64,
+    }
+    config = _retarget_config(target)
+    request = {
+        "provisionMode": "serve",
+        "workerPolicy": {"workerCount": 2, "semantic": True, "media": False},
+        "runtimeTarget": target,
+    }
+    stale = _fixed_helm_values(metadata, request, config)
+    stale["image"] = "ghcr.io/artexis10/exomem@sha256:" + "9" * 64
+    plane = _retarget_plane(metadata, request, config, stale, progress={})
+
+    with pytest.raises(MetadataConflict) as raised:
+        await plane.provision_retarget_required(metadata, request, config)
+    assert raised.value.reason is ConflictReason.RETARGET_RECOVERY_RECEIPT_INVALID


### PR DESCRIPTION
## What was broken

`provision_retarget_required` (`infra/provisioner/src/exomem_provisioner/live.py`) is a predicate: it answers whether a provision must be moved onto a different runtime. For `provisionMode: "serve"` it could never answer *no*.

Before comparing anything it required a valid `_runtime_retarget_recovery_v1` receipt on the operation, and treated an **absent** receipt exactly as a **corrupt** one. That receipt has exactly one writer in the tree — the operator-driven retarget recovery command at `operation_recovery.py:1058` — and the ordinary provision path never writes it. A cell being provisioned for the first time has never been retargeted, so it cannot hold one.

Every first provision therefore died at checkpoint `volume-owned` with `PROVISIONER_PROVIDER_METADATA_CONFLICT`, reason `retarget-recovery-receipt-invalid`.

Observed on exomem-alpha-01 on 2026-09-05. No cell has ever completed a provision end to end on this cluster. The condition was identified from a single worker log line, which is what PR #1065's `ConflictReason` vocabulary was built for — the same failure previously consumed hours of cluster archaeology without being named.

Introduced by a61519ce (#1039).

## The change

The function already contained the correct answer at the bottom — compare the desired Helm runtime selection against the current one, `return False` when nothing changed. The receipt validation moves **below** that comparison, so it runs only once a retarget is genuinely indicated, which is exactly when proof that an operator committed one is worth having.

No guard is removed. The `marker` local is renamed to `upgrade`/`receipt` because the original shadowed one name for two unrelated values.

## Why the reorder is safe

- `_provision` (`lifecycle.py:2116`) installs the Helm release before it can reach `volume-owned`, so `current_release_values` is safe to read earlier.
- It installs with the **same** `_fixed_helm_values` call this predicate uses for `desired`, so a fresh cell's current values match by construction and `changed` is `False`.
- The three keys compared (`image`, `expectedRelease`, `expectedProtocol`) derive from `config`/`request`, not from provider metadata identity, so `_owner(metadata)` vs `metadata` does not affect them.

## Tests

Two new tests drive `LiveLifecyclePlane` directly, not the in-memory double:

- `test_first_provision_answers_no_retarget_without_a_recovery_receipt` — **red before this change** with the exact production error (`MetadataConflict: retargeted provision recovery receipt is invalid`, `live.py:1024`), green after.
- `test_genuine_retarget_still_requires_the_operator_recovery_receipt` — a differing `image` must still refuse with `RETARGET_RECOVERY_RECEIPT_INVALID`, proving the guard was moved rather than deleted. Passes before and after.

`provision_retarget_required` previously had no test coverage of any kind.

## Verification

```
553 passed, 17 skipped in 74.22s
```

Baseline was 551 passed, 17 skipped; the two added tests account for the difference. `ruff check` and `ruff format --check` clean on both changed files.

## Worth flagging separately

The in-memory `HighFidelityProviderPlane` (`lifecycle.py:1059`) already implements the correct semantics for this predicate — compare, return `False`, raise only when a retarget is needed but unsafe. Every existing test drove that double, so the suite was green while production could not provision anything. **The provisioner suite also runs in no CI workflow at all**, which is how this shipped. Both are follow-ups, not addressed here.