### PR TITLE
fix(hosted): re-mint an expired authorization bundle before the cell serves

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/conflict_reason.py
+++ b/infra/provisioner/src/exomem_provisioner/conflict_reason.py
@@ -129,6 +129,7 @@ class ConflictReason(StrEnum):
     )
     AUTHORIZATION_BUNDLE_DOCUMENT_INVALID = "authorization-bundle-document-invalid"
     AUTHORIZATION_CONTROL_IS_INVALID = "authorization-control-is-invalid"
+    AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL = "authorization-session-expired-on-serving-cell"
     AUTHORIZATION_DRAIN_ACKNOWLEDGEMENT_IS_INCOMPLETE = (
         "authorization-drain-acknowledgement-is-incomplete"
     )

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -732,9 +732,15 @@ class LiveLifecyclePlane:
                     )
                 except MetadataConflict as error:
                     # Prove the refusal really is expiry rather than trusting that
-                    # `_require_fresh` gates nothing else. A future-dated bundle
-                    # also passes the call above and fails this one, and that is
-                    # not elapsed time -- fail closed on anything still in date.
+                    # `_require_fresh` gates nothing else. The control and
+                    # membership windows are tied to identical bounds
+                    # unconditionally (`authorization_membership` requires
+                    # membership.issued_at == control.issued_at and the same for
+                    # expires_at), so the call above can only have failed because
+                    # `current` fell outside one shared window -- either past its
+                    # end, which is age, or before its start, which is not. This
+                    # comparison separates exactly those two, and fails closed on
+                    # anything still in date.
                     if bundle.expires_at > current:
                         raise
                     # The bundle is sound and merely expired. A cell that has never

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -673,8 +673,9 @@ class LiveLifecyclePlane:
         replica_id = owned.resource_name + "-0"
         files = await self._cell.read_authorization_session_bundle(owned)
         current = int(self._now())
