### PR TITLE
docs(openspec): define agent-led vocabulary evolution

### DIFF
--- a/openspec/changes/activate-agent-led-vocabulary-evolution/.openspec.yaml
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/design.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/design.md
@@ -1,0 +1,110 @@
+## Context
+
+See proposal.md for motivation and capability ownership. The shipped relation resolver already exposes core definitions, extension candidates, aliases, direction and registry currency. Registry saves already validate and publish typed graph state. Entity types are extensible, but ordinary-text identity evidence, hydration and parent-family traversal are planned in `complete-recurring-entity-lifecycle`, not proven shipped by the presence of its planning artifacts.
+
+`mutation_terminal.py` currently supplies relation advice for unknown labels and excludes `relates_to`. This is a useful validation advisory, not a complete consideration loop. The v1 delegation envelope also explicitly lacks standing authority for entity creation and type changes. Both gaps need named contracts; a prompt-only change cannot close them.
+
+## Goals / Non-Goals
+
+**Goals:** add one bounded evidence/decision protocol above the existing family-specific resolvers and writers; make the active agent responsible for meaning; make user delegation independently enforceable; expose enough traceable state to distinguish advice from actual adoption.
+
+**Non-goals:** a new ontology engine, arbitrary schema execution, an internal reasoning LLM, automatic semantic deduplication, relationship quotas, source rewriting, bulk backfill, or a universal permission setting. Existing category/source taxonomy openness is not replaced by mandatory registry review. The observability, resource-management and vault-consolidation stacks are not dependencies of this plan.
+
+## Decisions
+
+### 1. Shared protocol, existing tool families
+
+Add a family-neutral vocabulary work-item layer over existing resolvers, not a new top-level catch-all tool. A versioned family descriptor declares evidence acquisition, resolver, proposal validator, canonical writer, supported decisions, authority actions and persistence currency. It is registered by product code. Vault data can supply definitions within a family, never modules or permissions.
+
+Proposed adapter mapping (new variants must be added to the canonical command manifest and generated surfaces together):
+
+| Intent | Surface | Effect |
+| --- | --- | --- |
+| List considerations | `review_memory(mode="vocabulary")` | Bounded queue, availability and continuation |
+| Inspect one item | Existing review-context read by item ref | Definitions, targets, evidence, hashes and permitted next operations |
+| Resolve a meaning | Existing `connect_memory` entity/relation resolvers; entity-type resolution under `schema_memory` | Read-only candidates; no semantic auto-selection |
+| Record a decision | `triage_memory(action="decide-vocabulary", ...)` with a typed decision payload | Fingerprint-bound review state only |
+| Propose or register a type | Existing `schema_memory` family operations | Canonical validation and guarded save |
+| Create an entity or edge | Existing `connect_memory` operations | Canonical additive leaf under current authority |
+| Request/inspect authority | Existing governance request/status command family, new finite additive variants | Pending request or non-secret status, never agent self-approval |
+
+The decision payload contains item ref/fingerprint, family, registry hashes, target versions, outcome, rationale and selected/proposed canonical identity. It cannot contain an arbitrary command to execute. Application remains a separate canonical operation; receipt reconciliation advances the work item. Reuse the existing relation resolver unchanged where possible. Add entity-type evidence parity rather than forcing type registration through a relation-shaped payload.
+
+Alternative rejected: a single `evolve_memory` tool that resolves, reasons and writes in one call. It obscures which part the agent decided and makes replay and authority harder to inspect. A generic protocol does not require a generic mutation endpoint.
+
+### 2. Evidence triggers and ordinary-session cadence
+
+Use current-write parsed context plus the existing indexed review/recurrence projections. Initially connect unknown labels, structurally eligible generic relation opportunities and entity-lifecycle evidence into one queue. Generic opportunities require an indexed resolved pair or canonical generic edge with at least two independent supporting origins; copy-equivalent origins count once. Preserve the raw supporting contexts and the provenance of the independence determination. If that projection cannot establish independence, report unavailable instead of guessing. Explicit agent-submitted meaning questions are independently eligible. Neither keyword matching nor a classifier may turn a context into a server-authored supplier/equivalence judgment. Entity candidate detection is supplied by its owning change; do not duplicate or weaken its evidence threshold here. The agent also has a pre-write duty to consider identities and meaning from the conversation because an index cannot see unsaved conversation.
+
+The default ordinary path returns at most one compact advisory per committed write and at most four work items per review page; each compact advisory is at most 1 KiB and contains references rather than full definitions. The agent consumes relevant pending work at a durable capture boundary, records a disposition, and avoids surfacing the same unchanged item twice in a conversation. Explicit review is paginated and can continue beyond these response budgets; these are resource bounds, not limits on retained knowledge or eventual work.
+
+Fingerprint logical evidence, canonical target identities and relevant meaning versions rather than raw mtime. Registry hash still guards a commit; an unrelated registry edit requires refreshing that guard, not treating unchanged semantics as fresh unsolicited advice. Deduplicate work by logical identity. Resolve by observed resulting state, including additive promotion where source material remains intact, to avoid the already-observed permanently loud advisory failure.
+
+Keep workflow consideration dispositions separate from linked integrity findings. In particular, `entity_type_unregistered` is non-quietable and resolves only through changed registry/page state under its canonical spec. Suppressing an optional workflow notification must never suppress that audit/attention row or claim the defect fixed.
+
+Put derived queue/index state under the resolved machine-local state root. Reuse the portable review decision ledger for user/agent dispositions and distinguish their origins. No new state database belongs in authored KB folders. Explicit broad discovery remains default-off, bounded and resumable. Optional guidance failure preserves the note commit and reports unavailable; bounded review projection recovery reconstructs missing considerations from committed state without replaying the content write.
+
+Alternative rejected: warn on every `relates_to`, or require every note to invent a specific edge. That measures conformity, not knowledge quality, and trains agents to ignore the channel.
+
+### 3. Decision lifecycle and graph publication
+
+Use `pending -> proposed -> awaiting_approval -> applying -> applied` for changes; `resolved_without_mutation` and `deferred` are legitimate alternate outcomes. Transitions bind evidence fingerprints, target versions and registry hashes. An agent rationale is an attributable decision, not proof of semantic correctness. Server-enforceable facts are identity, shape, collisions, permission, version currency and committed state.
+
+An applied item records canonical receipts; a proposed item never does. Registration and graph publication remain distinct: saved registry state can be durable while typed recall is warming. Reuse the shipped graph epoch/rebind/recovery contract and preserve authored raw labels/history. Multi-step registration-plus-entity/edge work is not advertised as atomic. Existing receipts cover individual leaves; the governed curation lane owns ordered previews, interrupted runs and compensation. A no-mutation decision closes only the reviewed evidence version.
+
+### 4. Versioned additive authority, not a relaxed restructuring switch
+
+Introduce v2 as an explicit vault activation recorded outside authored content, with a minimum supported authority runtime and no default grants. The v1 envelope remains unchanged. Activation is vault-owned server policy: old clients cannot choose v1 as a downgrade in a v2 vault. Preserve `restructure_execution` confirmation for all non-additive and mixed-plan effects.
+
+Authority records name contract version, issuer, authorizing user, agent/principal audience, logical vault, action set, resolved scope, expiry, generation and status. First actions are `entity.create`, `entity_type.add`, `relation_type.add`, and `edge.add`. There is no all-future-actions wildcard. Type additions are global registry effects and require vault-wide authority; project edge grants cannot include them implicitly. New entities have no canonical project membership yet, so initial standing `entity.create` grants are also vault-wide; narrower creation uses exact approval of the new destination/payload. A project label is never its own scope proof. Existing-fact replacement, alias changes to existing definitions, deprecation, merges, supersession and deletion remain outside this first additive set.
+
+Requesting permission through MCP is not granting permission. Reuse the existing authorization request and owner-control machinery, but add an explicit user-approval ceremony: the trusted control surface shows the exact payload/effects and accepts the user's authenticated decision through a control capability not possessed by the ordinary agent principal. Ordinary tool credentials can create pending requests and inspect non-secret status only. Personal installations without that distinction offer advice and pending requests, not a fictional machine-verified approval. The exact surface must pass the existing principal/session/custody contract; do not implement an independent bearer grammar or let `why`/`confirmed=true` serve as consent.
+
+Use exact-action approvals for ask-each and bounded expiring grants for delegation. Exact approval binds the full canonical payload and reviewed versions. Standing grants authorize only currently resolved matching effects, not stale previews. Resolve project membership from canonical target state and check both edge endpoints; cross-scope or unresolved objects need separate approval. Recheck under the leaf's mutation boundary. Serialize revoke versus commit with a generation check; committed-before-revoke is history, uncommitted-after-revoke is refused. Reads of existing receipts retain current disclosure checks without reexecuting or requiring a replacement grant.
+
+An exact approval is one-shot, not a payload-shaped standing grant. Bind and durably reserve it to one canonical operation identity before writing effects. Its first committed receipt spends and links that authorization; same-identity receipt replay is not a second execution. Proven pre-commit failure permits the same unchanged retry while approval is valid; uncertainty keeps the reservation until recovery. A new identity always needs a new exact approval, including recreation of a later-deleted object. Reuse the existing receipt/journal protocol for this ordering rather than claim atomicity across a filesystem write and an independent database.
+
+Effect classification must cover low-level/generic file writers and imports as well as friendly tools. Typed tools alone are not an enforcement boundary. Mark activated state with runtime admission constraints; rollback to a runtime without the gate must stop structural writes rather than interpret unknown configuration permissively. Do not enable v2 until the control channel, leaf coverage and admission/rollback fence have independent security evidence.
+
+Compare the complete before/after result, not just the declared operation name. Full entity-registry saves can combine a new type with edits to existing definitions. Classify each addition, alteration and removal; authorize all effects independently and reject the whole atomic payload if any effect lacks authority. Do not prune unauthorized fields and commit the remainder, since that is a different reviewed payload.
+
+Two existing entity-writer paths are required mixed-effect fixtures: `connections` adds authored `relates_to` edges, and decision creation can auto-register a project key. The former requires edge authority as well as entity authority; the latter is outside the first additive family set and requires its separately owned authority or a refused write. Neither is incidental index hygiene. New command variants must also be classified in the existing total credential/owner-control matrix; no adapter may infer authority from an unclassified route.
+
+Alternative rejected: silently turn `restructure_execution` into silent mode, or trust the agent to attest consent. That would grant far more than additive graph work and is incompatible with the current contract.
+
+### 5. Implementation ownership and staged delivery
+
+This change may deliver its consideration protocol and guidance while v1 remains in force. It does not need standing grants to begin fixing the no-nudge gap. Treat scoped authority as a later gated tranche, not a prerequisite for useful advice.
+
+| Owning change | Contract supplied | Integration boundary |
+| --- | --- | --- |
+| Shipped relation vocabulary | Resolution, registry save and graph currency | Call existing leaves, preserve semantics |
+| `complete-recurring-entity-lifecycle` | Ordinary-text identity evidence, hydration, type families | Consume its evidence and traversal APIs; do not duplicate its 37-task plan |
+| `add-governed-curation-lane` | Reviewed multi-step execution/recovery | Use for combined plans; single additive leaves do not invent a plan runner |
+| This change | Common queue/decisions, ordinary agent cadence, additive authority | Own shared adapters, bootstrap and authority guards |
+
+Before integration, amend the two active predecessor plans' confirm-only language to be explicitly v1, with an explicit dependency on this change for v2. Until that reconciliation and code evidence exist, those plans remain confirm-only and no task here may claim their work implemented. Preserve their scenario requirements and frozen hosted contributions; evolve the current candidate, never v1-v4 release artifacts. Completing this change requires the integration tasks, not only a newly available endpoint.
+
+### 6. Acceptance measures meaning and use
+
+Add pure protocol/state tests before adapters, then end-to-end cases for real entity enrichment, genuinely useful new entity and relation types, overlap resolved by an agent, collision refusal, generic/no-edge, unavailable evidence, stale review, replay, revocation and cross-vault isolation. Test generic-writer bypass and an older-client downgrade explicitly. A synthetic future-family adapter proves that the protocol is reusable but cannot inherit grants or invoke undeclared behaviour.
+
+Run a small, reviewed ordinary-domain acceptance cohort without vocabulary hints. Preserve input, delivered considerations, agent decisions, tool traces and retrieval/traversal results. Include negative cases and compare against the current generic-only/missed-enrichment behaviour. Success is the supported outcome per case; counts of new labels or edges are descriptive, not a pass criterion. Live KB writes require explicit scope approval or a valid live grant; never seed private registries to manufacture a success metric.
+
+## Risks / Trade-offs
+
+- Advisory saturation → fingerprinted decisions, resolution from actual state, one compact item per write and explicit pagination.
+- Missed unsaved meaning → portable pre-write agent responsibility complements server evidence; no claim that a deterministic detector understands every conversation.
+- Registry-wide effects under narrow grants → separate global type-addition actions and scope rejection tests.
+- Approval channel is not genuinely user-controlled → delegation stays unavailable until trusted-control evidence passes; no caller-controlled consent flag.
+- Generic writers bypass typed gates → classify complete resulting effects at shared leaves and exercise alternate-route tests.
+- Dependency plans drift → integration/wording reconciliation is an explicit task; no archive while required integrations remain unfinished.
+- State recovery or optional guidance adds write latency → point lookups only on the write path, typed unavailable results, bounded rebuild off the core commit path.
+
+## Migration Plan
+
+1. Ship the family protocol, read/decision surfaces and bounded guidance with v1 permissions intact. New review projections are rebuildable and old clients can ignore the additional terminal field.
+2. Integrate entity-lifecycle evidence and curation receipts when their acceptance is demonstrated; synchronize overlapping OpenSpec wording before enabling those paths.
+3. Ship but do not activate v2 authority. Validate trusted approval, generic/typed leaf gates, revoke/commit ordering and deployment downgrade refusal across supported surfaces.
+4. Let a user deliberately activate one vault and create narrowly scoped expiring grants through trusted control. Existing registries and notes remain unchanged. Test revocation and rejected out-of-scope work before widening the pilot.
+5. Roll back workflow presentation independently of authority. Once a vault has activated v2, any runtime serving structural writes must preserve its gates; an incompatible rollback is a refused deployment, not silent v1 fallback. Preserve receipts and dispositions throughout.

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/proposal.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Exomem can register custom entity and relationship types, but ordinary agent work can still leave recurring identities unmodelled, existing entities stale, and meaningful connections hidden behind generic links. Vocabulary evolution needs a visible, accountable agent workflow, not just registry endpoints that an agent must remember to discover.
+
+## What Changes
+
+- Make the active agent consider reuse, enrichment and justified extension during ordinary capture and review. The server supplies bounded evidence and candidate definitions; the agent judges meaning. Honest generic connections, no edge and deferral remain valid outcomes.
+- Introduce durable, fingerprint-bound vocabulary review items and decisions, including relevant opportunities that do not produce an unknown-label warning today. Repeated unchanged advice is suppressed without pretending the underlying work is resolved.
+- Cover entity instances, entity types and relation types first. Define a family adapter contract so future vocabulary families can share the workflow without inheriting permissions, arbitrary fields or executable behaviour. Existing open categories remain open without mandatory registration.
+- Extend existing review, triage, connection and schema tools over shared command leaves; do not add a universal mutation endpoint or a server-side reasoning model.
+- Add a versioned, opt-in authority contract: users can choose advice, per-action approval, or scoped additive delegation. Entity creation, type registration and edge acceptance have separate grantable actions. Merges, deletion, supersession, disclosure and changes to existing meanings remain separately controlled.
+- **BREAKING (opt-in v2 contract only):** additive structural writes require machine-verifiable user authority at the canonical leaves, not merely an agent's assertion that it obtained permission. Vaults remaining on v1 keep their explicitly disclosed confirmation contract; old clients cannot downgrade an activated v2 vault.
+- Keep optional expensive discovery default-off and soft-failing. Bounded ordinary guidance uses existing projections and current-write context, adds no model dependency, and never converts a committed note write into a failure.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-vocabulary-workflow`: Bounded agent-facing consideration, explicit decisions, family extensibility and evidence of real adoption.
+- `scoped-additive-authority`: Trusted user grants and exact approvals, per-action/per-vault scope, revocation and leaf enforcement for additive structural writes.
+
+### Modified Capabilities
+
+- `delegation-envelope`: Preserve v1 and separate prominence from the deliberately enabled v2 additive authority contract.
+- `agent-bootstrap-contract`: Teach and advertise the complete evolving-vocabulary loop, supported families and actual authority capabilities.
+- `mutation-terminal-contract`: Expose bounded vocabulary review context without changing mutation success or replay identity.
+
+## Impact
+
+Expected implementation areas are `commands.py`, `mutation_terminal.py`, the entity and relation registries/resolvers, review projections/state, engagement and authorization binding, MCP/REST/CLI adapters, and the generic skill scaffold. No live policy, registry or graph is changed by this proposal.
+
+Build on the shipped `relation-vocabulary-evolution` and `entity-type-registry` contracts. `complete-recurring-entity-lifecycle` owns ordinary-text identity detection, hydration evidence and entity-family traversal; `add-governed-curation-lane` owns multi-step reviewed execution and recovery. This change owns the common consideration/decision loop and additive authority, not duplicate implementations of those features. Their older confirm-only wording must be reconciled before v2 integration; v1 remains confirm-only. The vault-consolidation governance stack, observability and memory optimisation are outside this change.

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Bootstrap teaches consideration and authority as separate steps
+
+The served agent contract and installed workflow guidance SHALL teach an ordinary-work loop: consider relevant identities and meanings; resolve existing definitions and evidence; choose reuse, enrichment, justified extension, honest generic, no-edge or defer; inspect current authority; execute only permitted canonical operations; and record the decision or receipt. Guidance SHALL describe an obligation to consider supported meaning, not an obligation to invent structure.
+
+Bootstrap SHALL report the active vocabulary workflow version, supported families, actual adapter operations, authority-contract version and whether scoped delegation is available. Compact/session profiles SHALL expose bounded summaries and read routes rather than embed a corpus census or secrets. A runtime lacking a required operation SHALL report the limitation, not teach a nonexistent shortcut.
+
+#### Scenario: A hookless agent receives the complete loop
+
+- **WHEN** a client without installed skills calls compact bootstrap
+- **THEN** it learns how to obtain and resolve vocabulary work, how to abstain and how to distinguish proposing from permission to commit
+
+#### Scenario: Proactivity does not imply permission
+
+- **WHEN** the user chooses maximal prominence with no additive grants
+- **THEN** the served contract encourages relevant consideration but does not authorize delegated creation

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/specs/agent-vocabulary-workflow/spec.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/specs/agent-vocabulary-workflow/spec.md
@@ -1,0 +1,126 @@
+## Purpose
+
+Make vocabulary evolution an ordinary, evidence-backed agent workflow that improves the useful graph while preserving honest abstention, user control and compatibility with future vocabulary families.
+
+## ADDED Requirements
+
+### Requirement: Ordinary work exposes a bounded vocabulary consideration
+
+When permitted by the active structural-suggestion disposition, ordinary capture and review SHALL expose bounded, actionable vocabulary considerations drawn from the current material and available indexed evidence. Considerations SHALL cover entity promotion, existing-entity enrichment, entity-type fit and relationship-type fit, not only unknown authored labels. A generic registered relation SHALL be eligible through structural evidence: an indexed resolved entity pair or canonical generic edge supported by at least two independent origins, with bounded raw contexts. An explicit agent-submitted meaning question SHALL also be eligible without that recurrence threshold. Duplicate copies of one origin SHALL NOT satisfy recurrence; unresolved origin independence SHALL be reported unavailable. The runtime SHALL NOT label the opportunity as a supplier relationship, semantic equivalent or other inferred meaning. The mere use of a generic edge SHALL NOT itself be an error or a reason to demand greater specificity.
+
+Each item SHALL carry a stable reference, family, target identities, evidence references, registry/projection currency, signal fingerprint, supported decisions and a continuation for omitted evidence. Unavailable evidence SHALL be reported as unavailable, not as absence. Item generation SHALL NOT scan or embed the full corpus on the synchronous write path.
+
+#### Scenario: A registered generic edge can still receive useful review
+
+- **WHEN** a capture uses `relates_to` for a resolved pair supported by two independent origins whose raw contexts describe supplying goods
+- **THEN** ordinary guidance exposes the pair, origin evidence, raw contexts and registry review route without requiring an unregistered label first
+- **AND** the server neither selects a predicate nor rejects the generic edge
+
+#### Scenario: A keyword is not semantic detection
+
+- **WHEN** one context contains the word supplier but has neither independent recurrence nor an explicit agent-submitted meaning question
+- **THEN** that keyword alone does not generate a relation-meaning consideration
+
+#### Scenario: Existing entities receive new facts
+
+- **WHEN** the entity-lifecycle evidence provider identifies new durable facts about an existing entity
+- **THEN** the work item offers enrichment of that entity and its evidence, not duplicate creation as the default
+
+#### Scenario: Coverage is bounded and honest
+
+- **WHEN** a consideration has more evidence than the response budget or its projection is warming
+- **THEN** the response exposes continuation or typed unavailability and does not claim that no other candidates exist
+
+### Requirement: Meaning is decided by the active agent
+
+The workflow SHALL present existing definitions, aliases, direction, applicable parent families and available overlap evidence before a new type is committed. The active agent SHALL choose reuse, enrich, propose-new, generic, no-edge or defer with a concise rationale appropriate to the family. New meanings SHALL require a definition, justification and the family's existing registry validation. Exact identity or alias collisions SHALL be rejected; semantic proximity alone SHALL NOT veto a distinct meaning or select an equivalent meaning automatically.
+
+No server-side reasoning model, numeric semantic-authority score, minimum edge count, type-count target or relation-diversity quota SHALL decide or satisfy the workflow.
+
+#### Scenario: Similar labels describe different meanings
+
+- **WHEN** two nearby relation definitions have different direction or scope and the agent explains the distinction
+- **THEN** a structurally valid new proposal remains possible despite lexical overlap
+- **AND** the agent must still pass the canonical registry and authority checks
+
+#### Scenario: No useful distinction is supported
+
+- **WHEN** the agent reviews the evidence and finds only a genuine generic connection or no supported connection
+- **THEN** generic or no-edge closes consideration of that unchanged evidence with a rationale and without creating a type
+
+#### Scenario: A school does not force a school type
+
+- **WHEN** an organisation-type entity already represents the school and no useful type distinction is supported
+- **THEN** reuse or enrichment is valid; a new school type is not demanded by the noun alone
+
+### Requirement: Decisions are durable and completion is evidence-bound
+
+Decision writes SHALL bind to the item fingerprint, reviewed registry hashes and relevant target versions. Stale decisions SHALL refuse without altering content or disposition. Recorded states SHALL distinguish pending consideration, deferred, resolved without mutation, proposed, awaiting approval, applying and applied. A proposal or approval SHALL NOT count as applied; applied SHALL reference successful canonical mutation receipts and the resulting state. A stale or failed application SHALL remain recoverable rather than silently resolved.
+
+Unchanged items already considered SHALL NOT repeatedly interrupt the same conversation. A durable defer or family quiet SHALL suppress unsolicited repetition while preserving explicit review access. New evidence that changes the fingerprint SHALL permit reconsideration; a registry timestamp change alone SHALL NOT create an endless stream of equivalent advice. An ignored item SHALL remain pending without increasing authority.
+
+Workflow notification and semantic consideration SHALL be distinct from canonical integrity findings. A defer, generic/no-edge outcome or family quiet SHALL NOT dismiss, hide or resolve a finding whose owning contract requires state repair, including `entity_type_unregistered`. Linked audit findings SHALL retain their original visibility and state-based resolution rules even when a workflow notification is suppressed. Claiming a consideration resolved SHALL NOT claim its linked integrity defect repaired.
+
+#### Scenario: A proposal is not completion
+
+- **WHEN** a new relation type has been proposed but its registration has not committed
+- **THEN** the item remains proposed or awaiting approval and is not reported as an active typed edge
+
+#### Scenario: Registry changes invalidate the decision
+
+- **WHEN** an agent submits a decision against an older registry hash
+- **THEN** the write refuses with refresh guidance and no semantic mutation or false resolved state
+
+#### Scenario: Quiet is not clean
+
+- **WHEN** a user quiets the family and requests review in a later session
+- **THEN** unresolved work is still inspectable with its reasons and evidence
+- **AND** quieting has not granted mutation authority
+
+#### Scenario: Deferral cannot conceal an unregistered entity type
+
+- **WHEN** the agent defers a type-promotion consideration linked to `entity_type_unregistered`
+- **THEN** the optional workflow notification can be deferred but the canonical audit and attention finding remains visible until the registry or authored pages change
+
+### Requirement: Vocabulary families share protocol but not unrestricted semantics
+
+The workflow SHALL initially support entity instances, entity types and relation types as distinct families. Every additional supported family SHALL declare a versioned identifier, evidence and resolution contract, validator, persistence owner, allowed decisions, authority-action mapping and compatibility behaviour before it can mutate state. Family registration SHALL be product-controlled, not an executable plugin or permission declaration loaded from vault content.
+
+User-created labels within a supported family SHALL remain open subject to that family's validation; an unknown family SHALL remain unsupported and non-mutating. Existing open observation categories and tags SHALL NOT acquire mandatory registration merely to join the common consideration protocol. A vocabulary definition SHALL NOT introduce arbitrary schema fields, new governed semantic kinds or code execution.
+
+#### Scenario: A future family does not inherit a standing grant
+
+- **WHEN** a runtime adds a new supported vocabulary family
+- **THEN** existing grants do not cover it unless their explicit action set already names that supported action under the matching contract version
+- **AND** a grant never expands through a wildcard such as all future families
+
+#### Scenario: A vault file cannot install a new capability
+
+- **WHEN** a registry entry names a validator module, permission class or unknown semantic kind
+- **THEN** the entry cannot activate that code, authority or kind through vocabulary registration
+
+### Requirement: Shared tools lead to canonical application and graph visibility
+
+Read, decision and application operations SHALL be available through the existing review, triage, connection and schema tool families and equivalent supported REST/CLI routes over the same command leaves. Capability discovery SHALL identify supported operations rather than advertise unavailable adapter routes. No generic review decision SHALL bypass a family validator or execute an arbitrary mutation payload.
+
+Type registration SHALL persist through its existing canonical registry writer before the corresponding typed application is considered active. Graph publication SHALL preserve existing registry-epoch, warming, provenance, raw-label and parent-family contracts. Multi-step recovery SHALL use the governed curation protocol when available, not invent cross-file atomicity.
+
+#### Scenario: Registration is durable before graph projection is current
+
+- **WHEN** a permitted type save commits but graph publication is pending
+- **THEN** the response distinguishes registered from graph-current and gives the normal recovery/read route
+- **AND** it does not repeat the registration under a new mutation identity
+
+### Requirement: Adoption is verified through unprompted domain tasks
+
+Acceptance SHALL exercise ordinary domain tasks whose prompts do not name the vocabulary mechanism or demand particular labels. Evidence SHALL distinguish consideration delivered, agent decision, canonical write and downstream retrieval/traversal. It SHALL include useful custom-type adoption, truthful reuse, enrichment, justified abstention and deferred work. Each claimed success SHALL be traceable to source material and actual tool results, not an aggregate increase in edges or definitions.
+
+#### Scenario: Tools exist but the agent never considers vocabulary
+
+- **WHEN** registry unit tests pass but an ordinary-task run never receives or acts on its relevant consideration
+- **THEN** the adoption acceptance fails even though the registry capability works
+
+#### Scenario: Incidental names remain context
+
+- **WHEN** a task contains repeated boilerplate or an incidental name without a useful recurring identity
+- **THEN** acceptance requires abstention from entity proliferation, not a higher entity count

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/specs/delegation-envelope/spec.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/specs/delegation-envelope/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Explicit v2 additive authority does not raise a v1 ceiling
+
+The v1 action classes, ranges, hard ceilings and standing-delegation refusal SHALL remain unchanged for v1 vaults. The deliberately activated v2 additive-authority contract SHALL supply separate action-specific grants for additive entity, entity-type, relation-type and edge operations; it SHALL NOT be represented as a non-confirm `restructure_execution` disposition or a more permissive prominence setting.
+
+In an activated v2 vault the canonical effect classifier SHALL route those additive effects through `scoped-additive-authority` on every adapter. All remaining restructuring and disclosure effects SHALL retain their existing authority owner and gates. An enclosing confirmed curation plan SHALL NOT broaden a leaf grant, and a leaf grant SHALL NOT waive confirmation for a mixed or destructive curation plan. Read-time tolerance of unknown v1 configuration SHALL never be used as write-time fallback from an activated v2 contract.
+
+#### Scenario: A grant covers only its named additive effect
+
+- **WHEN** a v2 user delegates entity-instance creation
+- **THEN** that grant can authorize a matching new entity through the v2 leaf gate
+- **AND** it cannot authorize entity merge, supersession, existing-fact replacement or deletion
+
+#### Scenario: Standing restructuring delegation is still refused
+
+- **WHEN** either a v1 or v2 caller sets `restructure_execution` to silent
+- **THEN** the existing founder-gate refusal remains unchanged; v2 additions use their separate user-grant contract instead
+
+#### Scenario: Mixed curation retains the stricter requirement
+
+- **WHEN** a curation plan includes a delegated edge addition and an existing-page rewrite
+- **THEN** the edge grant alone cannot authorize the enclosing plan or rewrite

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/specs/mutation-terminal-contract/spec.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/specs/mutation-terminal-contract/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Vocabulary guidance is bounded and independent of commit truth
+
+A committed writer response SHALL be able to carry a compact vocabulary-review advisory with item reference, fingerprint, family, evidence availability and next read action when the active disposition permits. Rich definitions and evidence SHALL be fetched through review context, not copied into every acknowledgement. The advisory SHALL obey a declared bounded size and count, use current-write or bounded projection context, and not initiate a full-vault retrieval or model call.
+
+Failure to compute or persist optional guidance SHALL NOT turn a successful mutation into an error, change its replay identity, or trigger duplicate content writes. The response SHALL distinguish guidance unavailable from no findings when computation was attempted but failed. Durable work reconstruction SHALL remain possible from committed state through bounded review/projection recovery. Replaying a mutation SHALL not create another consideration or spend its notification budget again.
+
+#### Scenario: Advice computation fails after commit
+
+- **WHEN** content commits and vocabulary guidance cannot be produced
+- **THEN** the terminal remains committed with typed guidance unavailability and the original receipt identity
+- **AND** the client is not instructed to repeat the content mutation under a new identity
+
+#### Scenario: Replayed acknowledgement does not nag again
+
+- **WHEN** the same committed request is reconciled or replayed
+- **THEN** it returns the same content outcome without generating a duplicate work item or a fresh unsolicited notification

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/specs/scoped-additive-authority/spec.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/specs/scoped-additive-authority/spec.md
@@ -1,0 +1,119 @@
+## Purpose
+
+Let users deliberately delegate bounded additive graph work while keeping grants attributable, revocable and enforced independently of agent prose, vocabulary definitions and notification settings.
+
+## ADDED Requirements
+
+### Requirement: Additive authority is an explicit versioned opt-in
+
+The product SHALL provide a v2 additive-authority contract with advise, ask-each and delegated modes for separately named actions: entity-instance creation, entity-type addition, relation-type addition and edge addition. Activation SHALL be an explicit trusted user decision for a vault, not a client-supplied version preference. Migration SHALL create no standing grants and SHALL preserve the prior v1 contract until deliberate activation. An activated vault SHALL enforce v2 structural-write gates for every adapter, including older clients; omitting a version or selecting a legacy route SHALL NOT restore v1 authority.
+
+Advice authorizes no mutation. Ask-each SHALL require approval of the exact reviewed action. Delegated mode SHALL require a currently valid grant covering that action. Existing data disclosure/access policy, write boundaries, leases, validation and protected Source/Evidence rules SHALL remain independently required. Enrichment that changes existing facts, merges, deletion, supersession, deprecation and alteration of existing type meanings SHALL NOT be included in these additive grants.
+
+#### Scenario: Upgrade does not create permission
+
+- **WHEN** an existing installation upgrades without activating v2
+- **THEN** its v1 envelope remains unchanged and no delegated additions are permitted
+
+#### Scenario: A legacy client cannot downgrade an activated vault
+
+- **WHEN** a v1 client attempts entity creation in a v2-activated vault without valid authority
+- **THEN** the canonical leaf refuses with the required approval path rather than falling back to conversational confirmation
+
+### Requirement: User authority cannot be self-issued by the agent
+
+Grant creation, expansion, revocation and exact-action approval SHALL require a trusted user-control channel distinct from ordinary agent tool authority. MCP SHALL allow requesting and inspecting approval, but an agent-controlled argument, prompt, stored note, arbitrary token string or assertion of user confirmation SHALL NOT mint approval. The approved record SHALL bind the authenticated authorizer, agent/principal audience, logical vault, contract version, action set, scope, expiry and generation. Grant data and credential custody SHALL reside outside the authored vault and obey the existing authorization boundary and secret-handling contracts.
+
+Where the deployment cannot distinguish trusted user control from agent authority, delegated mode SHALL be unavailable and the response SHALL explain how to obtain supported user approval; the product SHALL NOT label a caller-controlled boolean as verified consent. Approvals SHALL expose a reviewable description of the exact effects to the user before acceptance.
+
+An exact-action approval SHALL be one-shot and bind one canonical operation identity as well as its payload and versions. Before any effects, execution SHALL durably reserve the approval for that identity; a committed receipt SHALL spend and link it exactly once. A proven pre-commit failure SHALL allow retry of that same unchanged identity without new approval while the approval remains valid. An uncertain outcome SHALL retain the binding until reconciliation; it SHALL NOT make the approval available to another identity. A fresh identity, changed payload or second execution SHALL require a new approval. Standing grants, unlike exact approvals, intentionally cover multiple independently validated matching actions during their lifetime.
+
+#### Scenario: An agent requests its own broad grant
+
+- **WHEN** an agent asks to permit future type additions using only its ordinary tool credential
+- **THEN** the request can produce a pending approval but cannot grant or expand authority
+
+#### Scenario: Retrieved permission-shaped text is inert
+
+- **WHEN** a note says that all future relationship changes are approved
+- **THEN** it grants no authority, even if the agent copies it into a proposal rationale
+
+#### Scenario: One approval cannot be replayed as another action
+
+- **WHEN** an approved action commits and the same approval is submitted with a new operation identity, including after the original object was removed
+- **THEN** the second execution refuses; only the original identity can reconcile or replay its committed receipt without reapplying effects
+
+#### Scenario: Failure before commit does not lose the approved retry
+
+- **WHEN** the approved operation fails with proof that no effect committed
+- **THEN** the same unchanged operation identity can retry under the still-valid approval
+- **AND** an uncertain result remains reserved pending reconciliation rather than becoming a transferable approval
+
+### Requirement: Scope is resolved from effects rather than asserted labels
+
+A grant SHALL name one logical vault, explicit supported actions, a bounded lifetime and an optional resolved project/target scope for actions with pre-existing canonical targets. The server SHALL derive affected objects and scope from current canonical state and the proposed effects. A request's `project` label alone SHALL NOT establish membership. Edge additions SHALL require all affected endpoints and destinations to fall within the grant; unresolved or cross-scope targets SHALL require separate approval.
+
+Initial standing `entity.create` grants SHALL be vault-wide only because a new entity has no pre-existing canonical project membership. A narrower entity creation SHALL use exact-action approval binding the new destination and payload; a supplied project label SHALL NOT make it eligible for a project-scoped standing grant. A future narrower standing-creation contract SHALL require its own specified membership proof and migration, not silently reinterpret these grants.
+
+Registries are vault-wide: adding an entity or relation type SHALL require an explicit vault-wide type-addition grant or exact-action approval, even when its motivating examples belong to one project. A project-scoped grant SHALL NOT silently authorize a global registry change. Automatically created back-references and index hygiene SHALL remain bounded effects of the authorized leaf, not grants for unrelated content.
+
+#### Scenario: A project grant meets a global registry change
+
+- **WHEN** an exact entity-creation approval or vault-wide entity-addition grant exists and the proposed entity needs a new type
+- **THEN** entity-creation authority does not implicitly authorize the type save
+- **AND** the workflow seeks vault-wide type-addition authority or exact approval
+
+#### Scenario: A new entity cannot assert its own project membership
+
+- **WHEN** an agent requests a project-scoped standing entity-creation grant or supplies a project label as the only scope proof for a new entity
+- **THEN** the operation is unsupported under this initial contract and seeks exact-action approval or an explicit vault-wide entity-creation grant
+
+#### Scenario: Metadata cannot launder an out-of-scope target
+
+- **WHEN** an agent supplies an allowed project label for an edge whose canonical target lies outside that grant
+- **THEN** the edge write refuses without modifying either endpoint
+
+### Requirement: Authority and review bind at every actual write
+
+Each v2 additive structural mutation SHALL validate authority at the canonical leaf immediately before its commit under the same serialization boundary used for the mutation. Exact approval SHALL bind the canonical action payload, target versions and registry hashes; a standing grant SHALL bind its current generation and resolved effects. Authority checks SHALL cover typed tools, generic file writers, imports, schema saves and every equivalent route that can produce those effects. A preview, cached bootstrap, review disposition or previous step's approval SHALL NOT substitute for the live check.
+
+Effect classification SHALL compare the complete proposed result with current canonical state and independently authorize every effect. A type-addition grant SHALL authorize new definitions only, not edits to existing aliases, parents, guidance, status, replacement fields or other existing definition data. If a single atomic save mixes authorized additions with any unauthorized effect, the entire save SHALL refuse with zero changes; it SHALL NOT silently prune, partially apply or relabel the mixed payload as additive.
+
+Entity creation that includes authored connections SHALL require `edge.add` authority for those effects in addition to `entity.create`. A writer that also introduces a project key or another vocabulary outside the declared additive set SHALL require that effect's separately owned authority; it SHALL NOT treat vocabulary registration as index hygiene or infer it from the enclosing entity grant. If the deployment cannot authorize that effect, the complete atomic write SHALL refuse and offer a separately reviewed path.
+
+Revocation and commit SHALL have a defined ordering: a commit serialized after revocation SHALL refuse; a commit already serialized before revocation SHALL remain an auditable completed effect. Receipts SHALL identify the non-secret authorizing record and executed action without leaking credentials. Replay of an already committed mutation SHALL not reapply effects or need a new grant, while access to its receipt SHALL still obey current disclosure policy. Uncommitted steps and changed payloads SHALL revalidate authority.
+
+#### Scenario: Revocation races with a prepared write
+
+- **WHEN** a grant is revoked after preview and before the leaf's serialized commit check
+- **THEN** the write refuses and produces no content effect
+
+#### Scenario: A generic writer attempts the same operation
+
+- **WHEN** a caller uses a generic file route to create an entity or alter a registry in a v2 vault
+- **THEN** the same effect classification and authority gate apply as on the typed tool
+
+#### Scenario: A registry addition conceals an existing-definition edit
+
+- **WHEN** a full registry save adds a permitted type and also changes an existing type's alias, parent, guidance or status without separate authority
+- **THEN** the complete save refuses and both new and existing registry state remain unchanged
+
+#### Scenario: Entity creation carries additional graph and vocabulary effects
+
+- **WHEN** a decision-entity create includes connections and a previously unregistered project key under an entity-only grant
+- **THEN** the complete write refuses without creating the entity, edges or key
+- **AND** the response identifies the missing edge and project-key authority rather than silently inheriting them
+
+#### Scenario: Recovery is not fresh authorization
+
+- **WHEN** a multi-step operation has one committed addition and a remaining uncommitted step after grant expiry
+- **THEN** the committed receipt remains reconcilable and the remaining step cannot execute without current authority
+
+### Requirement: Unsupported runtime and family states fail closed
+
+The activation record SHALL bind a minimum authority-contract reader/writer version. Supported deployment and rollback paths SHALL refuse structural write service by runtimes that cannot enforce an activated contract; the product SHALL NOT silently discard grants or activation to make an old runtime writable. Unsupported actions, ambiguous scope, unavailable authority state or incompatible family versions SHALL refuse mutation without blocking permitted read-only guidance.
+
+#### Scenario: Rollback cannot restore a weaker write path
+
+- **WHEN** deployment targets a runtime unable to enforce the vault's activated v2 contract
+- **THEN** admission refuses write service for that vault until a compatible runtime or explicitly reviewed migration is used

--- a/openspec/changes/activate-agent-led-vocabulary-evolution/tasks.md
+++ b/openspec/changes/activate-agent-led-vocabulary-evolution/tasks.md
@@ -1,0 +1,46 @@
+## 1. Protocol and evidence contract
+
+- [ ] 1.1 Add failing pure-logic tests for family descriptors, allowed outcomes, fingerprint/version binding, unknown-family refusal and non-inheritance of future actions; verify the tests fail for the missing behaviours before implementation.
+- [ ] 1.2 Implement the family/work-item protocol and typed decision validation in focused vocabulary modules; verify the tests from 1.1, including a synthetic future-family adapter that cannot load code or grant itself authority.
+- [ ] 1.3 Implement registry-aware evidence adapters over the shipped relation resolver and entity-type registry without changing their persistence semantics; verify exact aliases, distinct nearby meanings, unavailable recurrence and bounded continuation in scoped tests.
+- [ ] 1.4 Implement the decision state machine and receipt-bound completion in review state; verify stale decisions refuse, proposal is not applied, committed receipts reconcile once, and unchanged evidence retains its disposition across restart.
+
+## 2. Ordinary-work guidance under existing v1 permissions
+
+- [ ] 2.1 Add failing tests for a resolved generic pair/edge supported by two independent origins, copy-equivalent origin negatives, explicit agent meaning questions, single keyword negatives and unavailable independence evidence; verify the current unknown-label-only advisory cannot satisfy the positive case and the runtime never labels a supplier/equivalence meaning.
+- [ ] 2.2 Connect current-write context and bounded indexed origin/pair evidence to vocabulary work items in mutation/review projections; verify one advisory of at most 1 KiB per write, four items per default review page, explicit continuation, and zero full-corpus scans or model calls on the write path.
+- [ ] 2.3 Implement fingerprinted notification deduplication, deferral, family quiet and state-based resolution without moving original evidence; verify restart persistence, explicit access to quiet work, no re-notification from unrelated registry edits, and that linked non-quietable integrity findings remain visible until state repair.
+- [ ] 2.4 Add soft-failure and recovery tests before implementing optional guidance recovery; verify committed terminals keep their receipt/replay identity, unavailable is not empty, and bounded projection recovery reconstructs missed work without repeating the content mutation.
+- [ ] 2.5 Expose review/context/typed-decision variants through canonical command definitions and supported MCP/REST/CLI adapters; verify cross-surface schema fidelity, capability discovery and the same leaf results without a generic execution payload.
+- [ ] 2.6 Update bootstrap and the generic skill scaffold with pre-write consideration, review disposition, truthful generic/no-edge examples and v1 permission limits; verify bootstrap/scaffold contract tests, hookless consumption and the scaffold privacy gate.
+
+## 3. Entity and curation integration
+
+- [ ] 3.1 Reconcile the overlapping `complete-recurring-entity-lifecycle` and `add-governed-curation-lane` artifacts with their owners before integration: retain all v1 confirmation scenarios and name this change as the sole v2 authority dependency; verify strict OpenSpec validation and independent review of the resulting requirements.
+- [ ] 3.2 Connect the entity-lifecycle provider's ordinary-text promotion, hydration and ambiguity evidence to the common work-item layer once its own acceptance passes; verify recurring identities, useful existing-entity enrichment, alias matches, ambiguous identities and incidental-name negatives without duplicating its detector.
+- [ ] 3.3 Bind multi-step vocabulary proposals to governed curation previews and individual canonical receipts once that lane's acceptance passes; verify registration followed by entity/edge application, interrupted resume, stale targets and truthful partial completion.
+- [ ] 3.4 Exercise custom entity/relationship types through registration, authored use, exact and parent-family retrieval/traversal, deprecation history and warming-to-current graph publication; verify real downstream behaviour rather than registry counts alone.
+
+## 4. Versioned additive authority foundation
+
+- [ ] 4.1 Add failing authorization tests for opt-in activation, default no grants, separate entity/type/edge actions, vault-wide type/entity creation grants, exact approval for narrower new entities and resolved project edge scope; verify v1 is unchanged, new entities cannot assert project membership and an older client cannot downgrade an activated vault.
+- [ ] 4.2 Implement activation/grant records under external authority custody, reusing existing principal/session/secret-handling contracts; verify restart persistence, bounded expiry, generation validation and cross-principal/cross-vault isolation.
+- [ ] 4.3 Implement pending approval request/status variants and a trusted user-control approval ceremony distinct from ordinary agent credentials; verify agent self-approval, forged confirmation fields and retrieved permission text cannot mint approval, while an authenticated user approves the displayed exact effects. Inspect the real control surface with Chrome DevTools if rendered UI changes.
+- [ ] 4.4 Implement one-shot exact-action approval and scoped grant evaluation over canonical payloads/targets; verify single operation-identity reservation, proven pre-commit retry, uncertain-outcome recovery, refusal under a new identity, out-of-scope endpoints, project-label laundering, global registry effects, changed reviewed hashes and unsupported future actions.
+
+## 5. Enforcement and recovery gates
+
+- [ ] 5.1 Add failing complete-before/after effect-classification tests for typed writers, generic file creation/replacement, imports and registry saves; verify every route enters the same authority gate in v2, a permitted type addition mixed with an unauthorized existing-definition change refuses atomically, and entity creation cannot smuggle connections or a new project-key registration through an entity-only grant.
+- [ ] 5.2 Integrate effect classification and live authority validation into canonical mutation leaves under their commit boundary; verify permission cannot be bypassed through a legacy adapter, generic payload or cached preview and all existing validation/write-scope/lease gates remain intact.
+- [ ] 5.3 Serialize revocation against commit and bind non-secret authority evidence to canonical receipts; verify revoke-before-commit refusal, committed-before-revoke history, atomic one-shot spend/receipt linkage with crash recovery, replay without reapplication, current receipt disclosure and expired-authority refusal for remaining curation steps.
+- [ ] 5.4 Implement runtime admission and downgrade fences for activated authority state; verify supported deploy/rollback routes cannot serve weaker structural writes, unreadable authority refuses writes but permits authorized reads, and no migration silently grants authority.
+- [ ] 5.5 Obtain independent security review of the trusted approval channel, complete writer-route inventory, scope checks, revoke/commit race and downgrade reproduction; verify each blocking finding is resolved with rerunnable evidence before exposing v2 activation.
+
+## 6. Ordinary-agent acceptance and delivery
+
+- [ ] 6.1 Create a bounded ordinary-domain acceptance cohort with no vocabulary-mechanism hints, including useful custom entity/relation types, reused types, hydration, generic/no-edge and incidental-name negatives; verify expected outcomes are supported by the supplied evidence rather than quotas.
+- [ ] 6.2 Run that cohort through an active agent using the served contract and preserve delivered items, decisions, canonical receipts and retrieval/traversal outputs; verify each positive and negative case independently and distinguish absent advice, ignored advice and failed application.
+- [ ] 6.3 Compare ordinary-path latency, memory and projection-query work against the pre-change baseline on the same fixtures; verify declared response bounds, no per-write corpus scan/model load and no retained-knowledge or session-count limits introduced by this work.
+- [ ] 6.4 Run affected suites during development, then the full lean suite, required integration/capability checks, lint and public-artifact/privacy validation at the completion boundary; verify actual outputs and obtain independent end-to-end verification of the claimed tranche.
+- [ ] 6.5 Publish the implementation PRs with conventional titles and verification evidence; after authorized merges, verify default-branch state and remove only clean, pushed task worktrees with no live processes.
+- [ ] 6.6 After all non-optional integrations and acceptance tasks are evidenced as shipped, synchronize these deltas without discarding later scenarios and archive through OpenSpec; verify `openspec validate --all --strict` before and after archive. A planning PR alone does not complete or archive this change.


### PR DESCRIPTION
## Summary

Define the next phase of evolving vocabulary: ordinary-agent consideration of entities and relationship meanings, durable review decisions, and useful adoption through the existing MCP/REST/CLI tool families. Future vocabulary families share the protocol but must declare their own validation and authority rules.

The plan separates bounded guidance under current v1 permissions from later opt-in, scoped additive authority. Registry changes remain vault-wide effects; merges, deletion and changes to existing meanings are not included in additive grants.

This PR contains OpenSpec planning artifacts only. All implementation tasks remain unchecked; it changes no runtime behaviour or live permissions. Start implementation with the protocol and v1 guidance tasks, then complete the named entity/curation integrations and authority gates before claiming the full workflow shipped.

## Verification

- Independent plan critique approved after resolving semantic-trigger, scope, mixed-effect and one-shot approval gaps.
- CI-pinned OpenSpec 1.10.0: `validate --all --strict`, 182 passed, 0 failed.
- `python3 scripts/check_openspec_archive_discipline.py`: passed; no task-complete active changes.
- `python3 scripts/validate-public-artifacts.py --repository`: passed.
- `git diff --cached --check`: passed.

Scope is documentation/specification only; no application test result is claimed.
