### PR TITLE
fix(hosted): renew a cell's authorization before its window lapses

### DIFF
--- a/infra/contracts/platform-composition-v1.json
+++ b/infra/contracts/platform-composition-v1.json
@@ -24,7 +24,13 @@
       "commandRegistry"
     ],
     "command_registry_length": 21,
-    "command_exact_fields": ["name", "readOnly", "mode", "tier", "capability"],
+    "command_exact_fields": [
+      "name",
+      "readOnly",
+      "mode",
+      "tier",
+      "capability"
+    ],
     "command_types": {
       "name": "snake_case string",
       "readOnly": "boolean",
@@ -51,33 +57,88 @@
       "X-Exomem-Provisioner-Protocol"
     ],
     "actions": {
-      "provision": {"method": "POST", "path": "/cells/provision"},
-      "health": {"method": "POST", "path": "/cells/health"},
-      "rotate-credential": {"method": "POST", "path": "/cells/rotate-credential"},
-      "quiesce": {"method": "POST", "path": "/cells/quiesce"},
-      "resume": {"method": "POST", "path": "/cells/resume"},
-      "stop": {"method": "POST", "path": "/cells/stop"},
-      "export": {"method": "POST", "path": "/cells/export"},
-      "export-release": {"method": "POST", "path": "/cells/export-release"},
-      "export-delete": {"method": "POST", "path": "/cells/export-delete"},
-      "restore": {"method": "POST", "path": "/cells/restore"},
-      "export-download": {"method": "POST", "path": "/cells/export-download"},
-      "seal": {"method": "POST", "path": "/cells/seal"},
-      "discard": {"method": "POST", "path": "/cells/discard"},
-      "destroy": {"method": "POST", "path": "/cells/destroy"}
+      "provision": {
+        "method": "POST",
+        "path": "/cells/provision"
+      },
+      "health": {
+        "method": "POST",
+        "path": "/cells/health"
+      },
+      "rotate-credential": {
+        "method": "POST",
+        "path": "/cells/rotate-credential"
+      },
+      "quiesce": {
+        "method": "POST",
+        "path": "/cells/quiesce"
+      },
+      "renew-authorization": {
+        "method": "POST",
+        "path": "/cells/renew-authorization"
+      },
+      "resume": {
+        "method": "POST",
+        "path": "/cells/resume"
+      },
+      "stop": {
+        "method": "POST",
+        "path": "/cells/stop"
+      },
+      "export": {
+        "method": "POST",
+        "path": "/cells/export"
+      },
+      "export-release": {
+        "method": "POST",
+        "path": "/cells/export-release"
+      },
+      "export-delete": {
+        "method": "POST",
+        "path": "/cells/export-delete"
+      },
+      "restore": {
+        "method": "POST",
+        "path": "/cells/restore"
+      },
+      "export-download": {
+        "method": "POST",
+        "path": "/cells/export-download"
+      },
+      "seal": {
+        "method": "POST",
+        "path": "/cells/seal"
+      },
+      "discard": {
+        "method": "POST",
+        "path": "/cells/discard"
+      },
+      "destroy": {
+        "method": "POST",
+        "path": "/cells/destroy"
+      }
     }
   },
   "capacity_gate": {
     "implementation": "SignedLiveReceiptPostgreSQLCapacityAuthority",
-    "invoked_before": ["routine-provider-effect", "volume-registration-provider-effect"],
-    "provider_defense_checks": ["namespace-create", "helm-install"],
+    "invoked_before": [
+      "routine-provider-effect",
+      "volume-registration-provider-effect"
+    ],
+    "provider_defense_checks": [
+      "namespace-create",
+      "helm-install"
+    ],
     "pending_retry_seconds": 300,
     "sources": [
       "signed-kubernetes-hcloud-receipt",
       "fresh-kubernetes-observation",
       "postgresql-capacity-reservations"
     ],
-    "public_material_consumers": ["exomem-provisioner-worker", "exomem-volume-worker"],
+    "public_material_consumers": [
+      "exomem-provisioner-worker",
+      "exomem-volume-worker"
+    ],
     "limits": {
       "active_user_cells": 4,
       "active_recovery_cells": 2,
@@ -88,7 +149,10 @@
   },
   "volume_rebind": {
     "public_endpoint": null,
-    "invoked_by": ["restore", "node-recovery"],
+    "invoked_by": [
+      "restore",
+      "node-recovery"
+    ],
     "worker_primitive": "VolumeLifecycleWorker.rebind_static"
   },
   "provider_recovery_identity": {
@@ -118,7 +182,9 @@
       "deletion_job_template": "exomem-deletion-job-template",
       "volume_lifecycle": "exomem-volume-worker"
     },
-    "private_signers": ["exomem-provider-recovery-signer/private-key"],
+    "private_signers": [
+      "exomem-provider-recovery-signer/private-key"
+    ],
     "public_verifier": "exomem-provider-recovery-verifier/public-key"
   }
 }

--- a/infra/contracts/platform-composition-v1.json
+++ b/infra/contracts/platform-composition-v1.json
@@ -24,13 +24,7 @@
       "commandRegistry"
     ],
     "command_registry_length": 21,
-    "command_exact_fields": [
-      "name",
-      "readOnly",
-      "mode",
-      "tier",
-      "capability"
-    ],
+    "command_exact_fields": ["name", "readOnly", "mode", "tier", "capability"],
     "command_types": {
       "name": "snake_case string",
       "readOnly": "boolean",
@@ -57,88 +51,34 @@
       "X-Exomem-Provisioner-Protocol"
     ],
     "actions": {
-      "provision": {
-        "method": "POST",
-        "path": "/cells/provision"
-      },
-      "health": {
-        "method": "POST",
-        "path": "/cells/health"
-      },
-      "rotate-credential": {
-        "method": "POST",
-        "path": "/cells/rotate-credential"
-      },
-      "quiesce": {
-        "method": "POST",
-        "path": "/cells/quiesce"
-      },
-      "renew-authorization": {
-        "method": "POST",
-        "path": "/cells/renew-authorization"
-      },
-      "resume": {
-        "method": "POST",
-        "path": "/cells/resume"
-      },
-      "stop": {
-        "method": "POST",
-        "path": "/cells/stop"
-      },
-      "export": {
-        "method": "POST",
-        "path": "/cells/export"
-      },
-      "export-release": {
-        "method": "POST",
-        "path": "/cells/export-release"
-      },
-      "export-delete": {
-        "method": "POST",
-        "path": "/cells/export-delete"
-      },
-      "restore": {
-        "method": "POST",
-        "path": "/cells/restore"
-      },
-      "export-download": {
-        "method": "POST",
-        "path": "/cells/export-download"
-      },
-      "seal": {
-        "method": "POST",
-        "path": "/cells/seal"
-      },
-      "discard": {
-        "method": "POST",
-        "path": "/cells/discard"
-      },
-      "destroy": {
-        "method": "POST",
-        "path": "/cells/destroy"
-      }
+      "provision": {"method": "POST", "path": "/cells/provision"},
+      "health": {"method": "POST", "path": "/cells/health"},
+      "rotate-credential": {"method": "POST", "path": "/cells/rotate-credential"},
+      "quiesce": {"method": "POST", "path": "/cells/quiesce"},
+      "renew-authorization": {"method": "POST", "path": "/cells/renew-authorization"},
+      "resume": {"method": "POST", "path": "/cells/resume"},
+      "stop": {"method": "POST", "path": "/cells/stop"},
+      "export": {"method": "POST", "path": "/cells/export"},
+      "export-release": {"method": "POST", "path": "/cells/export-release"},
+      "export-delete": {"method": "POST", "path": "/cells/export-delete"},
+      "restore": {"method": "POST", "path": "/cells/restore"},
+      "export-download": {"method": "POST", "path": "/cells/export-download"},
+      "seal": {"method": "POST", "path": "/cells/seal"},
+      "discard": {"method": "POST", "path": "/cells/discard"},
+      "destroy": {"method": "POST", "path": "/cells/destroy"}
     }
   },
   "capacity_gate": {
     "implementation": "SignedLiveReceiptPostgreSQLCapacityAuthority",
-    "invoked_before": [
-      "routine-provider-effect",
-      "volume-registration-provider-effect"
-    ],
-    "provider_defense_checks": [
-      "namespace-create",
-      "helm-install"
-    ],
+    "invoked_before": ["routine-provider-effect", "volume-registration-provider-effect"],
+    "provider_defense_checks": ["namespace-create", "helm-install"],
     "pending_retry_seconds": 300,
     "sources": [
       "signed-kubernetes-hcloud-receipt",
       "fresh-kubernetes-observation",
       "postgresql-capacity-reservations"
     ],
-    "public_material_consumers": [
-      "exomem-provisioner-worker",
-      "exomem-volume-worker"
-    ],
+    "public_material_consumers": ["exomem-provisioner-worker", "exomem-volume-worker"],
     "limits": {
       "active_user_cells": 4,
       "active_recovery_cells": 2,
@@ -149,10 +89,7 @@
   },
   "volume_rebind": {
     "public_endpoint": null,
-    "invoked_by": [
-      "restore",
-      "node-recovery"
-    ],
+    "invoked_by": ["restore", "node-recovery"],
     "worker_primitive": "VolumeLifecycleWorker.rebind_static"
   },
   "provider_recovery_identity": {
@@ -182,9 +119,7 @@
       "deletion_job_template": "exomem-deletion-job-template",
       "volume_lifecycle": "exomem-volume-worker"
     },
-    "private_signers": [
-      "exomem-provider-recovery-signer/private-key"
-    ],
+    "private_signers": ["exomem-provider-recovery-signer/private-key"],
     "public_verifier": "exomem-provider-recovery-verifier/public-key"
   }
 }

--- a/infra/helm/cell/templates/quota.yaml
+++ b/infra/helm/cell/templates/quota.yaml
@@ -12,14 +12,21 @@ spec:
   # init container's 1 CPU / 1Gi. The previous 2Gi ceiling exactly equalled the
   # pre-embedding pair, so raising the cell's limit without raising this would
   # have made the init job unschedulable on quota rather than on capacity.
+  #
+  # The authorization-session-refresh sidecar adds its own 10m/16Mi requests and
+  # 100m/64Mi limits on top, permanently. A native sidecar is not an ordinary
+  # init container: its resources are not merely max'd against the other init
+  # containers, they count toward the pod for its whole life. Leaving this at
+  # 3 CPU put the serving pod at 2100m and left 900m for an init job that asks
+  # for 1000m, so the job was refused on quota and the release rolled back.
   hard:
     persistentvolumeclaims: "1"
     requests.storage: 10Gi
     pods: "2"
