### PR TITLE
fix(hosted): let reset reclaim the canary and the stage it already could

### DIFF
--- a/docs/runbooks/hosted/alpha-reviewer-run.md
+++ b/docs/runbooks/hosted/alpha-reviewer-run.md
@@ -122,8 +122,14 @@ tool discovery and authorization too. A refusal leaves reads working.
 
 ## Cost of a failed attempt
 
-`reset` reclaims the tenant. The invite, the alias, the staged release and an
-operator OAuth client slot are spent per attempt and never returned; client
-slots are bounded at 96. Nothing in this runbook is irreversible — the
-irreversible step was `run` — so a bad step inside the cell costs nothing.
-Stop and diagnose rather than re-running the bootstrap.
+Run `reset` against the failed attempt's `--state-dir`. It reclaims the tenant,
+revokes the internal canary credential and fails the leftover staged release.
+The canary is the one that matters most: it carries a 24-hour life and blocks
+every retry until it is revoked or expires, so skipping `reset` costs a day
+rather than a slot.
+
+The invite, the email alias and an operator OAuth client slot are spent per
+attempt and never returned; client slots are bounded at 96. Nothing in this
+runbook is irreversible — the irreversible step was `run` — so a bad step
+inside the cell costs nothing. Stop and diagnose rather than re-running the
+bootstrap.

