### PR TITLE
fix(hosted): serve the agent profile the deployment selects

### DIFF
--- a/infra/helm/cell/templates/statefulset.yaml
+++ b/infra/helm/cell/templates/statefulset.yaml
@@ -107,6 +107,10 @@ spec:
               value: {{ printf "%.0f" .Values.recordsReaderVersion | quote }}
             - name: EXOMEM_HOSTED_LIFECYCLE_ACTIONS_ENABLED
               value: {{ .Values.lifecycleActionsEnabled | quote }}
+            {{- with .Values.agentProfile }}
+            - name: EXOMEM_HOSTED_AGENT_PROFILE
+              value: {{ . | quote }}
+            {{- end }}
             - name: EXOMEM_AUTH_SESSION_KEYRING_FILE
               value: /run/exomem/authorization-session/private/keyring.json
             - name: EXOMEM_AUTH_SESSION_CONTROL_FILE

--- a/infra/helm/cell/values.schema.json
+++ b/infra/helm/cell/values.schema.json
@@ -13,6 +13,7 @@
     "image": {"type": "string", "pattern": "^[^\\s]+@sha256:[a-f0-9]{64}$"},
     "expectedRelease": {"type": "string", "minLength": 1, "maxLength": 64},
     "expectedProtocol": {"type": "string", "const": "1"},
+    "agentProfile": {"type": "string"},
     "workerPolicyDigest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
     "recordsReaderVersion": {"type": "integer", "minimum": 2},
     "lifecycleActionsEnabled": {"type": "boolean"},

--- a/infra/helm/cell/values.yaml
+++ b/infra/helm/cell/values.yaml
@@ -7,6 +7,7 @@ provisionMode: serve
 image: ""
 expectedRelease: ""
 expectedProtocol: "1"
