### PR TITLE
fix(hosted): admit the serving pod that carries a selected agent profile

### DIFF
--- a/infra/helm/cell/templates/namespace.yaml
+++ b/infra/helm/cell/templates/namespace.yaml
@@ -27,5 +27,8 @@ metadata:
     exomem.io/worker-policy-digest: {{ .Values.workerPolicyDigest | quote }}
     exomem.io/records-reader-version: {{ printf "%.0f" .Values.recordsReaderVersion | quote }}
     exomem.io/lifecycle-actions-enabled: {{ .Values.lifecycleActionsEnabled | quote }}
+    {{- with .Values.agentProfile }}
+    exomem.io/agent-profile: {{ . | quote }}
+    {{- end }}
     exomem.io/browser-origin: {{ .Values.browserOrigin | quote }}
     exomem.io/transfer-hostname: {{ .Values.transferHostname | quote }}

--- a/infra/helm/platform/templates/tenant-admission.yaml
+++ b/infra/helm/platform/templates/tenant-admission.yaml
@@ -305,7 +305,18 @@ spec:
         (
         !has(object.spec.containers[0].command) &&
         object.spec.containers[0].args == ['--transport', 'http', '--port', '8765'] &&
-        size(object.spec.containers[0].env) == 28 &&
+        (
+        (size(object.spec.containers[0].env) == 28 &&
+        !object.spec.containers[0].env.exists(env, env.name == 'EXOMEM_HOSTED_AGENT_PROFILE') &&
+        !('exomem.io/agent-profile' in namespaceObject.metadata.annotations)) ||
+        (size(object.spec.containers[0].env) == 29 &&
+        'exomem.io/agent-profile' in namespaceObject.metadata.annotations &&
+        namespaceObject.metadata.annotations['exomem.io/agent-profile'] != '' &&
+        object.spec.containers[0].env.exists(env,
+          env.name == 'EXOMEM_HOSTED_AGENT_PROFILE' && has(env.value) &&
+          env.value == namespaceObject.metadata.annotations['exomem.io/agent-profile'] &&
+          !has(env.valueFrom)))
+        ) &&
         object.spec.containers[0].env.exists(env,
           env.name == 'EXOMEM_HOSTED_CELL' && has(env.value) && env.value == '1' && !has(env.valueFrom)) &&
         object.spec.containers[0].env.exists(env,

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -1402,6 +1402,58 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
     ] == ["authorization-session-custody"]
     assert _server_dry_run(k3s, serving_pod).returncode == 0
 
+    # A selected agent profile is a platform decision: the chart writes it to the
+    # namespace annotation and the pod may only echo that exact value. The policy
+    # pins an exact env count, so it has to admit both arities -- 28 without a
+    # selection, 29 with one -- and every disagreement between the two halves has
+    # to be refused. Adding the variable to the chart without this cost a real
+    # provision on 2026-09-06: the cell reached a completed init job and a bound
+    # volume, then its serving pod was denied.
+    def _with_profile(value: str, name: str) -> dict[str, Any]:
+        selected = copy.deepcopy(serving_pod)
+        selected["metadata"]["name"] = name
+        selected["spec"]["containers"][0]["env"].append(
+            {"name": "EXOMEM_HOSTED_AGENT_PROFILE", "value": value}
+        )
+        return selected
+
+    # Before the namespace announces a profile, carrying one is refused.
+    _assert_denied(
+        k3s,
+        _with_profile("hosted-alpha-agent-v4", "cell-alpha-serve-profile-unannounced"),
+        message="approved serving command and environment",
+    )
+
+    _kubectl(
+        k3s,
+        [
+            "annotate",
+            "namespace",
+            namespace,
+            "exomem.io/agent-profile=hosted-alpha-agent-v4",
+            "--overwrite",
+        ],
+    )
+
+    selected_profile = _with_profile("hosted-alpha-agent-v4", "cell-alpha-serve-profile")
+    assert len(selected_profile["spec"]["containers"][0]["env"]) == 29
+    assert _server_dry_run(k3s, selected_profile).returncode == 0
+
+    # The pod cannot echo a profile other than the announced one.
+    _assert_denied(
+        k3s,
+        _with_profile("hosted-alpha-agent-v1", "cell-alpha-serve-profile-mismatch"),
+        message="approved serving command and environment",
+    )
+
+    # An announcing namespace refuses a pod that omits the variable, so the
+    # selection cannot be silently dropped on the way to the runtime.
+    omitted = copy.deepcopy(serving_pod)
+    omitted["metadata"]["name"] = "cell-alpha-serve-profile-omitted"
+    _assert_denied(k3s, omitted, message="approved serving command and environment")
+
+    _kubectl(k3s, ["annotate", "namespace", namespace, "exomem.io/agent-profile-"])
+
     serving_group_rewrite = copy.deepcopy(serving_pod)
     serving_group_rewrite["metadata"]["name"] = "cell-alpha-serve-fsgroup"
     serving_group_rewrite["spec"]["securityContext"].update(


### PR DESCRIPTION
## What happened

#1083 added `EXOMEM_HOSTED_AGENT_PROFILE` to the cell StatefulSet and stopped there. The serving environment is not owned by that chart — `exomem-tenant-boundary` pins it at **exactly 28 variables** (`tenant-admission.yaml:308`).

So the first real cell provisioned with a selected profile rendered correctly, passed every render test, shipped in an image whose contents I verified by introspection, and was then refused at pod creation:

> Serving pods must use the exact approved serving command and environment.

It had already reached a bound 10Gi PVC and a **completed** init job. Measured on the live alpha, 2026-09-06, operation `b26eac90` (now `failed_retryable`).

## The shape of the miss

Adding a variable to a policy-pinned environment is a three-part change: the chart that emits it, the platform metadata the value derives from, and the policy that admits the result. I moved one part.

The second missing part was subtler than the count. Every other gated variable binds to a namespace annotation the platform writes — `exomem.io/records-reader-version`, `exomem.io/lifecycle-actions-enabled` — so the pod echoes a decision rather than making one. Admitting the new variable by literal alone would have widened the tenant boundary while appearing to extend it.

## What changed

- `infra/helm/cell/templates/namespace.yaml` writes `exomem.io/agent-profile` under the same `with` that emits the variable.
- `tenant-admission.yaml` admits **28 without a selection, or 29 with one** — the second requiring a non-empty announced annotation and `env.value == annotation`.

Both arities are deliberate: the chart emits the variable conditionally, so cells without a selection carry 28, and pinning only the new count would refuse every cell already running.

## Coverage, in the place it should have been

`tests/test_hosted_k3s_admission.py` had **zero** references to the profile — it passed while never rendering a profile-carrying pod. It now covers four cases against a real k3s API:

| Case | Expected |
|---|---|
| namespace announces v4, pod echoes v4 (29 vars) | admitted |
| namespace announces nothing, pod carries a profile | denied |
| namespace announces v4, pod echoes v1 | denied |
| namespace announces v4, pod omits the variable | denied |

**Not decoration:** reverting the policy to the original 28-only pin turns the positive case red (`assert 1 == 0`), then green again with the fix restored.

## Verification

```
RUN_K3S_ADMISSION_TEST=1 pytest tests/test_hosted_k3s_admission.py \
  tests/test_hosted_helm_contract.py tests/test_hosted_profile_selection.py
75 passed, 4 skipped
```

The 4 skips need `RUN_K3S_RUNTIME_TEST=1`. Note the gate spins k3s up **in Docker** — it needs no cluster, and I should have run it before the deploy rather than substituting image introspection for it. Introspection proves the code shipped; it cannot prove the cluster will admit the result.

## Rollout

`src/exomem/**` is untouched, so **no new Exomem release is required** — provisioner image republish plus a platform `helm upgrade`. The stranded operation is `failed_retryable`, so reconcile should retry it onto the fixed policy.