-        if files is None:
-            bundle = build_initial_hosted_authorization_bundle(
+
+        async def _mint() -> Any:
+            minted = build_initial_hosted_authorization_bundle(
                 cell_id=owned.subject_id,
                 logical_vault_id=owned.tenant_id,
                 replica_id=replica_id,
@@ -685,13 +686,21 @@ class LiveLifecyclePlane:
             )
             await self._cell.write_authorization_session_bundle(
                 owned,
-                bundle.files,
+                minted.files,
                 recovery_envelope=recovery_envelope,
-                membership_epoch=bundle.epoch,
-                membership_digest=bundle.membership_digest,
-                revision=bundle.revision,
+                membership_epoch=minted.epoch,
+                membership_digest=minted.membership_digest,
+                revision=minted.revision,
             )
+            return minted
+
+        if files is None:
+            bundle = await _mint()
         else:
+            # Validate everything except the elapsed-time window first. The only
+            # clauses `_require_fresh` gates are the control and serving-membership
+            # freshness windows, so a bundle that passes here and fails below has
+            # nothing wrong with it but age.
             bundle = inspect_hosted_authorization_bundle(
                 files,
                 expected_cell_id=owned.subject_id,
@@ -701,8 +710,40 @@ class LiveLifecyclePlane:
                 expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
                 expected_recovery_envelope=recovery_envelope,
                 now=current,
-                _require_fresh=require_fresh,
+                _require_fresh=False,
             )
+            if require_fresh:
+                try:
+                    bundle = inspect_hosted_authorization_bundle(
+                        files,
+                        expected_cell_id=owned.subject_id,
+                        expected_logical_vault_id=owned.tenant_id,
+                        expected_replica_id=replica_id,
+                        expected_software_version=None,
+                        expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+                        expected_recovery_envelope=recovery_envelope,
+                        now=current,
+                        _require_fresh=True,
+                    )
+                except MetadataConflict:
+                    # The bundle is sound and merely expired. A cell that has never
+                    # been admitted or routed has never served a request under it,
+                    # so nothing is depending on the old session and re-minting is
+                    # the same act as minting one for a cell that had none.
+                    #
+                    # Provisioning a cell is not instantaneous: the bundle is minted
+                    # at `install_release`, and any pause before initialize -- a
+                    # retry, an operator recovery, a slow CSI attach -- can outlast
+                    # the one-hour attestation TTL. Failing terminally there makes
+                    # elapsed time indistinguishable from a forged attestation, and
+                    # leaves a cell that can never finish provisioning.
+                    snapshot = self._snapshot(metadata)
+                    if snapshot.runtime_admitted or snapshot.routes != (False, False):
+                        raise MetadataConflict(
+                            "authorization session expired on a serving cell",
+                            reason=(ConflictReason.AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL),
+                        ) from None
+                    bundle = await _mint()
         return bundle.revision
 
     async def _authorization_helm_values(

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -674,7 +674,7 @@ class LiveLifecyclePlane:
         files = await self._cell.read_authorization_session_bundle(owned)
         current = int(self._now())
 
-        async def _mint() -> Any:
+        async def _mint(*, expected_revision: str | None = None) -> Any:
             minted = build_initial_hosted_authorization_bundle(
                 cell_id=owned.subject_id,
                 logical_vault_id=owned.tenant_id,
@@ -691,6 +691,11 @@ class LiveLifecyclePlane:
                 membership_epoch=minted.epoch,
                 membership_digest=minted.membership_digest,
                 revision=minted.revision,
+                # Replacing an existing bundle is a compare-and-swap against the
+                # revision this pass read. Without it, a maintenance transition
+                # committed since that read is clobbered and its epoch silently
+                # reset to genesis.
+                expected_revision=expected_revision,
             )
             return minted
 
@@ -725,11 +730,18 @@ class LiveLifecyclePlane:
                         now=current,
                         _require_fresh=True,
                     )
-                except MetadataConflict:
+                except MetadataConflict as error:
+                    # Prove the refusal really is expiry rather than trusting that
+                    # `_require_fresh` gates nothing else. A future-dated bundle
+                    # also passes the call above and fails this one, and that is
+                    # not elapsed time -- fail closed on anything still in date.
+                    if bundle.expires_at > current:
+                        raise
                     # The bundle is sound and merely expired. A cell that has never
-                    # been admitted or routed has never served a request under it,
-                    # so nothing is depending on the old session and re-minting is
-                    # the same act as minting one for a cell that had none.
+                    # served -- not admitted, not serving, no routes open -- has
+                    # never answered a request under it, so nothing depends on the
+                    # old session and re-minting is the same act as minting one for
+                    # a cell that had none.
                     #
                     # Provisioning a cell is not instantaneous: the bundle is minted
                     # at `install_release`, and any pause before initialize -- a
@@ -738,12 +750,16 @@ class LiveLifecyclePlane:
                     # elapsed time indistinguishable from a forged attestation, and
                     # leaves a cell that can never finish provisioning.
                     snapshot = self._snapshot(metadata)
-                    if snapshot.runtime_admitted or snapshot.routes != (False, False):
+                    if (
+                        snapshot.runtime_admitted
+                        or snapshot.serving
+                        or snapshot.routes != (False, False)
+                    ):
                         raise MetadataConflict(
                             "authorization session expired on a serving cell",
                             reason=(ConflictReason.AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL),
-                        ) from None
-                    bundle = await _mint()
+                        ) from error
+                    bundle = await _mint(expected_revision=bundle.revision)
         return bundle.revision
 
     async def _authorization_helm_values(

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -11,6 +11,7 @@ from exomem.governance import authorization_custody, authorization_serving_membe
 from pydantic import ValidationError
 
 from exomem_provisioner.authorization_membership import (
+    AUTHORIZATION_SESSION_SCHEMA_VERSION,
     build_initial_hosted_authorization_bundle,
     inspect_hosted_authorization_bundle,
 )
@@ -2154,3 +2155,172 @@ async def test_genuine_retarget_still_requires_the_operator_recovery_receipt() -
     with pytest.raises(MetadataConflict) as raised:
         await plane.provision_retarget_required(metadata, request, config)
     assert raised.value.reason is ConflictReason.RETARGET_RECOVERY_RECEIPT_INVALID
+
+
+def _expiring_bundle_plane(
+    metadata: OpaqueProviderMetadata,
+    *,
+    minted_at: int,
+    now: int,
+    runtime_admitted: bool,
+    routes: tuple[bool, bool],
+):
+    """A live plane whose cell already holds a bundle minted at `minted_at`.
+
+    The bundle is produced by the production builder rather than hand-written,
+    so it is exactly the shape `install_release` leaves behind.
+    """
+
+    config = SimpleNamespace(
+        image="ghcr.io/artexis10/exomem@sha256:" + "a" * 64,
+        browser_origin="https://substratesystems.io",
+        control_hostname="control.example.invalid",
+        transfer_hostname="transfer.example.invalid",
+        protocol_version="1",
+        release_version="0.68.3",
+        migration_mode="state-root-v1",
+        runtime_target_for=lambda _request, *, v2: {
+            "releaseVersion": "0.68.3",
+            "protocolVersion": "1",
+        },
+    )
+    envelopes = cell_provider_recovery_envelopes(
+        IDENTITY_CODEC,
+        tenant_id=metadata.tenant_id,
+        cell_id=metadata.subject_id,
+        operation_id=metadata.operation_id,
+        fence_generation=metadata.fence_generation,
+        resource_name=metadata.resource_name,
+        operation_resource_name=provider_operation_resource_name(metadata.operation_id),
+    )
+    request = {
+        "provisionMode": "serve",
+        "workerPolicy": {"workerCount": 2, "semantic": True, "media": False},
+        "_providerRecoveryEnvelopes": envelopes,
+    }
+    original = build_initial_hosted_authorization_bundle(
+        cell_id=metadata.subject_id,
+        logical_vault_id=metadata.tenant_id,
+        replica_id=metadata.resource_name + "-0",
+        software_version="0.68.3",
+        schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+        recovery_envelope=envelopes["authorizationSessionSecret"],
+        now=minted_at,
+    )
+    written: list[dict[str, bytes]] = []
+    applied: list[dict[str, object]] = []
+
+    class Cell:
+        files = original.files
+
+        async def read_authorization_session_bundle(self, _owner):
+            return self.files
+
+        async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
+            self.files = files
+            written.append(files)
+
+    class Helm:
+        async def ensure_release(self, _owner, values):
+            applied.append(values)
+
+    class Routes:
+        async def enable(self, _owner):  # pragma: no cover - Helm carries identity
+            raise AssertionError("direct route writes lose provider recovery identity")
+
+    class Registry:
+        async def inspect(self, _current, _owner):
+            return SimpleNamespace(runtime_admitted=runtime_admitted, routes=routes)
+
+    plane = LiveLifecyclePlane(
+        repository=SimpleNamespace(),  # type: ignore[arg-type]
+        registry=Registry(),  # type: ignore[arg-type]
+        cell=Cell(),  # type: ignore[arg-type]
+        helm=Helm(),  # type: ignore[arg-type]
+        runtime=SimpleNamespace(),  # type: ignore[arg-type]
+        routes=Routes(),  # type: ignore[arg-type]
+        maintenance=SimpleNamespace(),  # type: ignore[arg-type]
+        capacity=SimpleNamespace(),  # type: ignore[arg-type]
+        identity_verifier=IDENTITY_CODEC.verifier(),
+        config=config,  # type: ignore[arg-type]
+        now=lambda: now,
+    )
+    key = plane._key(metadata)
+    plane._owned[key] = metadata
+    plane._helm_requests[key] = request
+    plane._snapshots[key] = SimpleNamespace(runtime_admitted=runtime_admitted, routes=routes)
+    return plane, request, original, written, applied
+
+
+@pytest.mark.asyncio
+async def test_expired_authorization_bundle_is_reminted_before_the_cell_serves() -> None:
+    """Elapsed time must not strand a cell that has never served a request.
+
+    The bundle is minted at `install_release` and carries a one-hour attestation
+    TTL. Any pause before the cell is routed -- a retry, an operator recovery, a
+    slow CSI attach -- can outlast it. Treating that as a terminal conflict makes
+    elapsed time indistinguishable from a forged attestation and leaves a cell
+    that can never finish provisioning, which is what happened on
+    exomem-alpha-01: minted 10:55:16Z, expired 11:55:16Z, retried 11:58Z.
+    """
+
+    metadata = _metadata()
+    minted_at = 1_900_000_000
+    plane, request, original, written, applied = _expiring_bundle_plane(
+        metadata,
+        minted_at=minted_at,
+        now=minted_at + 3_700,  # past the 3600s attestation TTL
+        runtime_admitted=False,
+        routes=(False, False),
+    )
+
+    await plane.enable_routes(metadata, request)
+
+    assert written, "an expired bundle on an unrouted cell must be re-minted"
+    assert written[-1] != original.files
+    assert applied and applied[-1]["authorizationSessionRevision"] != original.revision
+
+
+@pytest.mark.asyncio
+async def test_expired_authorization_bundle_still_refuses_on_a_serving_cell() -> None:
+    """Re-minting must not silently rotate the session of a live cell.
+
+    A cell that is admitted or routed has served under this keyring, so the
+    fix above must not reach it: that would be a session rotation disguised as
+    a provisioning step.
+    """
+
+    metadata = _metadata()
+    minted_at = 1_900_000_000
+    plane, request, _original, written, _applied = _expiring_bundle_plane(
+        metadata,
+        minted_at=minted_at,
+        now=minted_at + 3_700,
+        runtime_admitted=True,
+        routes=(True, True),
+    )
+
+    with pytest.raises(MetadataConflict) as raised:
+        await plane.enable_routes(metadata, request)
+    assert raised.value.reason is ConflictReason.AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL
+    assert not written, "a serving cell's session must never be re-minted"
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_authorization_bundle_is_reused_rather_than_reminted() -> None:
+    """The ordinary case must not start rotating bundles on every reconcile."""
+
+    metadata = _metadata()
+    minted_at = 1_900_000_000
+    plane, request, original, written, applied = _expiring_bundle_plane(
+        metadata,
+        minted_at=minted_at,
+        now=minted_at + 60,  # well inside the TTL
+        runtime_admitted=False,
+        routes=(False, False),
+    )
+
+    await plane.enable_routes(metadata, request)
+
+    assert not written, "a fresh bundle must be reused, not re-minted"
+    assert applied and applied[-1]["authorizationSessionRevision"] == original.revision

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -31,6 +31,7 @@ from exomem_provisioner.lifecycle import (
 )
 from exomem_provisioner.live import (
     KubernetesProviderRegistry,
+    KubernetesProviderSnapshot,
     LiveLifecyclePlane,
 )
 from exomem_provisioner.models import CapacityReservationClass, ResourceKind
@@ -2162,13 +2163,16 @@ def _expiring_bundle_plane(
     *,
     minted_at: int,
     now: int,
-    runtime_admitted: bool,
-    routes: tuple[bool, bool],
+    serving: bool = False,
+    runtime_admitted: bool = False,
+    routes: tuple[bool, bool] = (False, False),
 ):
     """A live plane whose cell already holds a bundle minted at `minted_at`.
 
-    The bundle is produced by the production builder rather than hand-written,
-    so it is exactly the shape `install_release` leaves behind.
+    The bundle comes from the production builder and the snapshot is a real
+    `KubernetesProviderSnapshot`, so neither can agree with the code under test
+    by construction. `init_complete` is False so `initialize` takes the branch
+    that reads the bundle back -- the branch the incident actually hit.
     """
 
     config = SimpleNamespace(
@@ -2207,7 +2211,17 @@ def _expiring_bundle_plane(
         recovery_envelope=envelopes["authorizationSessionSecret"],
         now=minted_at,
     )
-    written: list[dict[str, bytes]] = []
+    snapshot = KubernetesProviderSnapshot(
+        namespace=True,
+        release=True,
+        init_job_present=False,
+        init_complete=False,
+        init_failed=False,
+        serving=serving,
+        runtime_admitted=runtime_admitted,
+        routes=routes,
+    )
+    written: list[dict[str, object]] = []
     applied: list[dict[str, object]] = []
 
     class Cell:
@@ -2216,21 +2230,17 @@ def _expiring_bundle_plane(
         async def read_authorization_session_bundle(self, _owner):
             return self.files
 
-        async def write_authorization_session_bundle(self, _owner, files, **_kwargs):
+        async def write_authorization_session_bundle(self, _owner, files, **kwargs):
             self.files = files
-            written.append(files)
+            written.append({"files": files, **kwargs})
 
     class Helm:
         async def ensure_release(self, _owner, values):
             applied.append(values)
 
-    class Routes:
-        async def enable(self, _owner):  # pragma: no cover - Helm carries identity
-            raise AssertionError("direct route writes lose provider recovery identity")
-
     class Registry:
         async def inspect(self, _current, _owner):
-            return SimpleNamespace(runtime_admitted=runtime_admitted, routes=routes)
+            return snapshot
 
     plane = LiveLifecyclePlane(
         repository=SimpleNamespace(),  # type: ignore[arg-type]
@@ -2238,7 +2248,7 @@ def _expiring_bundle_plane(
         cell=Cell(),  # type: ignore[arg-type]
         helm=Helm(),  # type: ignore[arg-type]
         runtime=SimpleNamespace(),  # type: ignore[arg-type]
-        routes=Routes(),  # type: ignore[arg-type]
+        routes=SimpleNamespace(),  # type: ignore[arg-type]
         maintenance=SimpleNamespace(),  # type: ignore[arg-type]
         capacity=SimpleNamespace(),  # type: ignore[arg-type]
         identity_verifier=IDENTITY_CODEC.verifier(),
@@ -2248,51 +2258,46 @@ def _expiring_bundle_plane(
     key = plane._key(metadata)
     plane._owned[key] = metadata
     plane._helm_requests[key] = request
-    plane._snapshots[key] = SimpleNamespace(runtime_admitted=runtime_admitted, routes=routes)
-    return plane, request, original, written, applied
+    plane._snapshots[key] = snapshot
+    return plane, request, config, original, written, applied
 
 
 @pytest.mark.asyncio
 async def test_expired_authorization_bundle_is_reminted_before_the_cell_serves() -> None:
     """Elapsed time must not strand a cell that has never served a request.
 
-    The bundle is minted at `install_release` and carries a one-hour attestation
-    TTL. Any pause before the cell is routed -- a retry, an operator recovery, a
-    slow CSI attach -- can outlast it. Treating that as a terminal conflict makes
-    elapsed time indistinguishable from a forged attestation and leaves a cell
-    that can never finish provisioning, which is what happened on
-    exomem-alpha-01: minted 10:55:16Z, expired 11:55:16Z, retried 11:58Z.
+    The bundle is minted at `install_release` with a one-hour attestation TTL.
+    Any pause before initialize -- a retry, an operator recovery, a slow CSI
+    attach -- can outlast it. Treating that as terminal makes elapsed time
+    indistinguishable from a forged attestation and leaves a cell that can
+    never finish provisioning, which is what happened on exomem-alpha-01:
+    minted 10:55:16Z, expired 11:55:16Z, retried 11:58Z.
     """
 
     metadata = _metadata()
     minted_at = 1_900_000_000
-    plane, request, original, written, applied = _expiring_bundle_plane(
+    plane, request, config, original, written, applied = _expiring_bundle_plane(
         metadata,
         minted_at=minted_at,
         now=minted_at + 3_700,  # past the 3600s attestation TTL
-        runtime_admitted=False,
-        routes=(False, False),
     )
 
-    await plane.enable_routes(metadata, request)
+    await plane.initialize(metadata, request, config)  # type: ignore[arg-type]
 
-    assert written, "an expired bundle on an unrouted cell must be re-minted"
-    assert written[-1] != original.files
-    assert applied and applied[-1]["authorizationSessionRevision"] != original.revision
+    assert written, "an expired bundle on a cell that never served must be re-minted"
+    assert written[-1]["files"] != original.files
+    # Replacing an existing bundle must be a compare-and-swap on what we read.
+    assert written[-1]["expected_revision"] == original.revision
+    assert applied and applied[0]["authorizationSessionRevision"] != original.revision
 
 
 @pytest.mark.asyncio
-async def test_expired_authorization_bundle_still_refuses_on_a_serving_cell() -> None:
-    """Re-minting must not silently rotate the session of a live cell.
-
-    A cell that is admitted or routed has served under this keyring, so the
-    fix above must not reach it: that would be a session rotation disguised as
-    a provisioning step.
-    """
+async def test_expired_authorization_bundle_still_refuses_on_an_admitted_cell() -> None:
+    """Re-minting must never silently rotate the session of a live cell."""
 
     metadata = _metadata()
     minted_at = 1_900_000_000
-    plane, request, _original, written, _applied = _expiring_bundle_plane(
+    plane, request, config, _original, written, _applied = _expiring_bundle_plane(
         metadata,
         minted_at=minted_at,
         now=minted_at + 3_700,
@@ -2301,9 +2306,63 @@ async def test_expired_authorization_bundle_still_refuses_on_a_serving_cell() ->
     )
 
     with pytest.raises(MetadataConflict) as raised:
-        await plane.enable_routes(metadata, request)
+        await plane.initialize(metadata, request, config)  # type: ignore[arg-type]
     assert raised.value.reason is ConflictReason.AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL
-    assert not written, "a serving cell's session must never be re-minted"
+    assert not written, "an admitted cell's session must never be re-minted"
+
+
+@pytest.mark.asyncio
+async def test_expired_authorization_bundle_still_refuses_on_a_serving_pod() -> None:
+    """`serving` alone must block the rotation, without admission or routes.
+
+    Admission and routes are downstream of a running pod, so a guard that reads
+    only those two would rotate the keyring under a cell that is already
+    answering requests. Nothing in this file asserts that ordering, so the
+    guard must not depend on it.
+    """
+
+    metadata = _metadata()
+    minted_at = 1_900_000_000
+    plane, request, config, _original, written, _applied = _expiring_bundle_plane(
+        metadata,
+        minted_at=minted_at,
+        now=minted_at + 3_700,
+        serving=True,
+        runtime_admitted=False,
+        routes=(False, False),
+    )
+
+    with pytest.raises(MetadataConflict) as raised:
+        await plane.initialize(metadata, request, config)  # type: ignore[arg-type]
+    assert raised.value.reason is ConflictReason.AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL
+    assert not written, "a serving pod's session must never be re-minted"
+
+
+@pytest.mark.asyncio
+async def test_a_future_dated_authorization_bundle_still_fails_closed() -> None:
+    """Only elapsed time may be forgiven, not any other freshness anomaly.
+
+    A future-dated bundle never reaches the re-mint branch: the keyring's own
+    validity window is checked unconditionally, so it is refused by the first
+    call rather than by the freshness re-check. That is the stronger guarantee,
+    and this pins it -- if the keyring window ever became conditional on
+    `_require_fresh`, a not-yet-valid bundle would start looking like an
+    expired one, and the `expires_at` assertion in the re-mint branch is what
+    would then have to catch it.
+    """
+
+    metadata = _metadata()
+    minted_at = 1_900_000_000
+    plane, request, config, _original, written, _applied = _expiring_bundle_plane(
+        metadata,
+        minted_at=minted_at,
+        now=minted_at - 600,  # the bundle is not valid yet
+    )
+
+    with pytest.raises(MetadataConflict) as raised:
+        await plane.initialize(metadata, request, config)  # type: ignore[arg-type]
+    assert raised.value.reason is ConflictReason.AUTHORIZATION_KEYRING_IS_INVALID
+    assert not written, "a future-dated bundle must fail closed, not be re-minted"
 
 
 @pytest.mark.asyncio
@@ -2312,15 +2371,13 @@ async def test_a_fresh_authorization_bundle_is_reused_rather_than_reminted() -> 
 
     metadata = _metadata()
     minted_at = 1_900_000_000
-    plane, request, original, written, applied = _expiring_bundle_plane(
+    plane, request, config, original, written, applied = _expiring_bundle_plane(
         metadata,
         minted_at=minted_at,
         now=minted_at + 60,  # well inside the TTL
-        runtime_admitted=False,
-        routes=(False, False),
     )
 
-    await plane.enable_routes(metadata, request)
+    await plane.initialize(metadata, request, config)  # type: ignore[arg-type]
 
     assert not written, "a fresh bundle must be reused, not re-minted"
-    assert applied and applied[-1]["authorizationSessionRevision"] == original.revision
+    assert applied and applied[0]["authorizationSessionRevision"] == original.revision


### PR DESCRIPTION
## What was broken

The authorization session bundle is minted during `install_release` and carries a one-hour attestation TTL (`DEFAULT_ATTESTATION_TTL_SECONDS = 3600`). `initialize` and `enable_routes` later read it back and validate it with `_require_fresh=True`. Any pause between those two points — a retry, an operator recovery, a slow CSI attach — can outlast the TTL and fail the provision terminally with `PROVISIONER_PROVIDER_METADATA_CONFLICT`, reason `authorization-control-is-invalid`.

Measured on exomem-alpha-01, 2026-09-05, from the cell's own Secret:

```
issued_at   1788605716  = 10:55:16Z   (minted at install_release)
expires_at  1788609316  = 11:55:16Z
retry ran   ~11:58Z                   → three minutes late
```

The cell had never started a pod, was never admitted, and had no routes open — nothing had ever served under that session. Elapsed time was reported as though it were a forged attestation, and the cell could never finish provisioning.

This is the second instance today of the same shape: a condition that only means *time passed* folded into a terminal conflict, behind a label shared by ~20 distinct clauses. It surfaced immediately after #1080 because that fix let the provision reach this code for the first time.

## The change

An expired bundle on a cell that has never served is the same situation as a cell with **no** bundle — which the code already handles by minting one.

So: validate everything except the elapsed-time window first (`_require_fresh=False`), then re-validate with the window. The only two clauses gated on `_require_fresh` are the control and serving-membership freshness windows (`authorization_membership.py:539`, `:620`) and nothing else, so a bundle that passes the first call and fails the second has nothing wrong with it but age. In that case, re-mint.

**The guard is kept where it means something.** A cell that is admitted or routed has served requests under this keyring; re-minting there would be a session rotation disguised as a provisioning step. That case now refuses under its own label, `AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL`, rather than being folded into the compound condition.

## Tests

Three, all driving `LiveLifecyclePlane`, with the bundle built by the **production builder** rather than a hand-written fixture so it cannot agree by construction:

- `test_expired_authorization_bundle_is_reminted_before_the_cell_serves` — **red** against the parent commit with the exact production error, `MetadataConflict: authorization control is invalid`.
- `test_expired_authorization_bundle_still_refuses_on_a_serving_cell` — **red** against the parent (the reason does not exist there); proves the guard was narrowed, not deleted.
- `test_a_fresh_authorization_bundle_is_reused_rather_than_reminted` — passes before and after; guards against this starting to rotate sessions on every reconcile.

Red-first was verified by building a reverted source tree and forcing `PYTHONPATH` at it, because the editable install otherwise resolves to the fixed code.

## Verification

```
556 passed, 17 skipped in 72.70s
```

Baseline 553/17 (the count after #1080); the three added tests are the difference. `ruff check` and `ruff format --check` clean.

## Still worth fixing separately

`authorization-control-is-invalid` still covers roughly twenty distinct rejection causes behind one label, which is the same opacity the `ConflictReason` vocabulary exists to remove. This PR splits out only the one cause it needed to. The provisioner suite also still runs in no CI workflow.