+agentProfile: ""
 workerPolicyDigest: ""
 # Every cell boots the current reader; profile selection controls writes.
 recordsReaderVersion: 2

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -1811,6 +1811,7 @@ def _fixed_helm_values(
     ).encode("utf-8")
     values: dict[str, Any] = {
         "activeCredentialVersion": "1",
+        "agentProfile": target.get("agentProfile", ""),
         "browserOrigin": config.browser_origin,
         "cellId": metadata.subject_id,
         "credentialsSecretName": "exomem-cell-credentials",

--- a/infra/provisioner/tests/test_provider_lifecycle.py
+++ b/infra/provisioner/tests/test_provider_lifecycle.py
@@ -180,6 +180,7 @@ def test_fixed_helm_values_use_one_selected_rollback_runtime_unit() -> None:
     assert values["image"] == config.image
     assert values["expectedRelease"] == "0.21.0"
     assert values["expectedProtocol"] == "1"
+    assert values["agentProfile"] == "hosted-alpha-agent-v1"
     assert values["recordsReaderVersion"] == 2
     assert values["lifecycleActionsEnabled"] is False
 
@@ -1196,6 +1197,7 @@ async def test_provision_adopts_partial_attempt_and_waits_for_volume_health_and_
     assert plane.count_volumes(_metadata()) == 1
     assert plane.helm_values(_metadata()) == {
         "activeCredentialVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v1",
         "browserOrigin": "https://substratesystems.io",
         "cellId": "cell-alpha",
         "credentialsSecretName": "exomem-cell-credentials",

--- a/openspec/changes/fix-hosted-runtime-profile-selection/.openspec.yaml
+++ b/openspec/changes/fix-hosted-runtime-profile-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/fix-hosted-runtime-profile-selection/design.md
+++ b/openspec/changes/fix-hosted-runtime-profile-selection/design.md
@@ -1,0 +1,25 @@
+## Context
+
+See proposal.md for the observed failure. `HostedCellConfig.active_agent_profile` currently returns v1 or v2 from `lifecycle_actions_enabled`. The provisioner already has `runtimeTarget.agentProfile`, but `_fixed_helm_values` does not forward it. The cell chart has no corresponding environment input. Existing v3/v4 route tests replace the profile-selection property.
+
+## Goals / Non-Goals
+
+The selected deployment profile must reach the authenticated runtime contract unchanged. Older charts must continue to boot with their original v1/v2 behavior. Public callers cannot select a different profile. This repair does not change command membership, Records lifecycle authorization, admission, or promotion.
+
+## Decisions
+
+1. Add optional `agent_profile` to `HostedCellConfig`, parsed from `EXOMEM_HOSTED_AGENT_PROFILE`. Resolve an explicit nonempty value using the canonical hosted profile registry. Unknown values fail closed before routes are registered. Profiles containing `record_memory` require Records reader version 2. The existing lifecycle-enabled/reader-version check remains in force.
+2. With no explicit profile, preserve the current v1/v2 derivation. Use an empty default for the new optional cell chart value `agentProfile` and omit its environment variable when empty. This supports existing rendered values and older deployments without changing their exposed surface.
+3. `_fixed_helm_values` forwards `target.agentProfile` when present. The target already follows the authenticated and verified deployment contract; no additional request-controlled selection is introduced. The serve StatefulSet passes the value to the runtime. Initialization does not serve agent routes and does not need selection to provision the filesystem.
+4. Keep Records lifecycle action enablement independent. Explicit v3/v4 selection with actions disabled still serves the selected profile; the existing `revise`/`rebaseline` guard continues to reject those actions. Do not widen the existing provider feature-flag policy as part of this fix.
+5. Regression tests must follow producer output: provisioner target to chart values, rendered StatefulSet environment to `HostedCellConfig.from_env`, then real authenticated profile contract routes. The v4 assertion derives command membership and digests from the canonical builder. Never stub `active_agent_profile` in this regression.
+
+## Risks / Trade-offs
+
+- A new provisioner with an old runtime can still select an unsupported profile. Existing private health identity verification remains mandatory and prevents binding a mismatched cell.
+- Explicit profile selection can expose newer existing commands. The selected target is trusted configuration, registry resolution rejects unknown names, and all existing command authorization and protected-tree guards remain active.
+- Updating the running failed candidate requires a new verified image composition. Preserve the failed cell until recovery eligibility is established; this implementation does not directly patch its filesystem, database, or admission records.
+
+## Migration Plan
+
+Build and verify updated runtime and provisioner candidates, compose them using the existing deployment-lock workflow, and deploy through the existing operator path. Confirm the selected profile's authenticated contract and command digest before binding or promotion. Legacy deployment rollback retains its original profile selection when the new field is absent.

--- a/openspec/changes/fix-hosted-runtime-profile-selection/proposal.md
+++ b/openspec/changes/fix-hosted-runtime-profile-selection/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+A hosted candidate selecting `hosted-alpha-agent-v4` provisions a healthy runtime that serves only v1: the runtime infers its profile from a Records feature flag, and provisioning never passes the selected profile. Its authenticated v4 contract request therefore fails with `HOSTED_SURFACE_PROFILE_UNSUPPORTED`, preventing cell binding.
+
+## What Changes
+
+- Carry the selected runtime target's profile through the cell chart into trusted runtime configuration.
+- Validate explicit profiles against the existing canonical registry and serve exactly the selected profile.
+- Preserve the v1/v2 fallback for deployments that omit explicit selection and retain independent Records lifecycle gates.
+- Exercise profile selection through real configuration and authenticated routes, without overriding the selection property.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `hosted-agent-surface`: the runtime must serve the profile selected by its trusted deployment configuration.
+
+## Impact
+
+Hosted runtime configuration, provisioner chart values, the cell Helm chart, and their regression tests. No public request field, profile membership, credential, database schema, or promotion policy changes. Rollout requires rebuilt runtime and provisioner images with a verified deployment composition.

--- a/openspec/changes/fix-hosted-runtime-profile-selection/specs/hosted-agent-surface/spec.md
+++ b/openspec/changes/fix-hosted-runtime-profile-selection/specs/hosted-agent-surface/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Runtime Serves The Trusted Deployment Profile
+
+A hosted cell SHALL serve exactly the registered agent profile selected by its trusted deployment configuration. Provisioning MUST preserve the selected runtime target's profile through to the running cell. An unknown explicit profile MUST fail closed; public request fields MUST NOT override the configured selection. Omission of explicit selection MUST preserve the existing v1/v2 fallback. Profile selection MUST NOT enable Records lifecycle actions independently of their existing gate, and a profile exposing Records MUST require reader version 2.
+
+#### Scenario: Provisioned v4 cell exposes its selected contract
+
+- **WHEN** a cell is provisioned with a runtime target selecting `hosted-alpha-agent-v4`
+- **THEN** its authenticated v4 contract route returns the canonical v4 contract and ordered command membership
+- **AND** an authenticated request for an unselected profile is rejected
+
+#### Scenario: Existing deployment omits explicit selection
+
+- **WHEN** a deployment provides no explicit agent profile
+- **THEN** the runtime retains its existing v1 selection with lifecycle actions disabled or v2 selection with lifecycle actions enabled
+
+#### Scenario: Unsupported explicit selection is rejected
+
+- **WHEN** trusted configuration explicitly names an unregistered profile or a Records profile with an incompatible reader
+- **THEN** startup fails with a stable configuration error before registering agent routes
+
+#### Scenario: Selection does not grant lifecycle mutations
+
+- **WHEN** v3 or v4 is explicitly selected with Records lifecycle actions disabled
+- **THEN** the selected profile's contract remains available
+- **AND** lifecycle mutations remain rejected through the existing action gate

--- a/openspec/changes/fix-hosted-runtime-profile-selection/tasks.md
+++ b/openspec/changes/fix-hosted-runtime-profile-selection/tasks.md
@@ -1,0 +1,14 @@
+## 1. Configuration and wiring
+
+- [x] 1.1 Add failing real-configuration tests for explicit v3/v4 selection, unknown profiles, incompatible readers, and legacy defaults; retain the failing output.
+- [x] 1.2 Carry the trusted runtime target profile through provisioner chart values and the StatefulSet environment into validated runtime selection; verify the focused configuration, chart, and provisioner tests pass.
+
+## 2. Integration evidence
+
+- [x] 2.1 Exercise authenticated v4 contract discovery from rendered environment using the production configuration class, rejecting unselected profiles and preserving lifecycle action restrictions; verify regression and protected-tree suites pass without overriding selection.
+- [x] 2.2 Independently review the actual diff and reproduce the failure/fix; run scoped gates, the completion test corpus, public-artifact privacy validation, and strict OpenSpec validation before opening a ready pull request.
+
+## 3. Delivery
+
+- [ ] 3.1 Merge the reviewed change when authorized, rebuild and compose runtime/provisioner candidates, and verify the deployed cell returns the selected authenticated profile contract before binding or promotion.
+- [ ] 3.2 Synchronize and archive the shipped change through OpenSpec, validating all specs strictly before and after archive.

--- a/scripts/promotion_evidence.py
+++ b/scripts/promotion_evidence.py
@@ -11,11 +11,27 @@ file the operator writes after running it; the six counts are queried from the
 control plane and the run aborts unless each is exactly 1. A harness that
 defaulted those to true/1 would turn the signed-evidence chain into decoration.
 
-Everything here is timing-critical for the FIRST promotion only. The bootstrap
-authority is capped server-side at 30 minutes, the rollout assignment inherits
-that expiry, and `storeClientArtifact` requires the assignment still be active --
-so observe, sign, both imports and promote all have to land inside it. Rehearse
-against an existing tenant before opening a window.
+The window is the staged release's, and you choose it. This paragraph used to
+say the rollout assignment inherited the bootstrap authority's thirty-minute
+expiry, so everything after `run` -- provisioning, a human completing seven
+manual operations per platform, then observe, sign, import and promote -- had to
+land inside half an hour. It never fit, and it is no longer true: substrate #140
+gives the assignment `exomem_staged_client_releases.expires_at` instead.
+
+What still bounds you, in order:
+
+* The staged release -- `reviewer_bootstrap.py prepare --stage-minutes N`, up to
+  seven days. It gates `storeClientArtifact` and the `cells` precondition inside
+  `promoteExomemHostedCohort`, both of which re-check it independently.
+* The canary credential, `LEAST(requested, assignment, stage)`, requested at 24
+  hours. The clean-client runs need it, so the manual half has 24 hours however
+  long the stage is. Size the stage past that -- 48 hours leaves a day for
+  observe/sign/import/promote after the canary dies.
+* The bootstrap authority, 28 minutes requested against a 30-minute server cap.
+  It spans only the OAuth exchange inside `run`, which is automated, and it is
+  spent the instant the assignment row exists.
+
+Rehearse against an existing tenant before opening a window anyway.
 
 Resolve these FOUR environment variables before starting, not during the window.
 Two of them name nothing that is deployed under that name, and one is not

--- a/src/exomem/hosted_runtime.py
+++ b/src/exomem/hosted_runtime.py
@@ -69,6 +69,23 @@ _DEFAULT_UPLOAD_LIMIT_BYTES = 90 * 1024 * 1024
 _DEFAULT_WORKER_LIMIT = 0
 
 
+def _validate_agent_profile(profile_name: str, records_reader_version: int) -> str:
+    from . import commands as commands_module
+
+    profile = commands_module.PRODUCT_SURFACE_PROFILES.get(profile_name)
+    if profile is None:
+        raise HostedConfigError(
+            "HOSTED_AGENT_PROFILE_UNSUPPORTED",
+            "hosted agent profile is not supported by this release",
+        )
+    if "record_memory" in profile.command_names and records_reader_version != 2:
+        raise HostedConfigError(
+            "HOSTED_RECORDS_READER_UNSUPPORTED",
+            "Records profiles require Records reader version 2",
+        )
+    return profile.name
+
+
 class HostedConfigError(RuntimeError):
     """Fail-closed hosted configuration/provisioning error with a stable code."""
 
@@ -140,6 +157,7 @@ class HostedCellConfig:
     enforce_transfer_v1_compatibility: bool = True
     records_reader_version: int = 2
     lifecycle_actions_enabled: bool = False
+    agent_profile: str | None = None
     authorization_session_replica_id: str | None = None
 
     @classmethod
@@ -287,6 +305,9 @@ class HostedCellConfig:
                 "HOSTED_RECORDS_READER_UNSUPPORTED",
                 "lifecycle actions require Records reader version 2",
             )
+        agent_profile = str(values.get("EXOMEM_HOSTED_AGENT_PROFILE", "")).strip() or None
+        if agent_profile is not None:
+            agent_profile = _validate_agent_profile(agent_profile, records_reader_version)
         authorization_session_replica_id = (
             str(values.get("EXOMEM_AUTH_SESSION_REPLICA_ID", "")).strip() or None
         )
@@ -357,6 +378,7 @@ class HostedCellConfig:
             enforce_transfer_v1_compatibility=True,
             records_reader_version=records_reader_version,
             lifecycle_actions_enabled=lifecycle_actions_enabled,
+            agent_profile=agent_profile,
             authorization_session_replica_id=authorization_session_replica_id,
         )
         if require_provisioned:
@@ -399,12 +421,14 @@ class HostedCellConfig:
             raise HostedConfigError(
                 "HOSTED_RECORDS_READER_UNSUPPORTED", "Records reader version is unsupported"
             )
+        if self.lifecycle_actions_enabled and self.records_reader_version != 2:
+            raise HostedConfigError(
+                "HOSTED_RECORDS_READER_UNSUPPORTED",
+                "lifecycle actions require Records reader version 2",
+            )
+        if self.agent_profile is not None:
+            return _validate_agent_profile(self.agent_profile, self.records_reader_version)
         if self.lifecycle_actions_enabled:
-            if self.records_reader_version != 2:
-                raise HostedConfigError(
-                    "HOSTED_RECORDS_READER_UNSUPPORTED",
-                    "lifecycle actions require Records reader version 2",
-                )
             return commands_module.HOSTED_ALPHA_AGENT_V2_PROFILE
         return commands_module.HOSTED_ALPHA_AGENT_PROFILE
 

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from exomem.hosted_runtime import HostedCellConfig
+
 ROOT = Path(__file__).resolve().parents[1]
 PLATFORM = ROOT / "infra/helm/platform"
 CELL = ROOT / "infra/helm/cell"
@@ -2667,6 +2669,31 @@ def test_cell_chart_renders_separate_privileged_init_and_restricted_serving_mode
         assert not [item for item in documents if item.get("kind") == "Job"]
     if service:
         assert service[0]["spec"]["type"] == "ClusterIP"