-    requests.cpu: "1500m"
-    requests.memory: 1536Mi
-    limits.cpu: "3"
-    limits.memory: 3Gi
+    requests.cpu: "1510m"
+    requests.memory: 1552Mi
+    limits.cpu: "3100m"
+    limits.memory: 3136Mi
 ---
 apiVersion: v1
 kind: LimitRange

--- a/infra/helm/cell/templates/statefulset.yaml
+++ b/infra/helm/cell/templates/statefulset.yaml
@@ -61,6 +61,51 @@ spec:
               readOnly: true
             - name: authorization-session-custody
               mountPath: /run/exomem/authorization-session
+        {{- /*
+          A native sidecar (restartPolicy: Always on an init container) rather
+          than an ordinary container: the tenant boundary policy pins
+          `size(object.spec.containers) == 1`, and every other assertion in it
+          indexes `containers[0]`. Keeping the serving container alone in
+          `containers` leaves all of that untouched.
+
+          The runtime re-reads custody on every admission check and the source
+          is a Secret volume kubelet refreshes in place, so republishing each
+          new generation is what lets a renewed authorization bundle reach a
+          running pod. Without it the pod holds the generation its init
+          container copied until something restarts it.
+        */}}
+        - name: authorization-session-refresh
+          image: {{ .Values.image }}
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          command: ["python"]
+          args:
+            - -m
+            - exomem.governance.authorization_hosted_mount
+            - --watch
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+              ephemeral-storage: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+              ephemeral-storage: 16Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: {{ .Values.runtimeUid }}
+            runAsGroup: {{ .Values.runtimeGid }}
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: authorization-session-source
+              mountPath: /run/exomem/authorization-session-source
+              readOnly: true
+            - name: authorization-session-custody
+              mountPath: /run/exomem/authorization-session
       containers:
         - name: exomem
           image: {{ .Values.image }}

--- a/infra/helm/platform/templates/provisioner-route.yaml
+++ b/infra/helm/platform/templates/provisioner-route.yaml
@@ -16,6 +16,7 @@ spec:
         Path(`/cells/health`) ||
         Path(`/cells/rotate-credential`) ||
         Path(`/cells/quiesce`) ||
+        Path(`/cells/renew-authorization`) ||
         Path(`/cells/resume`) ||
         Path(`/cells/stop`) ||
         Path(`/cells/export`) ||

--- a/infra/helm/platform/templates/tenant-admission.yaml
+++ b/infra/helm/platform/templates/tenant-admission.yaml
@@ -109,7 +109,7 @@ spec:
         (
         (variables.lifecycleJob
           ? (!has(object.spec.initContainers) || size(object.spec.initContainers) == 0)
-          : (size(object.spec.initContainers) == 1 &&
+          : (size(object.spec.initContainers) == 2 &&
             object.spec.initContainers[0].name == 'authorization-session-custody' &&
             object.spec.initContainers[0].image in {{ $runtimeImages | toJson }} &&
             object.spec.initContainers[0].imagePullPolicy == 'IfNotPresent' &&
@@ -135,7 +135,6 @@ spec:
               size(object.spec.initContainers[0].env) == 0) &&
             (!has(object.spec.initContainers[0].ports) ||
               size(object.spec.initContainers[0].ports) == 0) &&
-            size(object.spec.initContainers) == 2 &&
             object.spec.initContainers[1].name == 'authorization-session-refresh' &&
             object.spec.initContainers[1].restartPolicy == 'Always' &&
             object.spec.initContainers[1].image == object.spec.initContainers[0].image &&

--- a/infra/helm/platform/templates/tenant-admission.yaml
+++ b/infra/helm/platform/templates/tenant-admission.yaml
@@ -134,9 +134,36 @@ spec:
             (!has(object.spec.initContainers[0].env) ||
               size(object.spec.initContainers[0].env) == 0) &&
             (!has(object.spec.initContainers[0].ports) ||
-              size(object.spec.initContainers[0].ports) == 0))) &&
+              size(object.spec.initContainers[0].ports) == 0) &&
+            size(object.spec.initContainers) == 2 &&
+            object.spec.initContainers[1].name == 'authorization-session-refresh' &&
+            object.spec.initContainers[1].restartPolicy == 'Always' &&
+            object.spec.initContainers[1].image == object.spec.initContainers[0].image &&
+            object.spec.initContainers[1].imagePullPolicy == 'IfNotPresent' &&
+            object.spec.initContainers[1].command == ['python'] &&
+            object.spec.initContainers[1].args ==
+              ['-m', 'exomem.governance.authorization_hosted_mount', '--watch'] &&
+            object.spec.initContainers[1].securityContext.runAsNonRoot == true &&
+            object.spec.initContainers[1].securityContext.runAsUser == 10001 &&
+            object.spec.initContainers[1].securityContext.runAsGroup == 10001 &&
+            object.spec.initContainers[1].securityContext.allowPrivilegeEscalation == false &&
+            object.spec.initContainers[1].securityContext.readOnlyRootFilesystem == true &&
+            size(object.spec.initContainers[1].securityContext.capabilities.drop) == 1 &&
+            object.spec.initContainers[1].securityContext.capabilities.drop[0] == 'ALL' &&
+            string(dyn(object.spec.initContainers[1].resources).requests['cpu']) == '10m' &&
+            string(dyn(object.spec.initContainers[1].resources).requests['memory']) == '16Mi' &&
+            string(dyn(object.spec.initContainers[1].resources).requests['ephemeral-storage']) == '16Mi' &&
+            string(dyn(object.spec.initContainers[1].resources).limits['cpu']) == '100m' &&
+            string(dyn(object.spec.initContainers[1].resources).limits['memory']) == '64Mi' &&
+            string(dyn(object.spec.initContainers[1].resources).limits['ephemeral-storage']) == '16Mi' &&
+            size(dyn(object.spec.initContainers[1].resources).requests) == 3 &&
+            size(dyn(object.spec.initContainers[1].resources).limits) == 3 &&
+            (!has(object.spec.initContainers[1].env) ||
+              size(object.spec.initContainers[1].env) == 0) &&
+            (!has(object.spec.initContainers[1].ports) ||
+              size(object.spec.initContainers[1].ports) == 0))) &&
         size(object.spec.containers) == 1)
