### PR TITLE
fix(schema): document the relation disposition a compiled write requires

### DIFF
--- a/docs/runbooks/hosted/alpha-reviewer-run.md
+++ b/docs/runbooks/hosted/alpha-reviewer-run.md
@@ -1,3 +1,5 @@
+<!-- authority:non-specification -->
+
 # Hosted alpha — the reviewer client run
 
 The manual half of a hosted promotion. A bootstrap `run` has produced a live

--- a/docs/runbooks/hosted/alpha-reviewer-run.md
+++ b/docs/runbooks/hosted/alpha-reviewer-run.md
@@ -1,0 +1,127 @@
+# Hosted alpha — the reviewer client run
+
+The manual half of a hosted promotion. A bootstrap `run` has produced a live
+cell and two canary credentials; this runbook covers what a human does in real
+clients before `observe`/`sign`/`import`/`promote` can proceed.
+
+It is unautomatable by design: the seven promotion operations are assertions
+that a person drove a real client through a real journey. `observe --rehearse`
+refuses to emit signable records precisely so this cannot be faked.
+
+## Before you start
+
+| Input | Where it comes from |
+|---|---|
+| MCP endpoint | `https://substratesystems.io/api/exomem/mcp/v1` |
+| Canary credentials, per platform | `<state-dir>/run-canary-<platform>.response.json` |
+| Sibling stage ids | `<state-dir>/sibling-stage-ids.json` |
+| Results templates | `<state-dir>/results-<platform>.json` |
+
+Three clocks, and the tightest one governs:
+
+- **Canary credentials** — 24 h from `run`. Bounds this entire runbook.
+- **Staged release** — the operator's choice at `prepare`, up to 7 days. Bounds
+  the evidence steps that follow.
+- **Bootstrap authority** — 28 min, spent inside `run`. Already gone; it never
+  constrained this phase.
+
+Both platforms share one tenant and one vault. Seed once, in the first run.
+
+## The seven operations
+
+Each is a boolean you assert per platform, recorded in
+`results-<platform>.json`.
+
+| Operation | Satisfied by |
+|---|---|
+| `native_install` | Adding the connector through the client's own connector UI, not a config file |
+| `authorization` | Signing in at `/exomem/sign-in` and consenting at `/exomem/authorize` |
+| `tool_discovery` | The client listing the profile's tools — 25 for `hosted-alpha-agent-v4` |
+| `content_recall` | Asking a natural question and getting governed content back |
+| `citation` | That answer naming its source page |
+| `durable_capture` | The assistant capturing a conclusion worth keeping |
+| `fresh_chat_recall` | A new chat with no history recalling what was captured |
+
+Only flip what actually happened. A false negative costs a rerun; a false
+positive poisons signed evidence and `import` rejects it later, at a point where
+the window is mostly spent.
+
+## Seeding: use real, connected material
+
+**Do not seed the marketplace review fixture for a promotion run.**
+`promotion_evidence.py` contains no reference to it. The evidence is seven
+human-observed booleans, six database counts and HMAC strings; nothing binds it
+to fixture content. The scrubbed fixture exists for provider review, where a
+reviewer needs a reproducible corpus — a different obligation, later.
+
+Seed notes you actually care about, in one pass, in ordinary language. Five to
+eight is plenty. They must be genuinely connected, because the authoring
+contract requires it and because a recall test over disconnected filler proves
+retrieval plumbing rather than the product.
+
+The rule, stated once so it does not surprise you: **the first compiled page in
+an empty vault commits freely; every later one must either carry a qualifying
+typed relation or explicitly record that none applied.** Material that cites its
+counterpart satisfies this for free. Material that stands alone needs
+`relation_disposition="reviewed_none"` with the `relation_review_hash` returned
+by validation and a stated reason. Write connected notes and the question does
+not arise.
+
+A workable shape: one page establishing context, two or three that cite it or
+each other, and one decision page with an explicit provenance link. That gives
+`content_recall` something to find, `citation` something to name, and the graph
+something real to traverse.
+
+## Running it
+
+Repeat per platform, first Claude then ChatGPT, seeding only in the first.
+
+1. Add the connector through the client's UI. → `native_install`
+2. Connect, sign in with that platform's canary pair, consent. → `authorization`
+3. Open the tool list and count. → `tool_discovery`
+4. *(First platform only.)* Seed the notes, in one pass.
+5. Ask a real question whose answer lives in what you seeded. → `content_recall`
+6. Confirm the answer names its source. → `citation`
+7. Reach a conclusion in conversation and have it captured. → `durable_capture`
+8. New chat, no history, ask for that conclusion. → `fresh_chat_recall`
+9. Delete the captured page before the next platform, so its `durable_capture`
+   starts from the same absent baseline.
+
+Then record both files and hand back to the operator for `observe`/`sign`/
+`import` per platform against the **sibling** stage ids — never the bootstrap
+stage from `bootstrap-context.json`. They look alike, `observe` signs the wrong
+one without complaint, and `import` rejects it afterwards.
+
+## When a write is refused
+
+A refusal is not an outage, and the client will not always tell you which it is.
+
+Substrate's MCP bridge recognises five error codes and maps everything else to
+`CELL_UNAVAILABLE` — "your Exomem is temporarily unavailable", `retryable:
+false`. Exomem defines eight refusal codes with user-facing messages and
+remediations; the other three, including every authoring-contract refusal,
+arrive rewritten as a service outage. Until that is fixed, **treat
+"temporarily unavailable" on a write as an unknown refusal, not a diagnosis.**
+
+The cell keeps an unredacted per-mutation record that the redacted pod log does
+not:
+
+```
+kubectl -n <cell-ns> exec <cell-pod> -c exomem -- cat /var/lib/exomem/logs/mutations.jsonl
+```
+
+One line per mutation with `tool`, `outcome`, `error_code`, `duration_ms` and
+the receipt id. That is the fastest route from a client symptom to a real code.
+`kubectl` is not on the node's PATH; use `k3s kubectl` with
+`KUBECONFIG=/etc/rancher/k3s/k3s.yaml`.
+
+To tell an outage from a refusal without leaving the client: an outage stops
+tool discovery and authorization too. A refusal leaves reads working.
+
+## Cost of a failed attempt
+
+`reset` reclaims the tenant. The invite, the alias, the staged release and an
+operator OAuth client slot are spent per attempt and never returned; client
+slots are bounded at 96. Nothing in this runbook is irreversible — the
+irreversible step was `run` — so a bad step inside the cell costs nothing.
+Stop and diagnose rather than re-running the bootstrap.

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exomem",
   "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at your vault; run `exomem setup` if you do not have one yet.",