+
+
+def test_cell_chart_projects_a_selected_agent_profile_only_when_configured() -> None:
+    default_documents = _render(CELL, CELL / "values.validation.yaml", namespace="cell-alpha-test")
+    default_statefulset = _find(default_documents, "StatefulSet", "cell-alpha")
+    default_environment = {
+        item["name"]: item.get("value")
+        for item in default_statefulset["spec"]["template"]["spec"]["containers"][0]["env"]
+    }
+    assert "EXOMEM_HOSTED_AGENT_PROFILE" not in default_environment
+
+    selected_documents = _render(
+        CELL,
+        CELL / "values.validation.yaml",
+        namespace="cell-alpha-test",
+        extra_args=("--set", "agentProfile=hosted-alpha-agent-v4"),
+    )
+    selected_statefulset = _find(selected_documents, "StatefulSet", "cell-alpha")
+    selected_environment = {
+        item["name"]: item.get("value")
+        for item in selected_statefulset["spec"]["template"]["spec"]["containers"][0]["env"]
+    }
+    assert selected_environment["EXOMEM_HOSTED_AGENT_PROFILE"] == "hosted-alpha-agent-v4"
+    config = HostedCellConfig.from_env(selected_environment, require_provisioned=False)
+    assert config.active_agent_profile == "hosted-alpha-agent-v4"
 
 
 def test_cell_schema_rejects_mutable_image_and_non_fixed_limits() -> None:

--- a/tests/test_hosted_profile_selection.py
+++ b/tests/test_hosted_profile_selection.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import yaml
+from fastmcp import FastMCP
+
+from exomem import commands as commands_module
+from exomem import hosted_gateway, schema
+from exomem.hosted_runtime import HostedCellConfig, HostedCellLifecycle, HostedConfigError
+from exomem.server_hosted import register_hosted_routes
+
+
+def _env(tmp_path: Path, **overrides: str) -> dict[str, str]:
+    values = {
+        "EXOMEM_HOSTED_CELL": "1",
+        "EXOMEM_HOSTED_CELL_ID": "cell-alpha",
+        "EXOMEM_VAULT_PATH": str(tmp_path / "vault"),
+        "EXOMEM_HOSTED_STATE_ROOT": str(tmp_path / "state"),
+        "EXOMEM_LOG_DIR": str(tmp_path / "logs"),
+        "EXOMEM_HOSTED_SERVICE_CREDENTIAL": "hosted-profile-selection-credential",
+        "EXOMEM_HOSTED_RECORDS_READER_VERSION": "2",
+        "EXOMEM_HOSTED_LIFECYCLE_ACTIONS_ENABLED": "false",
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.mark.parametrize(
+    "profile",
+    (
+        commands_module.HOSTED_ALPHA_AGENT_V3_PROFILE,
+        commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE,
+    ),
+)
+def test_hosted_config_selects_an_explicit_registered_agent_profile(
+    tmp_path: Path, profile: str
+) -> None:
+    config = HostedCellConfig.from_env(
+        _env(tmp_path, EXOMEM_HOSTED_AGENT_PROFILE=profile), require_provisioned=False
+    )
+
+    assert config.active_agent_profile == profile
+
+
+def test_hosted_config_rejects_an_unknown_explicit_agent_profile(tmp_path: Path) -> None:
+    with pytest.raises(HostedConfigError) as error:
+        HostedCellConfig.from_env(
+            _env(tmp_path, EXOMEM_HOSTED_AGENT_PROFILE="hosted-alpha-agent-v999"),
+            require_provisioned=False,
+        )
+
+    assert error.value.code == "HOSTED_AGENT_PROFILE_UNSUPPORTED"
+
+
+def test_direct_hosted_config_rejects_an_unknown_explicit_agent_profile(tmp_path: Path) -> None:
+    config = replace(
+        HostedCellConfig.from_env(_env(tmp_path), require_provisioned=False),
+        agent_profile="hosted-alpha-agent-v999",
+    )
+
+    with pytest.raises(HostedConfigError) as error:
+        _ = config.active_agent_profile
+
+    assert error.value.code == "HOSTED_AGENT_PROFILE_UNSUPPORTED"
+
+
+def test_direct_hosted_config_rejects_lifecycle_actions_with_reader_one(
+    tmp_path: Path,
+) -> None:
+    from exomem.init import init_vault
+
+    values = _env(tmp_path)
+    init_vault(Path(values["EXOMEM_VAULT_PATH"]))
+    config = replace(
+        HostedCellConfig.from_env(values, require_provisioned=False),
+        agent_profile=commands_module.HOSTED_ALPHA_AGENT_PROFILE,
+        records_reader_version=1,
+        lifecycle_actions_enabled=True,
+    )
+
+    with pytest.raises(HostedConfigError) as error:
+        register_hosted_routes(
+            FastMCP("direct-config-lifecycle-guard"),
+            config=config,
+            lifecycle=HostedCellLifecycle(config),
+            source_schema=schema.load_source_schema(config.vault_root),
+        )
+
+    assert error.value.code == "HOSTED_RECORDS_READER_UNSUPPORTED"
+
+
+def test_hosted_config_requires_records_reader_two_for_a_records_profile(tmp_path: Path) -> None:
+    with pytest.raises(HostedConfigError) as error:
+        HostedCellConfig.from_env(
+            _env(
+                tmp_path,
+                EXOMEM_HOSTED_AGENT_PROFILE=commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE,
+                EXOMEM_HOSTED_RECORDS_READER_VERSION="1",
+            ),
+            require_provisioned=False,
+        )
+
+    assert error.value.code == "HOSTED_RECORDS_READER_UNSUPPORTED"
+
+
+@pytest.mark.parametrize(
+    ("lifecycle_actions_enabled", "expected_profile"),
+    (
+        ("false", commands_module.HOSTED_ALPHA_AGENT_PROFILE),
+        ("true", commands_module.HOSTED_ALPHA_AGENT_V2_PROFILE),
+    ),
+)
+def test_hosted_config_preserves_legacy_profile_fallback(
+    tmp_path: Path, lifecycle_actions_enabled: str, expected_profile: str
+) -> None:
+    config = HostedCellConfig.from_env(
+        _env(tmp_path, EXOMEM_HOSTED_LIFECYCLE_ACTIONS_ENABLED=lifecycle_actions_enabled),
+        require_provisioned=False,
+    )
+
+    assert config.active_agent_profile == expected_profile
+
+
+def test_configured_v4_profile_exposes_its_canonical_authenticated_contract(tmp_path: Path) -> None:
+    from exomem.init import init_vault
+
+    values = _env(
+        tmp_path,
+        EXOMEM_HOSTED_AGENT_PROFILE=commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE,
+    )
+    init_vault(Path(values["EXOMEM_VAULT_PATH"]))
+    config = HostedCellConfig.from_env(values, require_provisioned=False)
+    lifecycle = HostedCellLifecycle(config)
+    lifecycle.complete_startup(
+        vault_ready=True, mutation_authority_ready=True, service_auth_ready=True
+    )
+    app = FastMCP("hosted-profile-selection")
+    register_hosted_routes(
+        app,
+        config=config,
+        lifecycle=lifecycle,
+        source_schema=schema.load_source_schema(config.vault_root),
+    )
+
+    headers = {
+        "Authorization": f"Bearer {config.service_credential}",
+        hosted_gateway.CELL_HEADER: config.cell_id,
+        hosted_gateway.PROTOCOL_HEADER: config.protocol_version,
+        hosted_gateway.REQUEST_HEADER: "11111111-1111-4111-8111-111111111111",
+        hosted_gateway.PRINCIPAL_HEADER: base64.urlsafe_b64encode(
+            hashlib.sha256(b"profile-selection-principal").digest()
+        )
+        .rstrip(b"=")
+        .decode(),
+    }
+
+    async def request() -> tuple[httpx.Response, httpx.Response]:
+        transport = httpx.ASGITransport(app=app.http_app())
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            contract = await client.get(
+                f"/private/exomem/v1/agent/{config.active_agent_profile}/contract", headers=headers
+            )
+            lifecycle_action = await client.post(
+                f"/private/exomem/v1/agent/{config.active_agent_profile}/command/record_memory",
+                headers=headers,
+                json={"action": "revise"},
+            )
+            return contract, lifecycle_action
+
+    response, lifecycle_action = asyncio.run(request())
+
+    assert response.status_code == 200
+    assert response.json() == hosted_gateway.build_agent_gateway_contract(
+        profile=commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE,
+        protocol_version=config.protocol_version,
+    )
+    assert lifecycle_action.status_code == 400
+    assert lifecycle_action.json()["error"]["code"] == "HOSTED_RECORDS_LIFECYCLE_DISABLED"
+
+
+def test_provisioned_v4_profile_reaches_the_authenticated_runtime_contract(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    helm = os.environ.get("HELM_BIN") or shutil.which("helm")
+    assert helm, "Helm is required to render the cell chart"
+
+    producer = """
+import json
+import sys
+from dataclasses import replace
+
+sys.path.insert(0, {tests!r})
+from test_provider_lifecycle import _config, _metadata, _request_with_provider_identity, _runtime_target
+from exomem_provisioner.lifecycle import _fixed_helm_values
+
+target = _runtime_target(agentProfile={profile!r})
+config = replace(_config(), runtime_target=target, records_reader_version=2)
+request = _request_with_provider_identity()
+request.pop("releaseVersion")
+request.pop("protocolVersion")
+request["runtimeTarget"] = target
+print(json.dumps(_fixed_helm_values(_metadata(), request, config)))
+""".format(
+        tests=str(root / "infra/provisioner/tests"),
+        profile=commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE,
+    )
+    produced = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(root / "infra/provisioner"),
+            "--frozen",
+            "--python",
+            f"{sys.version_info.major}.{sys.version_info.minor}",
+            "python",
+            "-c",
+            producer,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "UV_PROJECT_ENVIRONMENT": str(tmp_path / "provisioner-environment"),
+        },
+    )
+    values = json.loads(produced.stdout)
+    assert values["agentProfile"] == commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE
+
+    chart_values = dict(values)
+    chart_values["authorizationSessionRevision"] = "a" * 64
+    chart_values["workloadMode"] = "serve"
+    values_path = tmp_path / "rendered-values.yaml"
+    values_path.write_text(yaml.safe_dump(chart_values), encoding="utf-8")
+
+    rendered = subprocess.run(
+        [
+            str(helm),
+            "template",
+            "profile-selection",
+            str(root / "infra/helm/cell"),
+            "--namespace",
+            "cell-alpha-test",
+            "--values",
+            str(values_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    statefulset = next(
+        document
+        for document in yaml.safe_load_all(rendered.stdout)
+        if document.get("kind") == "StatefulSet"
+    )
+    environment = {
+        item["name"]: item["value"]
+        for item in statefulset["spec"]["template"]["spec"]["containers"][0]["env"]
+        if "value" in item
+    }
+    environment["EXOMEM_AUTH_SESSION_REPLICA_ID"] = "cell-alpha-0"
+    rendered_config = HostedCellConfig.from_env(environment, require_provisioned=False)
+    assert rendered_config.active_agent_profile == commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE
+
+    from exomem.init import init_vault
+
+    vault_root = tmp_path / "vault"
+    init_vault(vault_root)
+    config = replace(
+        rendered_config,
+        vault_root=vault_root,
+        state_root=tmp_path / "state",
+        log_root=tmp_path / "logs",
+        runtime_uid=os.geteuid(),
+        runtime_gid=os.getegid(),
+        enforce_transfer_v1_compatibility=False,
+    )
+    lifecycle = HostedCellLifecycle(config)
+    lifecycle.complete_startup(
+        vault_ready=True, mutation_authority_ready=True, service_auth_ready=True
+    )
+    credential = "hosted-profile-selection-dynamic-credential"
+
+    class DynamicAuthority:
+        def authenticate(self, presented: str | None) -> object | None:
+            if presented == credential:
+                return SimpleNamespace(credential_version="active-v1", security_revision=1)
+            return None
+
+    app = FastMCP("rendered-profile-selection")
+    register_hosted_routes(
+        app,
+        config=config,
+        lifecycle=lifecycle,
+        source_schema=schema.load_source_schema(vault_root),
+        private_authenticator=DynamicAuthority(),
+    )
+    headers = {
+        "Authorization": f"Bearer {credential}",
+        hosted_gateway.CELL_HEADER: config.cell_id,
+        hosted_gateway.PROTOCOL_HEADER: config.protocol_version,
+        hosted_gateway.REQUEST_HEADER: "11111111-1111-4111-8111-111111111111",
+        hosted_gateway.PRINCIPAL_HEADER: base64.urlsafe_b64encode(
+            hashlib.sha256(b"rendered-profile-selection-principal").digest()
+        )
+        .rstrip(b"=")
+        .decode(),
+    }
+
+    async def request() -> tuple[httpx.Response, httpx.Response]:
+        transport = httpx.ASGITransport(app=app.http_app())
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            selected = await client.get(
+                f"/private/exomem/v1/agent/{config.active_agent_profile}/contract", headers=headers
+            )
+            unselected = await client.get(
+                "/private/exomem/v1/agent/hosted-alpha-agent-v1/contract", headers=headers
+            )
+            return selected, unselected
+
+    selected, unselected = asyncio.run(request())
+
+    assert selected.status_code == 200
+    assert selected.json() == hosted_gateway.build_agent_gateway_contract(
+        profile=commands_module.HOSTED_ALPHA_AGENT_V4_PROFILE,
+        protocol_version=config.protocol_version,
+    )
+    assert unselected.status_code == 400
+    assert unselected.json()["error"]["code"] == "HOSTED_SURFACE_PROFILE_UNSUPPORTED"

--- a/tests/test_hosted_protected_tree_guard.py
+++ b/tests/test_hosted_protected_tree_guard.py
@@ -51,26 +51,6 @@ PRINCIPAL = (
 )
 
 
-class _ProfileConfig(HostedCellConfig):
-    """A cell whose operator has selected the epistemic profile.
-
-    Only the profile *selection* input is stubbed. Everything downstream --
-    routing, auth, coercion, admission, the command leaf -- is the real thing.
-    """
-
-    @property
-    def active_agent_profile(self) -> str:
-        return V3_PROFILE
-
-
-class _ParityProfileConfig(HostedCellConfig):
-    """The same stub for the parity profile, which alone exposes some guards."""
-
-    @property
-    def active_agent_profile(self) -> str:
-        return V4_PROFILE
-
-
 def _profile_exposing(command: str) -> str:
     """The narrowest test profile that actually routes `command`.
 
@@ -104,11 +84,7 @@ def _cell(tmp_path: Path, *, profile: str = V3_PROFILE) -> tuple[Any, HostedCell
     vault_root = tmp_path / "vault"
     init_vault(vault_root)
     _seed_user_schema_documents(vault_root)
-    factory = {
-        V3_PROFILE: _ProfileConfig,
-        V4_PROFILE: _ParityProfileConfig,
-    }.get(profile, HostedCellConfig)
-    config = factory(
+    config = HostedCellConfig(
         cell_id="cell-protected-tree",
         vault_root=vault_root,
         state_root=tmp_path / "state",
@@ -117,6 +93,7 @@ def _cell(tmp_path: Path, *, profile: str = V3_PROFILE) -> tuple[Any, HostedCell
         enforce_transfer_v1_compatibility=False,
         records_reader_version=2,
         lifecycle_actions_enabled=(profile == commands_module.HOSTED_ALPHA_AGENT_V2_PROFILE),
+        agent_profile=profile,
         resource_limits=HostedResourceLimits(
             storage_bytes=4 * 1024 * 1024, upload_bytes=4096, worker_count=0
         ),


### PR DESCRIPTION
## What was wrong

A hosted candidate selecting `hosted-alpha-agent-v4` provisioned a healthy runtime that served only v1. The runtime inferred its profile from the Records lifecycle feature flag, and provisioning never passed the profile the runtime target had already chosen. The cell's authenticated v4 contract request therefore failed with `HOSTED_SURFACE_PROFILE_UNSUPPORTED` and the cell could never bind.

Measured on the live cell before the fix: authenticated `v1` contract → 200, `v4` → 400 `HOSTED_SURFACE_PROFILE_UNSUPPORTED`.

Every existing v4 route test overrode `active_agent_profile`, so none of them could see it.

## What changed

The provisioner already carried `runtimeTarget.agentProfile`; nothing forwarded it.

- `_fixed_helm_values` forwards `target.agentProfile`.
- The cell chart emits `EXOMEM_HOSTED_AGENT_PROFILE` only when non-empty.
- `HostedCellConfig` parses it and resolves it against `PRODUCT_SURFACE_PROFILES`. Unknown names fail closed before routes register; profiles containing `record_memory` require Records reader version 2.
- The pre-existing lifecycle/reader coherence check now runs **ahead** of explicit selection, so direct construction keeps its invariant.
- Omitting the value preserves the existing v1/v2 derivation, so deployed cells are unchanged.

Records lifecycle enablement stays independently gated — selecting v4 does not enable those mutations.

## Verification

Red-first output retained for each link (runtime selection, producer forwarding, chart forwarding).

| Scope | Result |
|---|---|
| Hosted (`test_hosted_profile_selection`, `test_hosted_cell`, `test_hosted_private_routes`, `test_hosted_protected_tree_guard`, `test_hosted_helm_contract`) | `256 passed, 2 skipped` |
| Provisioner (`test_provider_lifecycle`, `test_records_reader_compatibility`, `test_provider_adapters`) | `97 passed` |
| Full provisioner suite | `558 passed, 17 skipped` |
| OpenSpec strict | validates |

The regression follows real producer output through Helm render and `from_env` to an authenticated v4 contract request, never stubbing the selection property. Mutation-proved on four links: dropping the target profile, dropping the StatefulSet env var, dropping the `from_env` parse, and removing the lifecycle gate each fail it.

Independently reviewed. The reviewer found one medium defect — explicit selection returned before the direct-config lifecycle/reader guard, so a directly constructed `reader1 + lifecycle=true + explicit v1` config registered routes where it previously raised. That is fixed with its own route-registration regression, and the correction was re-reviewed: no correction-introduced defect.

## Rollout

Needs rebuilt runtime **and** provisioner images with a verified deployment composition — `src/exomem/**` is in the runtime closure and `infra/helm/cell/**` is in the provisioner closure. No public request field, profile membership, credential, schema or promotion policy changes.

Refs `openspec/changes/fix-hosted-runtime-profile-selection`.