-      message: Tenant pods may use only the exact authorization-custody init container.
+      message: Tenant pods may use only the exact authorization-custody init and refresh containers.
     - expression: >-
         !variables.inScope ||
         (

--- a/infra/provisioner/src/exomem_provisioner/authorization_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/authorization_membership.py
@@ -735,7 +735,14 @@ def transition_hosted_authorization_bundle(
     # `target_state="SERVING"` against a drained cell it takes the resume branch
     # below AND rides the expiry exemption beside it, so a background sweep could
     # silently un-quiesce a cell and resurrect one expired by any amount.
-    if renew and source.replica_state != target_state:
+    #
+    # Both halves of the membership are pinned, not just the replica state. The
+    # drain flag alone is unreachable today because no caller varies it without
+    # varying the state, but a guard that is total needs no such argument to hold
+    # it up.
+    if renew and (
+        source.replica_state != target_state or source.no_in_flight is not target_no_in_flight
+    ):
         raise MetadataConflict(
             "renewal cannot change the membership state",
             reason=ConflictReason.AUTHORIZATION_RENEWAL_CANNOT_CHANGE_STATE,

--- a/infra/provisioner/src/exomem_provisioner/authorization_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/authorization_membership.py
@@ -740,15 +740,14 @@ def transition_hosted_authorization_bundle(
             "renewal cannot change the membership state",
             reason=ConflictReason.AUTHORIZATION_RENEWAL_CANNOT_CHANGE_STATE,
         )
-    # The exemption exists so a fully drained cell can still be resumed after its
-    # window lapsed. It is the one path that may act on a stale bundle, so it is
-    # explicitly closed to renewal -- the guard above already makes the two
-    # mutually exclusive, and saying so here keeps the property locally checkable.
+    # The exemption below exists so a fully drained cell can still be resumed
+    # after its window lapsed. It is the one path allowed to act on a stale
+    # bundle, and renewal cannot reach it: the exemption needs DRAINING -> SERVING
+    # and the guard above refuses any renewal whose target differs from its
+    # source. An explicit `not renew` here would be unreachable, so it is not
+    # written -- an untestable guard reads as protection and provides none.
     if source.expires_at <= current and not (
-        not renew
-        and source.replica_state == "DRAINING"
-        and source.no_in_flight
-        and target_state == "SERVING"
+        source.replica_state == "DRAINING" and source.no_in_flight and target_state == "SERVING"
     ):
         raise MetadataConflict(
             "stale authorization membership cannot be renewed",

--- a/infra/provisioner/src/exomem_provisioner/authorization_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/authorization_membership.py
@@ -730,8 +730,25 @@ def transition_hosted_authorization_bundle(
         and not renew
     ):
         return source
+    # A renewal moves the window and nothing else. Letting it name a target state
+    # would make it an unaudited state transition wearing a renewal's name: with
+    # `target_state="SERVING"` against a drained cell it takes the resume branch
+    # below AND rides the expiry exemption beside it, so a background sweep could
+    # silently un-quiesce a cell and resurrect one expired by any amount.
+    if renew and source.replica_state != target_state:
+        raise MetadataConflict(
+            "renewal cannot change the membership state",
+            reason=ConflictReason.AUTHORIZATION_RENEWAL_CANNOT_CHANGE_STATE,
+        )
+    # The exemption exists so a fully drained cell can still be resumed after its
+    # window lapsed. It is the one path that may act on a stale bundle, so it is
+    # explicitly closed to renewal -- the guard above already makes the two
+    # mutually exclusive, and saying so here keeps the property locally checkable.
     if source.expires_at <= current and not (
-        source.replica_state == "DRAINING" and source.no_in_flight and target_state == "SERVING"
+        not renew
+        and source.replica_state == "DRAINING"
+        and source.no_in_flight
+        and target_state == "SERVING"
     ):
         raise MetadataConflict(
             "stale authorization membership cannot be renewed",

--- a/infra/provisioner/src/exomem_provisioner/conflict_reason.py
+++ b/infra/provisioner/src/exomem_provisioner/conflict_reason.py
@@ -149,6 +149,7 @@ class ConflictReason(StrEnum):
     AUTHORIZATION_MEMBERSHIP_TRANSITION_IS_INVALID = (
         "authorization-membership-transition-is-invalid"
     )
+    AUTHORIZATION_RENEWAL_CANNOT_CHANGE_STATE = "authorization-renewal-cannot-change-state"
     AUTHORIZATION_RUNTIME_ATTESTATION_IS_INVALID = "authorization-runtime-attestation-is-invalid"
     AUTHORIZATION_SECRET_PROVIDER_AUTHORITY_IS_ABSENT = (
         "authorization-secret-provider-authority-is-absent"

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -1968,6 +1968,18 @@ class CellLifecycleDriver:
                     _metadata_from_context(context), context.provider_operation_id
                 )
                 return DriverFinal({})
+            if action == "renew-authorization":
+                # Deliberately not routed through `_lifecycle`: renewal touches
+                # neither routes nor the maintenance drain. It advances the
+                # membership on a cell that is still in date and healthy, so the
+                # attestation window moves forward before it can lapse. A cell
+                # whose window does lapse cannot recover -- minting is fenced off
+                # once it has served, and the drain that would renew it needs an
+                # attestation the expired cell can no longer sign.
+                await self._plane.renew_authorization_session(
+                    _metadata_from_context(context), request
+                )
+                return DriverFinal({})
             if action in {"quiesce", "stop", "resume", "seal"}:
                 return await self._lifecycle(action, request, context)
             if action == "rotate-credential":

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -792,6 +792,7 @@ class LiveLifecyclePlane:
         require_runtime_attestation: bool = False,
         runtime_credential: str | None = None,
         runtime_protocol_version: str | None = None,
+        renew: bool = False,
     ) -> str:
         """Commit one authenticated successor under the lifecycle maintenance lease."""
 
@@ -861,6 +862,7 @@ class LiveLifecyclePlane:
             target_no_in_flight=target_no_in_flight,
             target_software_version=target_software_version,
             now=current,
+            renew=renew,
             runtime_attestation=runtime_attestation,
         )
         if successor.revision != source.revision:
@@ -874,6 +876,40 @@ class LiveLifecyclePlane:
                 expected_revision=source.revision,
             )
         return successor.revision
+
+    async def renew_authorization_session(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+    ) -> str:
+        """Mint a fresh attestation window on a healthy cell, invisibly.
+
+        The bundle carries a one-hour TTL and nothing renewed it, so a cell
+        stopped admitting mutations an hour after it was provisioned while
+        continuing to serve reads normally -- and once expired it could not
+        recover, because minting is fenced off for a cell that has served and
+        the drain that would renew it needs an attestation the cell can no
+        longer sign. Renewing while still in date avoids all of that: the
+        membership simply advances and the window moves forward.
+
+        Deliberately not routed through `_authorization_helm_values`. The
+        rendered revision is a pod-template annotation, so putting a renewal
+        through Helm would roll the StatefulSet every hour. The new bundle
+        reaches the running pod through the projected Secret instead, which its
+        refresh sidecar republishes and the runtime re-reads on the next
+        admission check.
+        """
+
+        target = runtime_identity(request)
+        return await self._transition_authorization_session_membership(
+            metadata,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            require_runtime_attestation=True,
+            runtime_credential=str(request["serviceCredential"]),
+            runtime_protocol_version=str(target["protocolVersion"]),
+            renew=True,
+        )
 
     async def observed_fence(self, tenant_id: str) -> int:
         return await self._registry.observed_fence(tenant_id)

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -898,6 +898,13 @@ class LiveLifecyclePlane:
         reaches the running pod through the projected Secret instead, which its
         refresh sidecar republishes and the runtime re-reads on the next
         admission check.
+
+        Names SERVING because that is the only state renewal ever acts on. A cell
+        that is draining, or already drained, is refused rather than resumed:
+        `transition_hosted_authorization_bundle` rejects a renewal whose target
+        differs from the source state. Without that a renewal would take the
+        resume branch and ride the expiry exemption beside it, silently
+        un-quiescing a deliberately drained cell.
         """
 
         target = runtime_identity(request)

--- a/infra/provisioner/src/exomem_provisioner/models.py
+++ b/infra/provisioner/src/exomem_provisioner/models.py
@@ -41,6 +41,7 @@ class OperationAction(StrEnum):
     ROLLBACK_ROLLFORWARD = "rollback-rollforward"
     ROTATE_CREDENTIAL = "rotate-credential"
     QUIESCE = "quiesce"
+    RENEW_AUTHORIZATION = "renew-authorization"
     RESUME = "resume"
     STOP = "stop"
     EXPORT = "export"

--- a/infra/provisioner/src/exomem_provisioner/schemas.py
+++ b/infra/provisioner/src/exomem_provisioner/schemas.py
@@ -218,6 +218,10 @@ class V2ResumeRequest(V2TargetRequest):
     pass
 
 
+class V2RenewAuthorizationRequest(V2TargetRequest):
+    pass
+
+
 class V2StopRequest(V2TargetRequest):
     pass
 
@@ -411,6 +415,7 @@ V2_REQUEST_MODELS: dict[str, type[StrictSchema]] = {
     "rollback-rollforward": V2RollbackRollforwardRequest,
     "rotate-credential": V2RotateCredentialRequest,
     "quiesce": V2QuiesceRequest,
+    "renew-authorization": V2RenewAuthorizationRequest,
     "resume": V2ResumeRequest,
     "stop": V2StopRequest,
     "export": V2ExportRequest,
@@ -451,6 +456,10 @@ V2_FINAL_MODELS: dict[str, type[StrictSchema] | None] = {
     "health": V2HealthResponse,
     "rollforward": None,
     "rollback-rollforward": None,
+    # v2-only. `provisioner-wire-v1.json` is the frozen rollback corpus and its
+    # digest is a lock anchor (`rollback.v1CorpusSha256`), so a new action must
+    # never widen v1.
+    "renew-authorization": None,
 }
 
 

--- a/infra/provisioner/tests/fixtures/provisioner-wire-v2.json
+++ b/infra/provisioner/tests/fixtures/provisioner-wire-v2.json
@@ -1,25 +1,791 @@
 {
-  "protocol": "exomem-cell-provisioner.v2",
-  "schemaVersion": 2,
   "actions": {
-    "provision": {"idempotencyKey":"fixture-provision-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"provisionMode":"serve"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"providerRef":"hcloud.volume.fixture-alpha","privateEndpoint":"https://cell-v2-alpha.internal.example"}}},
-    "health": {"idempotencyKey":"fixture-health-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"live":true,"ready":true,"cellId":"cell-v2-alpha","runtimeIdentity":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"serviceAuthenticated":true,"mutationAuthority":true,"readAdmission":true,"writeAdmission":true,"workerPolicy":{"workerCount":0,"semantic":false,"media":false},"code":"CELL_READY"}}},
-    "rollforward": {"idempotencyKey":"fixture-rollforward-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "rotate-credential": {"idempotencyKey":"fixture-rotate-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"phase":"finalize","credentialVersion":2,"nextCredential":"$NEXT_SERVICE_CREDENTIAL"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"previousCredentialRejected":true}}},
-    "quiesce": {"idempotencyKey":"fixture-quiesce-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "resume": {"idempotencyKey":"fixture-resume-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "stop": {"idempotencyKey":"fixture-stop-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "export": {"idempotencyKey":"fixture-export-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"expiresAt":"$NOW_PLUS_86400_SECONDS"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"exportRef":"export.fixture-alpha","releaseRef":"release.fixture-alpha","archiveSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","manifestSha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","archiveSize":1048576,"encryptionScheme":"envelope-aes-256-gcm","integrityVerified":true}}},
-    "export-release": {"idempotencyKey":"fixture-export-release-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"releaseRef":"release.fixture-alpha"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "export-delete": {"idempotencyKey":"fixture-export-delete-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","exportRef":"export.fixture-alpha"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"objectDestroyed":true}}},
-    "restore": {"idempotencyKey":"fixture-restore-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"restoreRef":"restore.fixture-alpha","sourceCellId":"cell-source-fixture-alpha","archiveSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","manifestSha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","archiveSize":1048576},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "export-download": {"idempotencyKey":"fixture-export-download-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","exportRef":"export.fixture-alpha"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"url":"https://downloads.example/export.fixture-alpha","expiresAt":"$NOW_PLUS_600_SECONDS"}}},
-    "seal": {"idempotencyKey":"fixture-seal-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}},
-    "discard": {"idempotencyKey":"fixture-discard-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"computeDestroyed":true,"storageDestroyed":true,"keysDestroyed":true}}},
-    "destroy": {"idempotencyKey":"fixture-destroy-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":200,"body":{"computeDestroyed":true,"storageDestroyed":true,"keysDestroyed":true,"tenantResourcesDestroyed":true}}},
-    "rollback-rollforward": {"idempotencyKey":"fixture-rollback-rollforward-key","request":{"operationId":"operation-v2-alpha","checkpoint":"requested","fenceGeneration":7,"tenantId":"tenant-v2-alpha","cellId":"cell-v2-alpha","providerRef":"hcloud.volume.fixture-alpha","serviceCredential":"$ACTIVE_SERVICE_CREDENTIAL","workerPolicy":{"workerCount":0,"semantic":false,"media":false},"runtimeTarget":{"releaseVersion":"0.35.1","protocolVersion":"1","agentProfile":"hosted-alpha-agent-v1","gatewayContractDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","commandFingerprint":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","schemaDigest":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"compatibilityDigest":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"pending":{"status":202,"headers":{"retry-after":"2"},"body":{"status":"pending","operationId":"operation-v2-alpha","checkpoint":"requested","retryAfterSeconds":2}},"final":{"status":204,"body":null}}
+    "destroy": {
+      "final": {
+        "body": {
+          "computeDestroyed": true,
+          "keysDestroyed": true,
+          "storageDestroyed": true,
+          "tenantResourcesDestroyed": true
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-destroy-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "tenantId": "tenant-v2-alpha"
+      }
+    },
+    "discard": {
+      "final": {
+        "body": {
+          "computeDestroyed": true,
+          "keysDestroyed": true,
+          "storageDestroyed": true
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-discard-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "export": {
+      "final": {
+        "body": {
+          "archiveSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "archiveSize": 1048576,
+          "encryptionScheme": "envelope-aes-256-gcm",
+          "exportRef": "export.fixture-alpha",
+          "integrityVerified": true,
+          "manifestSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "releaseRef": "release.fixture-alpha"
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-export-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "expiresAt": "$NOW_PLUS_86400_SECONDS",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "export-delete": {
+      "final": {
+        "body": {
+          "objectDestroyed": true
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-export-delete-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "checkpoint": "requested",
+        "exportRef": "export.fixture-alpha",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "tenantId": "tenant-v2-alpha"
+      }
+    },
+    "export-download": {
+      "final": {
+        "body": {
+          "expiresAt": "$NOW_PLUS_600_SECONDS",
+          "url": "https://downloads.example/export.fixture-alpha"
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-export-download-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "checkpoint": "requested",
+        "exportRef": "export.fixture-alpha",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "tenantId": "tenant-v2-alpha"
+      }
+    },
+    "export-release": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-export-release-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "releaseRef": "release.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "health": {
+      "final": {
+        "body": {
+          "cellId": "cell-v2-alpha",
+          "code": "CELL_READY",
+          "live": true,
+          "mutationAuthority": true,
+          "readAdmission": true,
+          "ready": true,
+          "runtimeIdentity": {
+            "agentProfile": "hosted-alpha-agent-v1",
+            "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "protocolVersion": "1",
+            "releaseVersion": "0.35.1",
+            "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          },
+          "serviceAuthenticated": true,
+          "workerPolicy": {
+            "media": false,
+            "semantic": false,
+            "workerCount": 0
+          },
+          "writeAdmission": true
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-health-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "provision": {
+      "final": {
+        "body": {
+          "privateEndpoint": "https://cell-v2-alpha.internal.example",
+          "providerRef": "hcloud.volume.fixture-alpha"
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-provision-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "provisionMode": "serve",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "quiesce": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-quiesce-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "renew-authorization": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-renew-authorization-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "restore": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-restore-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "archiveSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "archiveSize": 1048576,
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "manifestSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "restoreRef": "restore.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "sourceCellId": "cell-source-fixture-alpha",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "resume": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-resume-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "rollback-rollforward": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-rollback-rollforward-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "rollforward": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-rollforward-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "rotate-credential": {
+      "final": {
+        "body": {
+          "previousCredentialRejected": true
+        },
+        "status": 200
+      },
+      "idempotencyKey": "fixture-rotate-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "credentialVersion": 2,
+        "fenceGeneration": 7,
+        "nextCredential": "$NEXT_SERVICE_CREDENTIAL",
+        "operationId": "operation-v2-alpha",
+        "phase": "finalize",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "seal": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-seal-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    },
+    "stop": {
+      "final": {
+        "body": null,
+        "status": 204
+      },
+      "idempotencyKey": "fixture-stop-key",
+      "pending": {
+        "body": {
+          "checkpoint": "requested",
+          "operationId": "operation-v2-alpha",
+          "retryAfterSeconds": 2,
+          "status": "pending"
+        },
+        "headers": {
+          "retry-after": "2"
+        },
+        "status": 202
+      },
+      "request": {
+        "cellId": "cell-v2-alpha",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "operationId": "operation-v2-alpha",
+        "providerRef": "hcloud.volume.fixture-alpha",
+        "runtimeTarget": {
+          "agentProfile": "hosted-alpha-agent-v1",
+          "commandFingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "compatibilityDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "gatewayContractDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "protocolVersion": "1",
+          "releaseVersion": "0.35.1",
+          "schemaDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "serviceCredential": "$ACTIVE_SERVICE_CREDENTIAL",
+        "tenantId": "tenant-v2-alpha",
+        "workerPolicy": {
+          "media": false,
+          "semantic": false,
+          "workerCount": 0
+        }
+      }
+    }
   },
-  "failures": [{"status":400,"body":{"code":"PROVISIONER_REJECTED","retryable":false}},{"status":409,"body":{"code":"CONTROL_PLANE_STATE_CONFLICT","retryable":false}},{"status":422,"body":{"code":"EXPORT_REQUEST_EXPIRED","retryable":false}},{"status":422,"body":{"code":"PROVISIONER_REJECTED","retryable":false}},{"status":500,"body":{"code":"PROVISIONER_RESPONSE_INVALID","retryable":false}},{"status":503,"body":{"code":"PROVISIONER_UNAVAILABLE","retryable":true}}],
-  "mismatch": {"status":422,"body":{"code":"PROVISIONER_REJECTED","retryable":false}},
-  "replayFailure": {"status":409,"body":{"code":"CONTROL_PLANE_STATE_CONFLICT","retryable":false}}
+  "failures": [
+    {
+      "body": {
+        "code": "PROVISIONER_REJECTED",
+        "retryable": false
+      },
+      "status": 400
+    },
+    {
+      "body": {
+        "code": "CONTROL_PLANE_STATE_CONFLICT",
+        "retryable": false
+      },
+      "status": 409
+    },
+    {
+      "body": {
+        "code": "EXPORT_REQUEST_EXPIRED",
+        "retryable": false
+      },
+      "status": 422
+    },
+    {
+      "body": {
+        "code": "PROVISIONER_REJECTED",
+        "retryable": false
+      },
+      "status": 422
+    },
+    {
+      "body": {
+        "code": "PROVISIONER_RESPONSE_INVALID",
+        "retryable": false
+      },
+      "status": 500
+    },
+    {
+      "body": {
+        "code": "PROVISIONER_UNAVAILABLE",
+        "retryable": true
+      },
+      "status": 503
+    }
+  ],
+  "mismatch": {
+    "body": {
+      "code": "PROVISIONER_REJECTED",
+      "retryable": false
+    },
+    "status": 422
+  },
+  "protocol": "exomem-cell-provisioner.v2",
+  "replayFailure": {
+    "body": {
+      "code": "CONTROL_PLANE_STATE_CONFLICT",
+      "retryable": false
+    },
+    "status": 409
+  },
+  "schemaVersion": 2
 }

--- a/infra/provisioner/tests/test_api.py
+++ b/infra/provisioner/tests/test_api.py
@@ -167,6 +167,21 @@ def _body_for(action: str) -> dict[str, Any]:
             "compatibilityDigest": "e" * 64,
         }
         return body
+    if action == "renew-authorization":
+        # v2-only, so the flat version fields give way to a runtimeTarget.
+        body = _target_body()
+        body.pop("releaseVersion")
+        body.pop("protocolVersion")
+        body["runtimeTarget"] = {
+            "releaseVersion": "0.35.1",
+            "protocolVersion": "1",
+            "agentProfile": "hosted-alpha-agent-v1",
+            "gatewayContractDigest": "a" * 64,
+            "commandFingerprint": "c" * 64,
+            "schemaDigest": "d" * 64,
+            "compatibilityDigest": "e" * 64,
+        }
+        return body
     if action == "rotate-credential":
         return _target_body(
             phase="stage",
@@ -551,7 +566,7 @@ async def _complete_as_worker(
 
 
 @pytest.mark.asyncio
-async def test_api_exposes_exact_sixteen_post_paths_and_strict_pending_union(
+async def test_api_exposes_exact_seventeen_post_paths_and_strict_pending_union(
     api: tuple[httpx.AsyncClient, OperationRepository, Path],
 ) -> None:
     client, _, _ = api
@@ -562,6 +577,7 @@ async def test_api_exposes_exact_sixteen_post_paths_and_strict_pending_union(
         "rollback-rollforward",
         "rotate-credential",
         "quiesce",
+        "renew-authorization",
         "resume",
         "stop",
         "export",
@@ -586,7 +602,9 @@ async def test_api_exposes_exact_sixteen_post_paths_and_strict_pending_union(
         body["operationId"] = f"operation-{index}"
         body["fenceGeneration"] = index
         headers = _headers(f"idempotency-{index}")
-        if action in {"rollforward", "rollback-rollforward"}:
+        # v2-only actions: `provisioner-wire-v1.json` is the frozen rollback
+        # corpus and its digest is a lock anchor, so v1 never gains an action.
+        if action in {"rollforward", "rollback-rollforward", "renew-authorization"}:
             headers["X-Exomem-Provisioner-Protocol"] = WIRE_PROTOCOL_V2
         response = await client.post(
             f"/cells/{action}",

--- a/infra/provisioner/tests/test_authorization_membership.py
+++ b/infra/provisioner/tests/test_authorization_membership.py
@@ -329,3 +329,124 @@ def test_membership_transition_commits_only_the_exact_runtime_attestation() -> N
             ttl_seconds=300,
             runtime_attestation=tampered,
         )
+
+
+def _drained_bundle(now: int):
+    """A cell that has been quiesced: DRAINING with its in-flight work acknowledged."""
+    initial = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+    common = {
+        "expected_cell_id": "cell-alpha",
+        "expected_logical_vault_id": "tenant-alpha",
+        "expected_replica_id": "exo-0123456789abcdef0123-0",
+        "expected_software_version": "0.48.0",
+        "expected_schema_version": 4,
+        "expected_recovery_envelope": "signed-authorization-session-secret",
+    }
+    drained = transition_hosted_authorization_bundle(
+        initial.files,
+        **common,
+        target_state="DRAINING",
+        target_no_in_flight=True,
+        now=now + 30,
+    )
+    return drained, common
+
+
+def test_renewal_cannot_un_quiesce_a_drained_cell() -> None:
+    """Renewal moves the window; it must not double as an unaudited resume.
+
+    `renew_authorization_session` names `target_state="SERVING"` because that is
+    the only state it ever renews. Against a drained cell that target would take
+    the resume branch, so a background sweep running every minute would silently
+    put a deliberately quiesced cell back into service.
+    """
+    now = 1_900_000_000
+    drained, common = _drained_bundle(now)
+    _, record = _runtime_membership(drained, now=now + 30)
+    assert [replica.state for replica in record.replicas] == ["DRAINING"]
+
+    with pytest.raises(MetadataConflict, match="renewal cannot change"):
+        transition_hosted_authorization_bundle(
+            drained.files,
+            **common,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=now + 60,
+            renew=True,
+        )
+
+
+def test_renewal_cannot_resurrect_a_drained_cell_whose_window_lapsed() -> None:
+    """The drain exemption is the one path allowed to act on a stale bundle.
+
+    It exists so a fully drained cell can still be resumed after its window
+    closed. Renewal riding it would resurrect a cell expired by any amount at
+    all, which is precisely the fence the whole change exists to respect.
+    """
+    now = 1_900_000_000
+    drained, common = _drained_bundle(now)
+
+    with pytest.raises(MetadataConflict, match="renewal cannot change"):
+        transition_hosted_authorization_bundle(
+            drained.files,
+            **common,
+            target_state="SERVING",
+            target_no_in_flight=False,
+            now=now + 999_999,
+            renew=True,
+        )
+
+    # The exemption itself is untouched: a real resume of the same drained cell,
+    # past expiry, still works. The guard closes renewal, not recovery.
+    resumed = transition_hosted_authorization_bundle(
+        drained.files,
+        **common,
+        target_state="SERVING",
+        target_no_in_flight=False,
+        now=now + 999_999,
+    )
+    _, resumed_record = _runtime_membership(resumed, now=now + 999_999)
+    assert [replica.state for replica in resumed_record.replicas] == ["SERVING"]
+
+
+def test_renewal_of_an_in_date_serving_cell_still_moves_the_window() -> None:
+    """The control: the guard must not have closed the path renewal exists for."""
+    now = 1_900_000_000
+    initial = build_initial_hosted_authorization_bundle(
+        cell_id="cell-alpha",
+        logical_vault_id="tenant-alpha",
+        replica_id="exo-0123456789abcdef0123-0",
+        software_version="0.48.0",
+        schema_version=4,
+        recovery_envelope="signed-authorization-session-secret",
+        now=now,
+        entropy=_entropy,
+    )
+    _, before_record = _runtime_membership(initial, now=now)
+
+    renewed = transition_hosted_authorization_bundle(
+        initial.files,
+        expected_cell_id="cell-alpha",
+        expected_logical_vault_id="tenant-alpha",
+        expected_replica_id="exo-0123456789abcdef0123-0",
+        expected_software_version="0.48.0",
+        expected_schema_version=4,
+        expected_recovery_envelope="signed-authorization-session-secret",
+        target_state="SERVING",
+        target_no_in_flight=False,
+        now=now + 1_800,
+        renew=True,
+    )
+    _, renewed_record = _runtime_membership(renewed, now=now + 1_800)
+
+    assert [replica.state for replica in renewed_record.replicas] == ["SERVING"]
+    assert renewed_record.expires_at > before_record.expires_at

--- a/infra/provisioner/tests/test_durability_runtime.py
+++ b/infra/provisioner/tests/test_durability_runtime.py
@@ -321,7 +321,7 @@ def test_production_worker_action_sets_have_one_owner_for_every_action() -> None
         for action in OperationAction
     }
 
-    assert len(ownership) == 16
+    assert len(ownership) == 17
     assert set(ownership.values()) == {1}
     assert DELETION_OPERATION_ACTIONS == frozenset(
         {OperationAction.DISCARD, OperationAction.DESTROY}

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -2381,3 +2381,64 @@ async def test_a_fresh_authorization_bundle_is_reused_rather_than_reminted() -> 
 
     assert not written, "a fresh bundle must be reused, not re-minted"
     assert applied and applied[0]["authorizationSessionRevision"] == original.revision
+
+
+@pytest.mark.asyncio
+async def test_renewing_a_healthy_session_moves_the_window_without_rolling_the_pod() -> None:
+    """Renewal must be invisible: a fresh window, and no Helm transition.
+
+    The bundle carries a one-hour TTL and nothing renewed it, so a cell stopped
+    admitting mutations an hour after provisioning while still serving reads.
+    The rendered `authorizationSessionRevision` is a pod-template annotation, so
+    routing a renewal through Helm would roll the StatefulSet every hour; the
+    new bundle reaches the running pod through the projected Secret instead.
+    """
+
+    metadata = _metadata()
+    minted_at = 1_900_000_000
+    plane, request, _config, original, written, applied = _expiring_bundle_plane(
+        metadata,
+        minted_at=minted_at,
+        now=minted_at + 3_000,  # still inside the 3600s attestation TTL
+        serving=True,
+        runtime_admitted=True,
+        routes=(True, True),
+    )
+    plane._runtime = SimpleNamespace(
+        attest_authorization_session_membership=_no_runtime_attestation
+    )
+    request = {
+        **request,
+        "serviceCredential": "credential-current",
+        "releaseVersion": "0.68.3",
+        "protocolVersion": "1",
+    }
+
+    revision = await plane.renew_authorization_session(metadata, request)
+
+    assert revision != original.revision
+    assert written, "a renewal must commit a successor bundle"
+    assert written[-1]["membership_epoch"] == original.epoch + 1
+    # Compare-and-swap against the revision this pass read.
+    assert written[-1]["expected_revision"] == original.revision
+    assert not applied, "a renewal must not apply Helm values and roll the pod"
+
+    renewed = inspect_hosted_authorization_bundle(
+        written[-1]["files"],
+        expected_cell_id=metadata.subject_id,
+        expected_logical_vault_id=metadata.tenant_id,
+        expected_replica_id=metadata.resource_name + "-0",
+        expected_software_version=None,
+        expected_schema_version=AUTHORIZATION_SESSION_SCHEMA_VERSION,
+        expected_recovery_envelope=request["_providerRecoveryEnvelopes"][
+            "authorizationSessionSecret"
+        ],
+        now=minted_at + 3_000,
+    )
+    assert renewed.replica_state == "SERVING"
+    assert renewed.expires_at > original.expires_at
+
+
+async def _no_runtime_attestation(*_args, **_kwargs):
+    """The synthesized path; the runtime signature is covered by its own tests."""
+    return None

--- a/infra/provisioner/tests/test_wire_protocol.py
+++ b/infra/provisioner/tests/test_wire_protocol.py
@@ -81,8 +81,8 @@ def test_v2_cell_requests_require_only_a_strict_seven_field_runtime_target() -> 
 def test_v2_has_one_closed_model_per_action_and_explicit_target_free_actions() -> None:
     request_models = REQUEST_MODELS_BY_PROTOCOL[WIRE_PROTOCOL_V2]
 
-    assert len(request_models) == 16
-    assert len(set(request_models.values())) == 16
+    assert len(request_models) == 17
+    assert len(set(request_models.values())) == 17
     assert set(request_models["rollforward"].model_fields) == {
         "operationId",
         "checkpoint",

--- a/src/exomem/governance/authorization_custody.py
+++ b/src/exomem/governance/authorization_custody.py
@@ -831,8 +831,30 @@ def load_authorization_custody(
     *,
     now: int,
 ) -> AuthorizationCustody:
-    """Load and authenticate the complete external session-custody bundle."""
+    """Load and authenticate the complete external session-custody bundle.
 
+    Retried once, because the three custody files are read separately and are
+    replaced one after another when a renewed authorization bundle is published
+    into a running cell. A read landing inside that burst sees a mixed
+    generation and fails cross-validation, which would refuse an occasional
+    mutation for no reason a caller could act on.
+
+    Retrying a fail-closed read cannot turn a real failure into a pass: the
+    second attempt re-reads and re-authenticates every file under the same
+    rules, so an expired, forged or genuinely absent bundle refuses twice.
+    """
+
+    try:
+        return _load_authorization_custody_once(Path(vault_root), now=now)
+    except AuthorizationCustodyUnavailable:
+        return _load_authorization_custody_once(Path(vault_root), now=now)
+
+
+def _load_authorization_custody_once(
+    vault_root: Path,
+    *,
+    now: int,
+) -> AuthorizationCustody:
     external = load_external_custody(Path(vault_root))
     keyring = parse_keyring(external.keyring)
     control = parse_control_record(external.control, keyring=keyring, now=now)

--- a/src/exomem/governance/authorization_hosted_mount.py
+++ b/src/exomem/governance/authorization_hosted_mount.py
@@ -238,6 +238,14 @@ def republish_projected_custody(source: Path, destination: Path) -> None:
             or info.st_gid != os.getegid()
         ):
             raise HostedCustodyMountUnavailable
+        # The sidecar is the only writer and never republishes concurrently with
+        # itself, so any staging file already present is an orphan from a crashed
+        # attempt. Left alone they accumulate without bound in a 256 KiB tmpfs.
+        for orphan in destination.glob(".*.tmp"):
+            try:
+                orphan.unlink()
+            except OSError:
+                pass
         replacements: list[tuple[Path, Path]] = []
         for name in _FILENAMES:
             temporary = destination / f".{name}.{uuid.uuid4().hex}.tmp"
@@ -295,6 +303,29 @@ def projected_generation(source: Path) -> str:
     return link if _GENERATION.match(link) else ""
 
 
+def _published_custody_is_current(source: Path, destination: Path) -> bool:
+    """Answer whether every published file already matches the projected one.
+
+    An unreadable source is treated as current: there is nothing to publish, and
+    republishing from a torn projection would be worse than waiting. An
+    unreadable or differing destination file is not current, which is what makes
+    a crash-interrupted publish and a restarted sidecar both self-healing.
+    """
+
+    try:
+        payloads = _projected_payloads(Path(source))
+    except HostedCustodyMountUnavailable:
+        return True
+    for name in _FILENAMES:
+        try:
+            with open(Path(destination) / name, "rb") as handle:
+                if handle.read(MAX_CUSTODY_FILE_BYTES + 1) != payloads[name]:
+                    return False
+        except OSError:
+            return False
+    return True
+
+
 def watch_projected_custody(
     source: Path,
     destination: Path,
@@ -314,22 +345,27 @@ def watch_projected_custody(
     watch. The previous generation stays whole and serving, so the cost of
     waiting is bounded by the attestation window, while exiting would strand the
     pod on a generation nothing will ever refresh.
+
+    The tick compares what is *published* against what is *projected*, rather
+    than remembering which source generation was last seen. Remembering is
+    edge-triggered and wrong twice over: a sidecar restart re-seeds the memory
+    from the current source and never notices that the destination is stale, and
+    a republish interrupted between file replacements leaves a mixed generation
+    that no later tick would ever revisit. Comparing content is level-triggered,
+    so both repair themselves within one interval.
     """
 
-    published = projected_generation(source)
     remaining = ticks
     while remaining is None or remaining > 0:
         sleeper(interval_seconds)
         if remaining is not None:
             remaining -= 1
-        current = projected_generation(source)
-        if not current or current == published:
+        if _published_custody_is_current(source, destination):
             continue
         try:
             republish_projected_custody(source, destination)
         except HostedCustodyMountUnavailable:
             continue
-        published = current
     return 0
 
 

--- a/src/exomem/governance/authorization_hosted_mount.py
+++ b/src/exomem/governance/authorization_hosted_mount.py
@@ -202,6 +202,83 @@ def copy_projected_custody(source: Path, destination: Path) -> None:
         raise HostedCustodyMountUnavailable from None
 
 
+def republish_projected_custody(source: Path, destination: Path) -> None:
+    """Replace a live custody generation with the current projected one.
+
+    `copy_projected_custody` creates its destination and refuses a non-empty
+    one, so it can only initialise. A renewed authorization bundle reaches the
+    projected Secret while the pod runs, and the runtime re-reads custody on
+    every admission check, so publishing the new generation in place is what
+    makes renewal invisible instead of requiring the pod to restart.
+
+    Every replacement file is written and fsynced before any of them is moved
+    into place. A source that turns out to be torn or ambiguous therefore leaves
+    the previous generation whole, rather than stranding the runtime on a
+    directory holding one renewed file beside two stale ones -- which would fail
+    cross-validation and refuse writes until something republished it correctly.
+    """
+
+    source = Path(source)
+    destination = Path(destination)
+    staged: list[Path] = []
+    try:
+        payloads = _projected_payloads(source)
+        info = os.lstat(destination)
+        if (
+            not stat.S_ISDIR(info.st_mode)
+            or stat.S_ISLNK(info.st_mode)
+            or stat.S_IMODE(info.st_mode) != 0o700
+            or info.st_uid != os.geteuid()
+            or info.st_gid != os.getegid()
+        ):
+            raise HostedCustodyMountUnavailable
+        replacements: list[tuple[Path, Path]] = []
+        for name in _FILENAMES:
+            temporary = destination / f".{name}.{uuid.uuid4().hex}.tmp"
+            descriptor = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            staged.append(temporary)
+            try:
+                view = memoryview(payloads[name])
+                while view:
+                    written = os.write(descriptor, view)
+                    if written < 1:
+                        raise HostedCustodyMountUnavailable
+                    view = view[written:]
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            replacements.append((temporary, destination / name))
+        for temporary, published in replacements:
+            os.replace(temporary, published)
+            staged.remove(temporary)
+        directory_fd = os.open(
+            destination,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0),
+        )
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except HostedCustodyMountUnavailable:
+        for path in staged:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        raise
+    except (OSError, TypeError, ValueError):
+        for path in staged:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        raise HostedCustodyMountUnavailable from None
+
+
 def main() -> int:
     try:
         copy_projected_custody(SOURCE_ROOT, HOSTED_CUSTODY_ROOT)

--- a/src/exomem/governance/authorization_hosted_mount.py
+++ b/src/exomem/governance/authorization_hosted_mount.py
@@ -293,16 +293,6 @@ def republish_projected_custody(source: Path, destination: Path) -> None:
         raise HostedCustodyMountUnavailable from None
 
 
-def projected_generation(source: Path) -> str:
-    """Name the generation `..data` currently points at, or "" when unreadable."""
-
-    try:
-        link = os.readlink(Path(source) / "..data")
-    except OSError:
-        return ""
-    return link if _GENERATION.match(link) else ""
-
-
 def _published_custody_is_current(source: Path, destination: Path) -> bool:
     """Answer whether every published file already matches the projected one.
 

--- a/src/exomem/governance/authorization_hosted_mount.py
+++ b/src/exomem/governance/authorization_hosted_mount.py
@@ -6,7 +6,9 @@ import os
 import re
 import stat
 import sys
+import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 from .authorization_custody import HOSTED_CUSTODY_ROOT, MAX_CUSTODY_FILE_BYTES
@@ -14,6 +16,10 @@ from .authorization_custody import HOSTED_CUSTODY_ROOT, MAX_CUSTODY_FILE_BYTES
 SOURCE_ROOT = Path("/run/exomem/authorization-session-source")
 _FILENAMES = ("control.json", "keyring.json", "serving-membership.json")
 _GENERATION = re.compile(r"\.\.[A-Za-z0-9_.-]{1,255}\Z")
+#: Kubelet refreshes a Secret volume about once a minute, so a shorter poll
+#: only costs syscalls. The renewal budget that matters is the attestation
+#: window, not this interval.
+WATCH_INTERVAL_SECONDS = 15.0
 
 
 class HostedCustodyMountUnavailable(RuntimeError):
@@ -279,7 +285,65 @@ def republish_projected_custody(source: Path, destination: Path) -> None:
         raise HostedCustodyMountUnavailable from None
 
 
-def main() -> int:
+def projected_generation(source: Path) -> str:
+    """Name the generation `..data` currently points at, or "" when unreadable."""
+
+    try:
+        link = os.readlink(Path(source) / "..data")
+    except OSError:
+        return ""
+    return link if _GENERATION.match(link) else ""
+
+
+def watch_projected_custody(
+    source: Path,
+    destination: Path,
+    *,
+    interval_seconds: float = WATCH_INTERVAL_SECONDS,
+    sleeper: Callable[[float], None] = time.sleep,
+    ticks: int | None = None,
+) -> int:
+    """Republish each time kubelet swaps the projected generation.
+
+    The runtime re-reads custody on every admission check, so keeping the
+    published generation current is the whole of seamless renewal: a renewed
+    bundle reaches the Secret volume while the pod runs, and the pod picks it up
+    without restarting.
+
+    A republish that fails is retried on the next tick rather than ending the
+    watch. The previous generation stays whole and serving, so the cost of
+    waiting is bounded by the attestation window, while exiting would strand the
+    pod on a generation nothing will ever refresh.
+    """
+
+    published = projected_generation(source)
+    remaining = ticks
+    while remaining is None or remaining > 0:
+        sleeper(interval_seconds)
+        if remaining is not None:
+            remaining -= 1
+        current = projected_generation(source)
+        if not current or current == published:
+            continue
+        try:
+            republish_projected_custody(source, destination)
+        except HostedCustodyMountUnavailable:
+            continue
+        published = current
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    watch = "--watch" in arguments
+    if watch:
+        arguments.remove("--watch")
+    if arguments:
+        return 2
+    if watch:
+        # The init container has already published the first generation; a
+        # second copy would refuse against its own non-empty destination.
+        return watch_projected_custody(SOURCE_ROOT, HOSTED_CUSTODY_ROOT)
     try:
         copy_projected_custody(SOURCE_ROOT, HOSTED_CUSTODY_ROOT)
     except HostedCustodyMountUnavailable:

--- a/tests/test_authorization_hosted_mount.py
+++ b/tests/test_authorization_hosted_mount.py
@@ -342,3 +342,117 @@ def _republished_secret_without_previous(root: Path, payloads: dict[str, bytes])
     replacement = root / "..data.tmp"
     replacement.symlink_to(generation.name, target_is_directory=True)
     os.replace(replacement, root / "..data")
+
+
+def test_watch_republishes_a_stale_destination_after_a_sidecar_restart(
+    tmp_path: Path,
+) -> None:
+    """A restarted watch must reconcile, not re-seed and go quiet.
+
+    The watch used to remember which source generation it had last seen. On
+    restart that memory was re-seeded from the *current* source, so a generation
+    swapped while the sidecar was down was never published — and the pod served
+    on a bundle that would expire, which is the original defect exactly.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    # The swap happens while nothing is watching.
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    _republished_secret(source, renewed)
+
+    # A freshly started watch sees an unchanged source for its whole life.
+    authorization_hosted_mount.watch_projected_custody(
+        source, destination, sleeper=lambda _seconds: None, ticks=1
+    )
+
+    for name, payload in renewed.items():
+        assert (destination / name).read_bytes() == payload
+
+
+def test_watch_repairs_a_generation_left_mixed_by_an_interrupted_publish(
+    tmp_path: Path,
+) -> None:
+    """A crash between file replacements must not strand the pod permanently.
+
+    The published files are cross-validated against each other, so one renewed
+    file beside two stale ones refuses every mutation. Nothing repaired it while
+    the watch keyed on the source generation, because the source had not moved.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    _republished_secret(source, renewed)
+    # Exactly the state a kill between os.replace calls leaves behind.
+    first = sorted(_FILES)[0]
+    (destination / first).write_bytes(renewed[first])
+    assert (destination / sorted(_FILES)[1]).read_bytes() != renewed[sorted(_FILES)[1]]
+
+    authorization_hosted_mount.watch_projected_custody(
+        source, destination, sleeper=lambda _seconds: None, ticks=1
+    )
+
+    for name, payload in renewed.items():
+        assert (destination / name).read_bytes() == payload
+
+
+def test_watch_leaves_a_current_destination_untouched(tmp_path: Path) -> None:
+    """The control: level-triggered must not mean republishing every tick.
+
+    Without this, the two tests above would pass against an implementation that
+    simply rewrote the files unconditionally, which would churn a tmpfs and
+    widen the window in which a reader can see a torn generation.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+    before = {
+        name: (destination / name).stat().st_ino for name in _FILES
+    }
+
+    authorization_hosted_mount.watch_projected_custody(
+        source, destination, sleeper=lambda _seconds: None, ticks=4
+    )
+
+    assert {name: (destination / name).stat().st_ino for name in _FILES} == before
+
+
+def test_republish_sweeps_staging_files_a_crashed_attempt_left_behind(
+    tmp_path: Path,
+) -> None:
+    """Orphaned temporaries accumulate unbounded in a 256 KiB tmpfs.
+
+    Nothing reclaims them: the failure path unlinks only what the current
+    attempt staged, and a killed process unlinks nothing at all.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+    orphan = destination / ".keyring.json.deadbeef.tmp"
+    orphan.write_bytes(b"orphaned by a crashed publish")
+
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    _republished_secret(source, renewed)
+    authorization_hosted_mount.republish_projected_custody(source, destination)
+
+    assert not orphan.exists()
+    assert sorted(path.name for path in destination.iterdir()) == sorted(_FILES)

--- a/tests/test_authorization_hosted_mount.py
+++ b/tests/test_authorization_hosted_mount.py
@@ -421,15 +421,26 @@ def test_watch_leaves_a_current_destination_untouched(tmp_path: Path) -> None:
     _projected_secret(source)
     wrapper.mkdir(mode=0o700)
     authorization_hosted_mount.copy_projected_custody(source, destination)
-    before = {
-        name: (destination / name).stat().st_ino for name in _FILES
-    }
 
-    authorization_hosted_mount.watch_projected_custody(
-        source, destination, sleeper=lambda _seconds: None, ticks=4
-    )
+    # Counted, not inferred from inode identity: a filesystem is free to reuse
+    # an inode number immediately after an unlink, so that comparison passes
+    # against an implementation that rewrites the files on every tick.
+    republishes = {"count": 0}
+    real = authorization_hosted_mount.republish_projected_custody
 
-    assert {name: (destination / name).stat().st_ino for name in _FILES} == before
+    def counting(*args, **kwargs):
+        republishes["count"] += 1
+        return real(*args, **kwargs)
+
+    authorization_hosted_mount.republish_projected_custody = counting
+    try:
+        authorization_hosted_mount.watch_projected_custody(
+            source, destination, sleeper=lambda _seconds: None, ticks=4
+        )
+    finally:
+        authorization_hosted_mount.republish_projected_custody = real
+
+    assert republishes["count"] == 0
 
 
 def test_republish_sweeps_staging_files_a_crashed_attempt_left_behind(

--- a/tests/test_authorization_hosted_mount.py
+++ b/tests/test_authorization_hosted_mount.py
@@ -263,3 +263,82 @@ def test_republish_projected_custody_survives_a_write_failure_midway(
     assert {path.name for path in destination.iterdir()} == set(_FILES)
     for name, payload in _FILES.items():
         assert (destination / name).read_bytes() == payload
+
+
+def test_watch_republishes_only_when_the_generation_changes(tmp_path: Path) -> None:
+    """Seamless renewal is the watch keeping the published generation current."""
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    swapped = {"done": False}
+
+    def sleeper(_seconds: float) -> None:
+        if not swapped["done"]:
+            _republished_secret(source, renewed)
+            swapped["done"] = True
+
+    authorization_hosted_mount.watch_projected_custody(
+        source, destination, sleeper=sleeper, ticks=3
+    )
+
+    for name, payload in renewed.items():
+        assert (destination / name).read_bytes() == payload
+
+
+def test_watch_survives_a_failed_republish_and_retries(tmp_path: Path) -> None:
+    """A transient failure must not end the watch and strand the pod.
+
+    Exiting would leave the runtime on a generation nothing will refresh, which
+    is exactly the stranding this whole path exists to prevent. Waiting costs at
+    most the remainder of the attestation window.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    steps = {"n": 0}
+
+    def sleeper(_seconds: float) -> None:
+        steps["n"] += 1
+        if steps["n"] == 1:
+            # A torn generation: ..data points at a directory that is not there.
+            broken = source / "..data.tmp"
+            broken.symlink_to("..2026_09_06_00_00_00.999999999", target_is_directory=True)
+            os.replace(broken, source / "..data")
+        elif steps["n"] == 2:
+            for stale in source.iterdir():
+                if stale.name.startswith("..2026") and stale.is_dir():
+                    for child in stale.iterdir():
+                        child.unlink()
+                    stale.rmdir()
+            _republished_secret_without_previous(source, renewed)
+
+    authorization_hosted_mount.watch_projected_custody(
+        source, destination, sleeper=sleeper, ticks=4
+    )
+
+    for name, payload in renewed.items():
+        assert (destination / name).read_bytes() == payload
+
+
+def _republished_secret_without_previous(root: Path, payloads: dict[str, bytes]) -> None:
+    generation = root / "..2026_09_06_00_00_00.000000003"
+    generation.mkdir(mode=0o700)
+    for name, payload in payloads.items():
+        target = generation / name
+        target.write_bytes(payload)
+        target.chmod(0o440)
+    replacement = root / "..data.tmp"
+    replacement.symlink_to(generation.name, target_is_directory=True)
+    os.replace(replacement, root / "..data")

--- a/tests/test_authorization_hosted_mount.py
+++ b/tests/test_authorization_hosted_mount.py
@@ -130,3 +130,136 @@ def test_copy_projected_hosted_custody_cleans_a_partial_publication(
         authorization_hosted_mount.copy_projected_custody(source, destination)
 
     assert not destination.exists()
+
+
+def _republished_secret(root: Path, payloads: dict[str, bytes]) -> None:
+    """Replace the projected generation the way kubelet refreshes a Secret."""
+    generation = root / "..2026_09_06_00_00_00.000000002"
+    generation.mkdir(mode=0o700)
+    for name, payload in payloads.items():
+        target = generation / name
+        target.write_bytes(payload)
+        target.chmod(0o440)
+    replacement = root / "..data.tmp"
+    replacement.symlink_to(generation.name, target_is_directory=True)
+    previous = (root / "..data").resolve()
+    os.replace(replacement, root / "..data")
+    # kubelet removes the superseded generation once ..data points past it.
+    for stale in previous.iterdir():
+        stale.unlink()
+    previous.rmdir()
+
+
+def test_republish_projected_custody_replaces_a_live_generation(
+    tmp_path: Path,
+) -> None:
+    """Renewal must reach a pod that is already reading the custody directory.
+
+    `copy_projected_custody` mkdirs its destination and refuses a non-empty one,
+    so it can only initialise. Without a republish path the runtime holds the
+    generation its init container copied for the pod's whole life, which is why
+    a renewed authorization bundle could only be delivered by restarting the pod.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    _republished_secret(source, renewed)
+
+    authorization_hosted_mount.republish_projected_custody(source, destination)
+
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o700
+    assert {path.name for path in destination.iterdir()} == set(_FILES)
+    for name, payload in renewed.items():
+        published = destination / name
+        assert published.read_bytes() == payload
+        assert stat.S_IMODE(published.stat().st_mode) == 0o600
+        assert published.stat().st_uid == os.geteuid()
+        # The reader refuses a file with more than one link, so a republish must
+        # produce a fresh inode rather than hard-linking the projected source.
+        assert published.stat().st_nlink == 1
+
+
+def test_republish_projected_custody_requires_an_existing_generation(
+    tmp_path: Path,
+) -> None:
+    """Republishing is not a second way to initialise custody."""
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+
+    with pytest.raises(authorization_hosted_mount.HostedCustodyMountUnavailable):
+        authorization_hosted_mount.republish_projected_custody(source, wrapper / "private")
+
+
+def test_republish_projected_custody_keeps_the_previous_generation_on_a_bad_source(
+    tmp_path: Path,
+) -> None:
+    """A torn or ambiguous source is rejected before anything is written."""
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    (source / "unexpected.json").symlink_to("..data/keyring.json")
+
+    with pytest.raises(authorization_hosted_mount.HostedCustodyMountUnavailable):
+        authorization_hosted_mount.republish_projected_custody(source, destination)
+
+    assert {path.name for path in destination.iterdir()} == set(_FILES)
+    for name, payload in _FILES.items():
+        assert (destination / name).read_bytes() == payload
+
+
+def test_republish_projected_custody_survives_a_write_failure_midway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure partway through must leave the live generation whole.
+
+    Every replacement is written and fsynced before any is moved into place, so
+    a write that fails on the second file strands nothing. Replacing each file
+    as it is written would leave the runtime on a directory holding one renewed
+    file beside two stale ones, which fails cross-validation and refuses writes
+    until something republished it correctly.
+    """
+
+    source = tmp_path / "source"
+    wrapper = tmp_path / "destination"
+    destination = wrapper / "private"
+    _projected_secret(source)
+    wrapper.mkdir(mode=0o700)
+    authorization_hosted_mount.copy_projected_custody(source, destination)
+
+    renewed = {name: payload.replace(b"sentinel", b"renewed") for name, payload in _FILES.items()}
+    _republished_secret(source, renewed)
+
+    real_write = os.write
+    writes = {"count": 0}
+
+    def failing_write(fd: int, data) -> int:  # type: ignore[no-untyped-def]
+        writes["count"] += 1
+        if writes["count"] == 2:
+            raise OSError(28, "No space left on device")
+        return real_write(fd, data)
+
+    monkeypatch.setattr(authorization_hosted_mount.os, "write", failing_write)
+
+    with pytest.raises(authorization_hosted_mount.HostedCustodyMountUnavailable):
+        authorization_hosted_mount.republish_projected_custody(source, destination)
+
+    monkeypatch.undo()
+    # Every file is still the previous generation, and no temp file was left.
+    assert {path.name for path in destination.iterdir()} == set(_FILES)
+    for name, payload in _FILES.items():
+        assert (destination / name).read_bytes() == payload

--- a/tests/test_authorization_session_custody.py
+++ b/tests/test_authorization_session_custody.py
@@ -879,3 +879,52 @@ def test_fifo_custody_file_refuses_without_blocking(
 
     with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
         authorization_custody.load_external_custody(tmp_path / "vault")
+
+
+def test_custody_load_retries_once_through_a_republished_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A renewal republishes three files in turn; a read inside that burst must not refuse.
+
+    The custody files are read separately and replaced one after another, so a
+    read landing mid-burst sees a mixed generation and fails cross-validation.
+    That would refuse an occasional mutation for no reason a caller could act on.
+    """
+
+    attempts = {"n": 0}
+    marker = object()
+
+    def torn_then_whole(vault_root, *, now):  # type: ignore[no-untyped-def]
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise authorization_custody.AuthorizationCustodyUnavailable
+        return marker
+
+    monkeypatch.setattr(
+        authorization_custody, "_load_authorization_custody_once", torn_then_whole
+    )
+    assert authorization_custody.load_authorization_custody(tmp_path, now=1) is marker
+    assert attempts["n"] == 2
+
+
+def test_custody_load_still_refuses_a_bundle_that_fails_twice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The retry re-authenticates under the same rules, so it masks nothing.
+
+    An expired, forged or absent bundle refuses on both attempts. Pinning the
+    count is what stops the retry becoming an unbounded one.
+    """
+
+    attempts = {"n": 0}
+
+    def always_bad(vault_root, *, now):  # type: ignore[no-untyped-def]
+        attempts["n"] += 1
+        raise authorization_custody.AuthorizationCustodyUnavailable
+
+    monkeypatch.setattr(
+        authorization_custody, "_load_authorization_custody_once", always_bad
+    )
+    with pytest.raises(authorization_custody.AuthorizationCustodyUnavailable):
+        authorization_custody.load_authorization_custody(tmp_path, now=1)
+    assert attempts["n"] == 2

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -2521,15 +2521,35 @@ def test_cell_chart_renders_separate_privileged_init_and_restricted_serving_mode
         assert "runtimeClassName" not in pod
         assert "fsGroup" not in pod["securityContext"]
         assert "fsGroupChangePolicy" not in pod["securityContext"]
-        assert len(pod.get("initContainers", [])) == 1
+        assert len(pod.get("initContainers", [])) == 2
         custody_init = pod["initContainers"][0]
         assert custody_init["name"] == "authorization-session-custody"
         assert custody_init["args"] == [
             "-m",
             "exomem.governance.authorization_hosted_mount",
         ]
+        assert "restartPolicy" not in custody_init
         assert custody_init["securityContext"]["runAsUser"] == 10001
         assert custody_init["resources"]["requests"]["ephemeral-storage"] == "16Mi"
+        # A native sidecar, not an ordinary container: the tenant boundary policy
+        # pins `size(object.spec.containers) == 1` and indexes containers[0]
+        # throughout, so the refresher has to live in initContainers to leave all
+        # of that untouched. It republishes each generation kubelet projects, so
+        # a renewed authorization bundle reaches the pod without a restart.
+        refresh = pod["initContainers"][1]
+        assert refresh["name"] == "authorization-session-refresh"
+        assert refresh["restartPolicy"] == "Always"
+        assert refresh["image"] == custody_init["image"]
+        assert refresh["args"] == [
+            "-m",
+            "exomem.governance.authorization_hosted_mount",
+            "--watch",
+        ]
+        assert refresh["securityContext"] == custody_init["securityContext"]
+        assert refresh["resources"] == custody_init["resources"]
+        assert refresh["volumeMounts"] == custody_init["volumeMounts"]
+        assert "env" not in refresh and "ports" not in refresh
+        assert len(pod["containers"]) == 1
         container = pod["containers"][0]
         security = container["securityContext"]
         assert "seccompProfile" not in security

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -2954,11 +2954,25 @@ def test_cell_quota_holds_the_serving_pod_and_its_init_job_together() -> None:
     job's. Raising the runtime limit without raising this would have made the
     init job fail admission on quota rather than on real capacity — and it would
     have failed during provisioning, not during a test.
+
+    Native sidecars count too, and this test did not know that. An init
+    container with `restartPolicy: Always` is not merely max'd against the other
+    init containers: its resources are charged to the pod for its whole life.
+    Summing only `containers[0]` left the model 100m short of what the cluster
+    actually charges, so the quota looked sufficient here while k3s refused the
+    init job with `exceeded quota: cell-alpha-quota`.
     """
     documents = _render(CELL, CELL / "values.validation.yaml", namespace="cell-alpha-test")
     quota = _find(documents, "ResourceQuota", "cell-alpha-quota")["spec"]["hard"]
     statefulset = _find(documents, "StatefulSet", "cell-alpha")
-    runtime = statefulset["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"]
+    pod = statefulset["spec"]["template"]["spec"]
+    runtime = pod["containers"][0]["resources"]["limits"]
+    sidecars = [
+        container["resources"]["limits"]
+        for container in pod.get("initContainers", [])
+        if container.get("restartPolicy") == "Always"
+    ]
+    assert sidecars, "the refresh sidecar must be charged to the pod, not max'd away"
 
     def mebibytes(value: str) -> int:
         if value.endswith("Gi"):
@@ -2967,10 +2981,17 @@ def test_cell_quota_holds_the_serving_pod_and_its_init_job_together() -> None:
             return int(value.removesuffix("Mi"))
         raise AssertionError(f"unhandled memory unit: {value}")
 
+    def millicores(value: str) -> int:
+        if value.endswith("m"):
+            return int(value.removesuffix("m"))
+        return int(value) * 1000
+
     init_job_memory = mebibytes("1Gi")  # init-job.yaml, limits.memory
-    init_job_cpu = 1  # init-job.yaml, limits.cpu
-    assert mebibytes(quota["limits.memory"]) >= mebibytes(runtime["memory"]) + init_job_memory
-    assert int(quota["limits.cpu"]) >= int(runtime["cpu"]) + init_job_cpu
+    init_job_cpu = 1000  # init-job.yaml, limits.cpu
+    pod_memory = mebibytes(runtime["memory"]) + sum(mebibytes(s["memory"]) for s in sidecars)
+    pod_cpu = millicores(runtime["cpu"]) + sum(millicores(s["cpu"]) for s in sidecars)
+    assert mebibytes(quota["limits.memory"]) >= pod_memory + init_job_memory
+    assert millicores(quota["limits.cpu"]) >= pod_cpu + init_job_cpu
 
 
 def test_cell_routes_expose_only_exact_control_and_transfer_paths() -> None:

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -1489,7 +1489,7 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
     _assert_denied(
         k3s,
         serving_init_escape,
-        message="exact authorization-custody init container",
+        message="exact authorization-custody init and refresh containers",
     )
 
     serving_command_escape = copy.deepcopy(serving_pod)
@@ -1826,7 +1826,7 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
     for field in ("ports", "env", "startupProbe", "livenessProbe", "readinessProbe"):
         helper.pop(field, None)
     side_init["spec"]["initContainers"] = [helper]
-    _assert_denied(k3s, side_init, message="exact authorization-custody init container")
+    _assert_denied(k3s, side_init, message="exact authorization-custody init and refresh containers")
 
 
 def test_exact_k3s_scopes_privileged_volume_and_deletion_mutations(k3s: str) -> None:

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -1397,9 +1397,18 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
     serving = _render(CELL, CELL / "values.validation.yaml", namespace)
     stateful_set = next(item for item in serving if item.get("kind") == "StatefulSet")
     serving_pod = _pod(stateful_set, name="cell-alpha-serve-positive", namespace=namespace)
+    # Both init containers, in order. The second is a native sidecar
+    # (`restartPolicy: Always`) that republishes the authorization bundle while
+    # the pod runs, so a renewed bundle reaches the runtime without a restart.
+    # The policy pins this list exactly, and every place that enumerates it is
+    # part of the same change -- this assertion was the last one, and the live
+    # gate is what found it.
     assert [
         container["name"] for container in serving_pod["spec"]["initContainers"]
-    ] == ["authorization-session-custody"]
+    ] == ["authorization-session-custody", "authorization-session-refresh"]
+    assert (
+        serving_pod["spec"]["initContainers"][1].get("restartPolicy") == "Always"
+    ), "the refresh container must be a native sidecar, not a one-shot init step"
     assert _server_dry_run(k3s, serving_pod).returncode == 0
 
     # A selected agent profile is a platform decision: the chart writes it to the

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -2286,11 +2286,18 @@ def test_production_composition_contract_binds_release_and_operator_actions() ->
         "port": 8080,
     }
     assert contract["provisioner"]["protocol"] == "exomem-cell-provisioner.v1"
+    # `protocol` names the default wire envelope, not an exhaustive action gate.
+    # This map is the served HTTP surface, and the ingress route is generated
+    # against it, so an action absent here is unreachable however it is called.
+    # `renew-authorization` is v2-only on the wire -- the frozen v1 corpus in
+    # provisioner-wire-v1.json never gains an action -- but it is still served,
+    # so it belongs in the composition.
     assert set(contract["provisioner"]["actions"]) == {
         "provision",
         "health",
         "rotate-credential",
         "quiesce",
+        "renew-authorization",
         "resume",
         "stop",
         "export",


### PR DESCRIPTION
A hosted cell's authorization bundle carries a one-hour attestation TTL and
nothing renewed it. An hour after provisioning a cell kept serving reads while
refusing every mutation with `ATTACHMENT_DRAINING`, and could not recover:
minting is fenced off once a cell has served, and the drain that would renew it
needs a runtime attestation an expired cell can no longer sign.

This is the runtime half. The control plane half is substrate-systems/substrate#162, and neither
does anything useful alone — these bytes make renewal possible, that PR makes it
happen.

## What changed

- `republish_projected_custody` publishes a new generation into a live custody
  directory, so a renewed bundle reaches the running pod through the projected
  Secret instead of requiring a restart.
- A native sidecar (`restartPolicy: Always`) runs the watch. The admission policy
  pins the exact pod shape, so it also gains the second init container's full
  assertion set, and the cell quota rises by the sidecar's exact contribution.
- `renew-authorization`, v2-only: `provisioner-wire-v1.json` is the frozen
  rollback corpus whose digest is pinned in three places, and never gains an
  action.

## Defects found in review, and fixed

Independent review returned REQUEST_CHANGES with four confirmed high or critical
findings, then APPROVE after correction.

**The admission policy was unsatisfiable.** The sidecar needs
`size(object.spec.initContainers) == 2`; the new assertion landed beside the
existing `== 1` in the same conjunction under `failurePolicy: Fail`. Every tenant
pod would have been denied. Extending a count pin is a replace, never an add —
each new conjunct passes on its own, which is why no per-field test sees it.

**The ingress had no route for the action**, so substrate's call would have 404'd
while the sweep reported success every minute until cells lapsed.

**Renewal could resume a cell and resurrect an expired one.** It names
`target_state="SERVING"`, and against a drained cell that took the resume branch
AND rode the expiry exemption beside it. A renewal now refuses when its target
differs from the source state. The exemption is untouched: a genuine resume of a
drained cell past its expiry still works, and a test pins that.

**The watch was edge-triggered on the source generation**, so a restarted sidecar
never noticed a stale destination and a publish interrupted between file
replacements left a permanently mixed generation. It now compares published bytes
against projected bytes; both repair within one interval. Not fixed by swapping a
symlink as first proposed — `retain_regular_file` opens one regular child without
following aliases, so the reader refuses symlinks by design (verified: `ELOOP`
for a symlinked file, `ENOTDIR` for a symlinked directory).

## Verification

- Provisioner suite: 562 passed, 17 skipped.
- Product hosted suites: 221 passed. Five `active_secret_registry*` failures are
  pre-existing and reproduce identically on `b736df9d` in a separate worktree.
- Reviewer re-evaluated the corrected CEL against the rendered pod with 14
  negative controls (extra container, swapped order, shell command, root,
  privilege escalation, retained capabilities, foreign image, demoted sidecar,
  second serving container, …) — all denied, real pod admitted.
- Mutation-proven: dropping each guard, the orphan sweep, and the level-trigger
  each fails a test. Two guards that survived mutation were deleted rather than
  kept — both were unreachable, and an untestable guard reads as protection while
  providing none.

## Known and deliberate

`_published_custody_is_current` treats an unreadable source as current, and the
sidecar has no probe, so a persistently broken projection is silent until the
window lapses. Observability for that is a follow-up, not part of this fix.