-  "version": "0.71.0",
+  "version": "0.73.0",
   "author": {
     "name": "Substrate Systems O\u00dc",
     "url": "https://substratesystems.io"

--- a/plugins/claude-code/skills/exomem-capture/SKILL.md
+++ b/plugins/claude-code/skills/exomem-capture/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-capture
 description: Preserve a durable conclusion or recurring entity from a conversation without dumping transcripts into compiled memory.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-continue/SKILL.md
+++ b/plugins/claude-code/skills/exomem-continue/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-continue
 description: Resume prior project or session context from Exomem when the user wants to continue, pick something back up, or remember what was happening on a topic.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-curate/SKILL.md
+++ b/plugins/claude-code/skills/exomem-curate/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-curate
 description: Improve Exomem note quality by adding links, clarifying compiled notes, and organizing safely without editing raw Sources or Evidence.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.2.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-defrag/SKILL.md
+++ b/plugins/claude-code/skills/exomem-defrag/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-defrag
 description: Reconcile duplicate, stale, or conflicting Exomem memory while preserving history through review, merge, or supersession.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-ingest/SKILL.md
+++ b/plugins/claude-code/skills/exomem-ingest/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-ingest
 description: Ingest an external article, PDF, pasted note, dataset, image, audio, or video into Exomem while preserving raw evidence before compiling conclusions.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-media/SKILL.md
+++ b/plugins/claude-code/skills/exomem-media/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-media
 description: Search, inspect, cite, and preserve Exomem media artifacts such as PDFs, images, audio, and video.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-reflect/SKILL.md
+++ b/plugins/claude-code/skills/exomem-reflect/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-reflect
 description: Distill a session or project episode into decisions, failures, patterns, open questions, and next actions.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-research/SKILL.md
+++ b/plugins/claude-code/skills/exomem-research/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-research
 description: "Run a focused research loop with Exomem: gather sources, preserve evidence, compile attributed findings, and connect prior notes."
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-review/SKILL.md
+++ b/plugins/claude-code/skills/exomem-review/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-review
 description: Use Exomem's Epistemic Inbox and audit queues to surface stale conclusions, contradictions, relation debt, and unprocessed sources safely.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.2.0"
 ---
 

--- a/plugins/claude-code/skills/exomem/SKILL.md
+++ b/plugins/claude-code/skills/exomem/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem
 description: Use Exomem for governed knowledge-base recall, capture, compilation, connections, review, and preservation. Engage for Exomem, KB, vault, Obsidian or notes, including save, log, compile, "interesting, save it", and "what did I conclude"; consult prior project/domain knowledge and capture durable outcomes according to the active engagement policy. Sources and Evidence stay immutable; content outside the managed Knowledge Base stays read-only.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.32.0"
 ---
 

--- a/plugins/claude-code/skills/exomem/references/mutation-results.md
+++ b/plugins/claude-code/skills/exomem/references/mutation-results.md
@@ -37,6 +37,29 @@ following their remediation: wait before retrying a warming or busy call; retry 
 call only with the same identity; do not submit a new identity after a
 committed-uncertain result—reconcile and retry only as instructed.
 
+## Relation disposition on compiled writes
+
+Once a vault holds any compiled page, a new compiled page must either carry a
+qualifying typed relation or record that relations were reviewed and none
+applied. The first page in an empty vault has nothing to relate to and commits
+without this; every later page is subject to it. A page that genuinely cites its
+counterpart — a provenance link, a supersession, any typed relation — satisfies
+the rule as written and needs no extra argument, so connected material passes
+for free and only disconnected material needs the explicit disposition.
+
+Validation reports the obligation before it can block a commit: a
+`validate_only=true` call returns `relation_review_hash` alongside the draft
+fields, and lists the finding under `blocking_findings`. Read that list on every
+validation rather than only on failure — it is the sole notice you get. To
+commit an unrelated page, re-issue the identical creation with the returned
+`draft_id`, `draft_hash` and `draft_token`, plus
+`relation_disposition="reviewed_none"`, the returned `relation_review_hash`, and
+a `relation_review_reason` naming why nothing qualified. Committing with the
+draft fields alone refuses with `SEMANTIC_CONTRACT_BLOCKED` and a
+`RELATION_DISPOSITION_MISSING` finding whose `remediation` restates this
+sequence. Prefer adding the real relation over asserting none exists; the
+disposition is for material that genuinely stands alone.
+
 On MCP these expected refusals arrive as normal tool content with top-level
 `success: false`; inspect the structured `error` rather than treating it as a
 transport failure. A `receipt_id` is diagnostic and is not a transferable

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem
 description: Use Exomem for governed knowledge-base recall, capture, compilation, connections, review, and preservation. Engage for Exomem, KB, vault, Obsidian or notes, including save, log, compile, "interesting, save it", and "what did I conclude"; consult prior project/domain knowledge and capture durable outcomes according to the active engagement policy. Sources and Evidence stay immutable; content outside the managed Knowledge Base stays read-only.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.32.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/references/mutation-results.md
+++ b/src/exomem/_scaffold/_Schema/references/mutation-results.md
@@ -37,6 +37,29 @@ following their remediation: wait before retrying a warming or busy call; retry 
 call only with the same identity; do not submit a new identity after a
 committed-uncertain result—reconcile and retry only as instructed.
 
+## Relation disposition on compiled writes
+
+Once a vault holds any compiled page, a new compiled page must either carry a
+qualifying typed relation or record that relations were reviewed and none
+applied. The first page in an empty vault has nothing to relate to and commits
+without this; every later page is subject to it. A page that genuinely cites its
+counterpart — a provenance link, a supersession, any typed relation — satisfies
+the rule as written and needs no extra argument, so connected material passes
+for free and only disconnected material needs the explicit disposition.
+
+Validation reports the obligation before it can block a commit: a
+`validate_only=true` call returns `relation_review_hash` alongside the draft
+fields, and lists the finding under `blocking_findings`. Read that list on every
+validation rather than only on failure — it is the sole notice you get. To
+commit an unrelated page, re-issue the identical creation with the returned
+`draft_id`, `draft_hash` and `draft_token`, plus
+`relation_disposition="reviewed_none"`, the returned `relation_review_hash`, and
+a `relation_review_reason` naming why nothing qualified. Committing with the
+draft fields alone refuses with `SEMANTIC_CONTRACT_BLOCKED` and a
+`RELATION_DISPOSITION_MISSING` finding whose `remediation` restates this
+sequence. Prefer adding the real relation over asserting none exists; the
+disposition is for material that genuinely stands alone.
+
 On MCP these expected refusals arrive as normal tool content with top-level
 `success: false`; inspect the structured `error` rather than treating it as a
 transport failure. A `receipt_id` is diagnostic and is not a transferable

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-capture/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-capture/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-capture
 description: Preserve a durable conclusion or recurring entity from a conversation without dumping transcripts into compiled memory.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-continue/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-continue/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-continue
 description: Resume prior project or session context from Exomem when the user wants to continue, pick something back up, or remember what was happening on a topic.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-curate/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-curate/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-curate
 description: Improve Exomem note quality by adding links, clarifying compiled notes, and organizing safely without editing raw Sources or Evidence.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.2.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-defrag/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-defrag/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-defrag
 description: Reconcile duplicate, stale, or conflicting Exomem memory while preserving history through review, merge, or supersession.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-ingest/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-ingest/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-ingest
 description: Ingest an external article, PDF, pasted note, dataset, image, audio, or video into Exomem while preserving raw evidence before compiling conclusions.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-media/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-media/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-media
 description: Search, inspect, cite, and preserve Exomem media artifacts such as PDFs, images, audio, and video.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-reflect/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-reflect/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-reflect
 description: Distill a session or project episode into decisions, failures, patterns, open questions, and next actions.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-research/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-research/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-research
 description: "Run a focused research loop with Exomem: gather sources, preserve evidence, compile attributed findings, and connect prior notes."
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-review/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-review/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-review
 description: Use Exomem's Epistemic Inbox and audit queues to surface stale conclusions, contradictions, relation debt, and unprocessed sources safely.
 metadata:
-  skill_contract: 4db8c2d965f8ab13cbd6500f83a46999fa67e53f56465944acbba6c545db673e
+  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
   version: "0.2.0"
 ---
 


### PR DESCRIPTION
## What changed

`_Schema/references/mutation-results.md` gains a section on relation disposition, and `docs/runbooks/hosted/alpha-reviewer-run.md` documents the manual half of a hosted promotion.

## Why

Once a vault holds any compiled page, a new compiled page must either carry a qualifying typed relation or explicitly record that relations were reviewed and none applied. The shipped schema never documented this — `relation_disposition` and `reviewed_none` appear nowhere under `_Schema/`. An agent could only discover the rule by parsing `blocking_findings[].remediation` on a validation response it had no reason to inspect.

Measured on the first live hosted cell, seeding five notes:

```
1. review-project-brief          reviewed_none_required=False   -> OK
2. review-launch-plan            reviewed_none_required=True    -> BLOCKED
3. review-pricing-policy-source  reviewed_none_required=True    -> BLOCKED
4. review-pricing-decision       reviewed_none_required=False   -> OK
5. review-review-item            reviewed_none_required=True    -> BLOCKED
```

Note 1 committed because it was first. Note 4 committed because it cites its source under `## Provenance`. The three that failed are disconnected fragments. The contract is behaving correctly — connected material satisfies it for free, and only material that genuinely stands alone needs the explicit disposition. The documentation gap is what made this look like a defect.

## Runbook placement

`docs/runbooks/hosted/alpha-reviewer-run.md` is deliberately **not** added to `infra/contracts/runbooks-v1.json`. That index governs the ten operator platform runbooks and `test_runbook_index_is_complete_and_executable_by_default` pins the set exactly; this documents a human client journey rather than an operator procedure.

## Verification

```
pytest tests/test_bootstrap_compact_budget.py tests/test_bootstrap.py tests/test_scaffold_no_leak.py
41 passed

pytest tests/test_scaffold_no_leak.py \
       tests/test_hosted_platform_operations.py::test_runbook_index_is_complete_and_executable_by_default
8 passed
```

Scope: the scaffold schema budget and leak gates plus the runbook index gate. No code paths change — this is documentation shipped inside the runtime image.

## Note on reach

The scaffold is baked into the runtime image at vault init, so this guidance reaches cells only from the next release onward. It does not change the behaviour of any running cell.