--- a/scripts/reviewer_bootstrap.py
+++ b/scripts/reviewer_bootstrap.py
@@ -1166,9 +1166,7 @@ def reset(
     authority rather than from an argument is what makes that structural: there
     is no way to point this at something that is not a reviewer bootstrap.
     """
-    status, clients = cp.call(
-        "GET", "/api/exomem/admin/oauth-clients", label="reset-authorities"
-    )
+    status, clients = cp.call("GET", "/api/exomem/admin/oauth-clients", label="reset-authorities")
     if status != 200:
         raise SystemExit(f"could not read bootstrap authorities: {status} {clients}")
     authorities = clients.get("bootstrapAuthorities", [])

--- a/scripts/reviewer_bootstrap.py
+++ b/scripts/reviewer_bootstrap.py
@@ -463,6 +463,120 @@ class ControlPlane:
         return status, parsed
 
 
+def _recorded(cp: ControlPlane, label: str) -> dict | None:
+    """Read back an exchange this state dir already recorded, if it is there."""
+    path = cp.state_dir / f"{label}.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return None
+
+
+def reclaim_internal_canaries(cp: ControlPlane) -> int:
+    """Revoke every internal canary this attempt issued.
+
+    A live internal canary blocks the *next* bootstrap outright: the authority
+    insert carries `NOT EXISTS (... credential_kind = 'internal_canary' AND
+    revoked_at IS NULL AND expires_at > now())`. The script issues them with a
+    24-hour expiry, so an attempt that got as far as the canary and then failed
+    locks the operator out until tomorrow -- which is what turns "try again" into
+    "try again after the weekend".
+
+    Nothing reclaimed them, though `DELETE /admin/reviewer-access` has always
+    existed. It cannot be called blind: both GET and DELETE demand the full seven
+    field selector, and no route answers "is any canary live?". The selector is
+    recoverable from exactly one place, which is the request this attempt already
+    wrote to its own state dir.
+    """
+    revoked = 0
+    for request_path in sorted(cp.state_dir.glob("run-canary-*.request.json")):
+        label = request_path.name[: -len(".request.json")]
+        try:
+            issued = json.loads(request_path.read_text())
+        except json.JSONDecodeError:
+            print(f"  WARN  {request_path.name} is not readable JSON; skipping")
+            continue
+        selector = {
+            key: issued.get(key)
+            for key in (
+                "platform",
+                "tenantId",
+                "candidateId",
+                "assignmentId",
+                "assignmentGeneration",
+                "stagedClientReleaseId",
+                "oauthClientId",
+            )
+        }
+        if any(value is None for value in selector.values()):
+            print(f"  WARN  {request_path.name} names no complete canary selector; skipping")
+            continue
+        status, result = cp.call(
+            "DELETE",
+            "/api/exomem/admin/reviewer-access",
+            label=f"reset-revoke-{label}",
+            body={"credentialKind": "internal_canary", **selector},
+        )
+        if status != 200:
+            print(f"  WARN  canary revoke refused for {selector['platform']}: {status} {result}")
+            continue
+        # `revoked: false` means it was already gone -- expired, or revoked by an
+        # earlier reset. That is the desired end state either way.
+        revoked += 1 if result.get("revoked") else 0
+        print(
+            f"  canary {selector['platform']}: "
+            f"{'revoked' if result.get('revoked') else 'already clear'}"
+        )
+    return revoked
+
+
+def reclaim_staged_releases(cp: ControlPlane) -> int:
+    """Fail every staged client release this attempt created.
+
+    A leftover `staged` release collides with the next attempt's `create-stage`
+    on a unique index and answers a bare 500, inside the window. `fail-stage`
+    has always existed; the script only ever printed a hint telling the operator
+    to run it by hand, which is a step nobody performs while reading a stack
+    trace. The `expectedVersion` it needs is in the create response this state
+    dir already holds.
+    """
+    failed = 0
+    labels = ["prepare-stage"] + sorted(
+        path.name[: -len(".response.json")]
+        for path in cp.state_dir.glob("run-sibling-stage-*.response.json")
+    )
+    for label in labels:
+        recorded = _recorded(cp, f"{label}.response")
+        stage = (recorded or {}).get("stage")
+        if not isinstance(stage, dict):
+            continue
+        stage_id, version = stage.get("id"), stage.get("version")
+        if not isinstance(stage_id, str) or not isinstance(version, int):
+            print(f"  WARN  {label} recorded no stage id and version; skipping")
+            continue
+        status, result = cp.call(
+            "POST",
+            "/api/exomem/admin/contracts",
+            label=f"reset-fail-{label}",
+            body={
+                "action": "fail-stage",
+                "stagedClientReleaseId": stage_id,
+                "expectedVersion": version,
+            },
+        )
+        if status != 200:
+            print(f"  WARN  fail-stage refused for {label}: {status} {result}")
+            continue
+        # It matches only a `staged` row at that exact version. A stage already
+        # evidenced, failed, or version-advanced answers false, and none of those
+        # blocks the next attempt.
+        failed += 1 if result.get("failed") else 0
+        print(f"  stage {label}: {'failed' if result.get('failed') else 'already clear'}")
+    return failed
+
+
 def reusable_client_record(cp: ControlPlane, client_id: str) -> str:
     if not client_id.startswith("exomem-reviewer-bootstrap-") or len(client_id) > 256:
         raise SystemExit("--existing-client-id is not a reviewer bootstrap client ID")
@@ -604,14 +718,25 @@ def preflight(
     )
     ok &= good
 
+    # Three preconditions of `create_reviewer_bootstrap` are invisible from here.
+    # Two are not reported by any admin route at all; the third has a route that
+    # demands the full seven-field selector of the credential being asked about,
+    # so there is no way to ask "is any canary live?" without already knowing the
+    # answer. Naming them is the most this can honestly do -- and `reset` now
+    # clears the two it can reach, so the usual fix is to run it.
     print(
-        "\n  NOTE  A reviewer-purpose tenant with a bound or CELL_READY cell also blocks\n"
-        "        the bootstrap, and is not visible through any admin endpoint. If the\n"
-        "        authority call returns 400 with everything above green, that is almost\n"
-        "        certainly the cause. `reset` releases it with this same admin token;\n"
-        "        it needs the tenant's fence generation, which no admin route reports.\n"
-        "        Note a failed attempt still costs the invite, the alias, the stage and\n"
-        "        the client -- reset reclaims the tenant, not those."
+        "\n  NOTE  Three blockers are invisible to this preflight:\n"
+        "          - a reviewer-purpose tenant with a bound or CELL_READY cell\n"
+        "          - an active reviewer-purpose rollout assignment\n"
+        "          - an unrevoked internal canary credential, which the last attempt\n"
+        "            issued with a 24-hour life and which locks out every retry until\n"
+        "            it expires\n"
+        "        If the authority call returns 400 with everything above green, it is\n"
+        "        one of those. `reset` on the previous attempt's --state-dir clears\n"
+        "        the canary and the leftover stage, and releases the tenant; the\n"
+        "        tenant needs its fence generation, which no admin route reports.\n"
+        "        Still permanently spent per attempt: the invite, the email alias\n"
+        "        and the operator client slot. Nothing reclaims those."
     )
     return bool(ok)
 
@@ -1058,6 +1183,14 @@ def reset(
             "(`revoke_reviewer_bootstrap`) before resetting."
         )
 
+    # Reclaim what this attempt spent that substrate can actually take back, before
+    # deciding whether there is a tenant to release. These two are independent of
+    # the tenant and of each other: an attempt that died before redeem still leaves
+    # a stage, and one that died after the canary leaves a 24-hour lockout. Both
+    # ran only by hand until now, which is to say never.
+    reclaimed_canaries = reclaim_internal_canaries(cp)
+    reclaimed_stages = reclaim_staged_releases(cp)
+
     candidates = [
         a
         for a in authorities
@@ -1066,11 +1199,19 @@ def reset(
         and (authority_id is None or a.get("id") == authority_id)
     ]
     if not candidates:
-        raise SystemExit(
-            "no consumed reviewer-bootstrap authority with a recorded outcome operation; "
-            "there is nothing this can release. An attempt that failed at or before "
-            "redeem never created a tenant."
+        # Not a failure. An attempt that died before redeem never created a tenant,
+        # and the canary and stage reclaim above is the whole of what it left behind.
+        print(
+            "\n  No consumed authority with a recorded outcome operation, so no tenant "
+            "to release.\n  An attempt that failed at or before redeem never created "
+            "one."
         )
+        print(
+            f"  Reclaimed: {reclaimed_canaries} canary credential(s), "
+            f"{reclaimed_stages} staged release(s)."
+        )
+        print("  Re-run `preflight` before preparing again.")
+        return
     if len(candidates) > 1:
         raise SystemExit(
             f"{len(candidates)} consumed authorities are present; name one with "

--- a/tests/test_reviewer_bootstrap_cli.py
+++ b/tests/test_reviewer_bootstrap_cli.py
@@ -380,9 +380,7 @@ def test_load_locks_reads_the_candidates_profile_not_the_generated_root(
 
     def _write(root: pathlib.Path, declared: str, artifact: str) -> None:
         package = {**OPENAI_PACKAGE_LOCK, "profile": declared, "artifact_sha256": artifact}
-        (root / "claude.lock.json").write_text(
-            json.dumps({**package, "platform": "claude"})
-        )
+        (root / "claude.lock.json").write_text(json.dumps({**package, "platform": "claude"}))
         (root / "claude.zip.lock.json").write_text(
             json.dumps({"platform": "claude", "archive_sha256": "0d" * 32})
         )
@@ -574,9 +572,7 @@ def test_prepare_sizes_the_staged_release_from_stage_minutes(monkeypatch, tmp_pa
     cp = _prepare_cp(tmp_path)
 
     before = module.utc_now()
-    context = module.prepare(
-        cp, "cand-1", "reviewer@example.invalid", _locks(), None, 150
-    )
+    context = module.prepare(cp, "cand-1", "reviewer@example.invalid", _locks(), None, 150)
     after = module.utc_now()
 
     stage_call = next(call for call in cp.calls if call["label"] == "prepare-stage")
@@ -861,9 +857,7 @@ def _run_responses(*, owner_status: tuple[int, dict] | None = None):
     }
 
 
-def test_run_readiness_failure_makes_zero_reviewer_credential_calls(
-    monkeypatch, tmp_path
-) -> None:
+def test_run_readiness_failure_makes_zero_reviewer_credential_calls(monkeypatch, tmp_path) -> None:
     module = _load_module()
     monkeypatch.setattr(
         module, "chatgpt_cimd_identity", lambda *_: ("https://c/x.json", ["https://c/cb"])
@@ -1428,7 +1422,9 @@ def test_reset_fails_the_leftover_stages_at_their_recorded_version(tmp_path) -> 
     exact `expectedVersion`, which only the create response carries.
     """
     module = _load_module()
-    _record(tmp_path, "prepare-stage.response", {"status": 200, "stage": {"id": "s1", "version": 3}})
+    _record(
+        tmp_path, "prepare-stage.response", {"status": 200, "stage": {"id": "s1", "version": 3}}
+    )
     _record(
         tmp_path,
         "run-sibling-stage-claude.response",
@@ -1452,7 +1448,9 @@ def test_reset_reclaims_and_returns_when_no_tenant_was_ever_created(tmp_path, ca
     `reset` in exactly the case where the stage most needs clearing.
     """
     module = _load_module()
-    _record(tmp_path, "prepare-stage.response", {"status": 200, "stage": {"id": "s1", "version": 1}})
+    _record(
+        tmp_path, "prepare-stage.response", {"status": 200, "stage": {"id": "s1", "version": 1}}
+    )
     cp = _StateDirControlPlane(tmp_path, _reset_responses())
 
     module.reset(cp, expected_fence=1)

--- a/tests/test_reviewer_bootstrap_cli.py
+++ b/tests/test_reviewer_bootstrap_cli.py
@@ -1169,13 +1169,23 @@ def test_reset_releases_a_stranded_reviewer_tenant(tmp_path, capsys) -> None:
     assert "delete-op-1" in printed
 
 
-def test_reset_refuses_an_authority_that_bound_no_tenant(tmp_path) -> None:
+def test_reset_never_reaches_the_cleanup_preflight_without_a_consumed_authority(
+    tmp_path,
+) -> None:
     """Nothing but a consumed bootstrap authority can name a target.
 
     `reset` takes no tenant, cell or operation id from the operator. It reads the
     source operation off the authority record, so an authority that never
     consumed -- and therefore never created a reviewer tenant -- has nothing to
-    release and must stop before the preflight.
+    release and must stop before the preflight. That is the invariant; it is
+    unchanged.
+
+    What changed is the exit. This used to raise SystemExit, which is wrong now
+    that `reset` also reclaims the staged release and the internal canary: an
+    attempt that died before redeem is exactly the case where the leftover stage
+    most needs clearing, and a non-zero exit taught the operator to skip the
+    command that clears it. The stop is still absolute -- it simply reports
+    rather than fails.
     """
     module = _load_module()
     cp = _RecordingControlPlane(
@@ -1183,9 +1193,9 @@ def test_reset_refuses_an_authority_that_bound_no_tenant(tmp_path) -> None:
     )
     cp.state_dir = tmp_path
 
-    with pytest.raises(SystemExit, match="no consumed reviewer-bootstrap authority"):
-        module.reset(cp, expected_fence=7)
+    module.reset(cp, expected_fence=7)
 
+    # An empty state dir means nothing to reclaim, so this is still the only call.
     assert [call["label"] for call in cp.calls] == ["reset-authorities"]
 
 
@@ -1333,3 +1343,176 @@ def test_main_refuses_a_profile_consuming_command_without_a_profile(
 
     assert module.main() == 2
     assert "--profile is required" in capsys.readouterr().err
+
+
+class _StateDirControlPlane(_RecordingControlPlane):
+    """A recording control plane that also owns a state directory.
+
+    `reset` reclaims from what the attempt recorded on disk, so a double without
+    a state dir cannot exercise it at all.
+    """
+
+    def __init__(self, state_dir: pathlib.Path, responses: dict):
+        super().__init__(responses)
+        self.state_dir = state_dir
+
+
+def _record(state_dir: pathlib.Path, label: str, payload: dict) -> None:
+    (state_dir / f"{label}.json").write_text(json.dumps(payload))
+
+
+def _canary_request(platform: str) -> dict:
+    return {
+        "credentialKind": "internal_canary",
+        "platform": platform,
+        "tenantId": f"tenant-{platform}",
+        "candidateId": "candidate-1",
+        "assignmentId": "assignment-1",
+        "assignmentGeneration": 1,
+        "stagedClientReleaseId": f"stage-{platform}",
+        "oauthClientId": f"client-{platform}",
+        "expiresAt": "2026-09-07T07:00:00Z",
+        "fixtureVersion": "v2",
+    }
+
+
+def _reset_responses(**overrides) -> dict:
+    responses = {
+        "reset-authorities": (200, {"bootstrapAuthorities": []}),
+        "reset-revoke-run-canary-claude": (200, {"revoked": True}),
+        "reset-revoke-run-canary-openai": (200, {"revoked": True}),
+        "reset-fail-prepare-stage": (200, {"failed": True}),
+        "reset-fail-run-sibling-stage-claude": (200, {"failed": True}),
+    }
+    responses.update(overrides)
+    return responses
+
+
+def test_reset_revokes_every_canary_the_attempt_recorded(tmp_path) -> None:
+    """A live internal canary locks out the next bootstrap for 24 hours.
+
+    `DELETE /admin/reviewer-access` has always existed and was never called, so a
+    failed attempt cost a day rather than a retry. The selector cannot be
+    reconstructed from any admin route -- it is recoverable only from the request
+    this attempt wrote to its own state dir.
+    """
+    module = _load_module()
+    for platform in ("claude", "openai"):
+        _record(tmp_path, f"run-canary-{platform}.request", _canary_request(platform))
+    cp = _StateDirControlPlane(tmp_path, _reset_responses())
+
+    module.reset(cp, expected_fence=1)
+
+    revokes = [c for c in cp.calls if c["label"].startswith("reset-revoke-")]
+    assert len(revokes) == 2
+    for call, platform in zip(revokes, ("claude", "openai"), strict=True):
+        assert call["method"] == "DELETE"
+        assert call["path"] == "/api/exomem/admin/reviewer-access"
+        # The route refuses anything but the exact seven-field selector.
+        assert call["body"] == {
+            "credentialKind": "internal_canary",
+            "platform": platform,
+            "tenantId": f"tenant-{platform}",
+            "candidateId": "candidate-1",
+            "assignmentId": "assignment-1",
+            "assignmentGeneration": 1,
+            "stagedClientReleaseId": f"stage-{platform}",
+            "oauthClientId": f"client-{platform}",
+        }
+
+
+def test_reset_fails_the_leftover_stages_at_their_recorded_version(tmp_path) -> None:
+    """A leftover `staged` release collides with the next `create-stage`.
+
+    The collision answers a bare 500 inside the window. `fail-stage` needs an
+    exact `expectedVersion`, which only the create response carries.
+    """
+    module = _load_module()
+    _record(tmp_path, "prepare-stage.response", {"status": 200, "stage": {"id": "s1", "version": 3}})
+    _record(
+        tmp_path,
+        "run-sibling-stage-claude.response",
+        {"status": 200, "stage": {"id": "s2", "version": 1}},
+    )
+    cp = _StateDirControlPlane(tmp_path, _reset_responses())
+
+    module.reset(cp, expected_fence=1)
+
+    fails = [c for c in cp.calls if c["label"].startswith("reset-fail-")]
+    assert [c["body"] for c in fails] == [
+        {"action": "fail-stage", "stagedClientReleaseId": "s1", "expectedVersion": 3},
+        {"action": "fail-stage", "stagedClientReleaseId": "s2", "expectedVersion": 1},
+    ]
+
+
+def test_reset_reclaims_and_returns_when_no_tenant_was_ever_created(tmp_path, capsys) -> None:
+    """An attempt that died before redeem left a stage and no tenant.
+
+    That is not a failure, and exiting non-zero on it taught the operator to skip
+    `reset` in exactly the case where the stage most needs clearing.
+    """
+    module = _load_module()
+    _record(tmp_path, "prepare-stage.response", {"status": 200, "stage": {"id": "s1", "version": 1}})
+    cp = _StateDirControlPlane(tmp_path, _reset_responses())
+
+    module.reset(cp, expected_fence=1)
+
+    assert [c["label"] for c in cp.calls if c["label"].startswith("reset-fail-")] == [
+        "reset-fail-prepare-stage"
+    ]
+    out = capsys.readouterr().out
+    assert "no tenant" in out.lower()
+    assert "1 staged release(s)" in out
+
+
+def test_reset_skips_an_incomplete_canary_rather_than_sending_a_partial_selector(
+    tmp_path, capsys
+) -> None:
+    """A truncated record must not become a malformed revoke.
+
+    The route rejects an incomplete selector, but a partial DELETE would report a
+    refusal that reads like the credential is gone.
+    """
+    module = _load_module()
+    incomplete = _canary_request("claude")
+    del incomplete["oauthClientId"]
+    _record(tmp_path, "run-canary-claude.request", incomplete)
+    cp = _StateDirControlPlane(tmp_path, _reset_responses())
+
+    module.reset(cp, expected_fence=1)
+
+    assert [c for c in cp.calls if c["label"].startswith("reset-revoke-")] == []
+    assert "names no complete canary selector" in capsys.readouterr().out
+
+
+def test_reset_counts_an_already_expired_canary_as_clear_not_as_reclaimed(tmp_path, capsys) -> None:
+    """`revoked: false` means it was already gone, which is the desired end state."""
+    module = _load_module()
+    _record(tmp_path, "run-canary-claude.request", _canary_request("claude"))
+    cp = _StateDirControlPlane(
+        tmp_path,
+        _reset_responses(**{"reset-revoke-run-canary-claude": (200, {"revoked": False})}),
+    )
+
+    module.reset(cp, expected_fence=1)
+
+    out = capsys.readouterr().out
+    assert "canary claude: already clear" in out
+    assert "0 canary credential(s)" in out
+
+
+def test_reset_refuses_to_reclaim_while_an_authority_is_still_active(tmp_path) -> None:
+    """Reclaim must not run on a live attempt: the canary is what it is using."""
+    module = _load_module()
+    _record(tmp_path, "run-canary-claude.request", _canary_request("claude"))
+    cp = _StateDirControlPlane(
+        tmp_path,
+        _reset_responses(
+            **{"reset-authorities": (200, {"bootstrapAuthorities": [{"state": "active"}]})}
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        module.reset(cp, expected_fence=1)
+
+    assert [c for c in cp.calls if c["label"].startswith("reset-revoke-")] == []


### PR DESCRIPTION
A failed bootstrap attempt left two things behind that substrate has always been
able to take back, and that nothing ever asked it to. This is why "try again"
became "try again tomorrow" across twenty-plus provisioning attempts.

## The expensive one

`create_reviewer_bootstrap` refuses while any unrevoked internal canary is live,
and the script issues them with a 24-hour expiry. So an attempt that reached the
canary and then failed locked out every retry until the next day.

`DELETE /api/exomem/admin/reviewer-access` revokes it and was never called. It
cannot be called blind either: both GET and DELETE demand the full seven-field
selector and no route answers "is any canary live?", so the selector is
recoverable from exactly one place — the request the attempt wrote to its own
state dir. That is where `reset` now reads it.

## The cheap one with the ugly failure

A leftover `staged` client release collides with the next `create-stage` on a
unique index and answers a bare 500, inside the window. `fail-stage` needs an
exact `expectedVersion`, which the create response in the state dir carries. The
script previously printed a hint telling the operator to run it by hand, which is
a step nobody performs while reading a stack trace.

## Ordering

Reclaim runs after the active-authority refusal, so it never touches a live
attempt's own credential, and before the tenant lookup, so an attempt that died
before redeem still gets its stage cleared.

That last case no longer exits non-zero. It is not a failure — an attempt that
died before redeem never created a tenant — and failing there taught the operator
to skip the one command that clears the stage. The stop before the cleanup
preflight is unchanged and still absolute; its test now asserts that invariant
rather than the exit code.

## What preflight can and cannot do

It cannot detect any of this. Three preconditions `create_reviewer_bootstrap`
enforces are invisible to it: two are reported by no admin route at all, and the
canary's route demands the selector of the credential being asked about, so you
would have to know the answer to ask the question. Preflight now names all three
instead of one, and says plainly what stays permanently spent per attempt: the
invite, the email alias, the operator client slot.

Making preflight actually detect a live canary needs a small substrate addition —
a selector-free GET, or a count on `/admin/contracts`. Worth doing, but it only
matters once you have lost the previous attempt's state dir, which `reset` now
makes the uncommon case.

## Verification

- `tests/test_reviewer_bootstrap_cli.py`: 55 passed.
- With the docs-governance suites: 70 passed.
- Mutation-proven: dropping either reclaim, dropping the incomplete-selector
  guard, or moving reclaim ahead of the active-authority check each fails a test.
- ruff check and format clean.

## Review status

This branch has NOT had an independent review pass, unlike the two renewal PRs it
ships alongside. It is the smallest of the three and touches only the bootstrap
harness, but it is self-reviewed, and that is worth knowing before merge.