### PR TITLE
fix(scripts): keep the promotion evidence DSN out of argv and error output

### DIFF
--- a/scripts/promotion_evidence.py
+++ b/scripts/promotion_evidence.py
@@ -65,9 +65,11 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
@@ -151,15 +153,63 @@ def canonical(value: object) -> str:
     raise TypeError(f"cannot canonicalise {type(value)!r}")
 
 
+#: Matches any connection URI so it can be stripped from output. psql echoes the
+#: whole DSN -- password included -- in connection errors such as `invalid
+#: connection option`, and that output used to be raised verbatim.
+_DSN_RE = re.compile(r"postgres(?:ql)?(?:\+\w+)?://\S*")
+
+
+def redact_dsn(text: str) -> str:
+    """Strip any connection URI from text bound for a log, error or transcript."""
+    return _DSN_RE.sub("postgresql://<redacted>", text)
+
+
+def libpq_url(url: str) -> str:
+    """Normalise an application DSN to something libpq accepts.
+
+    The provisioner stores its DSN for SQLAlchemy, so it arrives as
+    `postgresql+asyncpg://...?ssl=require`. libpq understands neither the
+    dialect suffix nor asyncpg's `ssl` parameter, and psql rejects the whole
+    string with an error that quotes it back in full.
+    """
+    url = re.sub(r"^postgres(ql)?\+\w+://", "postgresql://", url)
+    return re.sub(r"([?&])ssl=", r"\1sslmode=", url)
+
+
+def libpq_environment(url: str) -> dict[str, str]:
+    """Split a DSN into libpq's own variables.
+
+    The password never becomes a command-line argument: argv is world-readable
+    through `ps` for the life of the call, whereas another user's environment is
+    not. Unrecognised query parameters are carried through unchanged rather than
+    dropped, so a DSN that needs `channel_binding` or `options` still works.
+    """
+    parts = urllib.parse.urlsplit(libpq_url(url))
+    environment = {**os.environ}
+    for name, value in (
+        ("PGHOST", parts.hostname),
+        ("PGPORT", str(parts.port) if parts.port else None),
+        ("PGUSER", urllib.parse.unquote(parts.username) if parts.username else None),
+        ("PGPASSWORD", urllib.parse.unquote(parts.password) if parts.password else None),
+        ("PGDATABASE", parts.path.lstrip("/") or None),
+    ):
+        if value:
+            environment[name] = value
+    for key, value in urllib.parse.parse_qsl(parts.query):
+        environment[f"PG{key.upper()}"] = value
+    return environment
+
+
 def query(url: str, sql: str) -> list[str]:
     result = subprocess.run(
-        ["psql", url, "-X", "-A", "-t", "-F", "\x1f", "-c", sql],
+        ["psql", "-X", "-A", "-t", "-F", "\x1f", "-c", sql],
         capture_output=True,
         text=True,
         timeout=90,
+        env=libpq_environment(url),
     )
     if result.returncode != 0:
-        raise SystemExit(f"query failed: {result.stderr.strip()[:400]}")
+        raise SystemExit(f"query failed: {redact_dsn(result.stderr.strip())[:400]}")
     return [line for line in result.stdout.strip().split("\n") if line]
 
 

--- a/tests/test_promotion_evidence_dsn_handling.py
+++ b/tests/test_promotion_evidence_dsn_handling.py
@@ -1,0 +1,121 @@
+"""The promotion evidence script must never let a DSN reach output or argv.
+
+`query()` shells out to psql, and psql quotes the whole connection string back —
+password included — in errors like `invalid connection option`. That stderr used
+to be raised verbatim, which put a live database password into whatever log,
+terminal or agent transcript the operator was running under. It happened.
+
+The DSN also arrives in a shape libpq cannot parse: the provisioner stores its
+URL for SQLAlchemy, so it reads `postgresql+asyncpg://...?ssl=require`. That
+mismatch is what produced the error that leaked the password in the first place,
+so the normalisation and the redaction are tested together.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/promotion_evidence.py"
+
+SQLALCHEMY_DSN = (
+    "postgresql+asyncpg://exomem_runtime:s3cr3t-p455w0rd"
+    "@ep-lively-queen.eu-central-1.aws.neon.tech/neondb?ssl=require"
+)
+PASSWORD = "s3cr3t-p455w0rd"
+
+
+@pytest.fixture(scope="module")
+def evidence():
+    spec = importlib.util.spec_from_file_location("promotion_evidence", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sqlalchemy_dialect_and_ssl_param_are_normalised_for_libpq(evidence):
+    normalised = evidence.libpq_url(SQLALCHEMY_DSN)
+    assert normalised.startswith("postgresql://")
+    assert "+asyncpg" not in normalised
+    assert "sslmode=require" in normalised
+    assert "?ssl=require" not in normalised
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        SQLALCHEMY_DSN,
+        "postgres://u:p@host/db",
+        "postgresql://u:p@host:5432/db?sslmode=require",
+    ],
+)
+def test_redaction_removes_every_connection_uri_shape(evidence, dsn):
+    leaked = f'psql: error: invalid connection option "{dsn}"'
+    redacted = evidence.redact_dsn(leaked)
+    assert dsn not in redacted
+    assert "<redacted>" in redacted
+
+
+def test_redaction_survives_a_dsn_embedded_in_a_longer_message(evidence):
+    redacted = evidence.redact_dsn(
+        f"connection to {SQLALCHEMY_DSN} failed after 3 attempts; giving up"
+    )
+    assert PASSWORD not in redacted
+    assert "giving up" in redacted
+
+
+def test_password_goes_to_the_environment_never_to_argv(evidence):
+    environment = evidence.libpq_environment(SQLALCHEMY_DSN)
+    assert environment["PGPASSWORD"] == PASSWORD
+    assert environment["PGUSER"] == "exomem_runtime"
+    assert environment["PGHOST"] == "ep-lively-queen.eu-central-1.aws.neon.tech"
+    assert environment["PGDATABASE"] == "neondb"
+    # asyncpg's `ssl` became libpq's `sslmode` before the split, not after.
+    assert environment["PGSSLMODE"] == "require"
+
+
+def test_query_invokes_psql_without_the_dsn_on_the_command_line(evidence, monkeypatch):
+    seen = {}
+
+    class Result:
+        returncode = 0
+        stdout = "row\n"
+        stderr = ""
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["env"] = kwargs["env"]
+        return Result()
+
+    monkeypatch.setattr(evidence.subprocess, "run", fake_run)
+    evidence.query(SQLALCHEMY_DSN, "select 1")
+
+    assert not any(PASSWORD in str(argument) for argument in seen["argv"])
+    assert not any("neon.tech" in str(argument) for argument in seen["argv"])
+    assert seen["env"]["PGPASSWORD"] == PASSWORD
+
+
+def test_query_failure_does_not_raise_the_dsn(evidence, monkeypatch):
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = f'psql: error: invalid connection option "{SQLALCHEMY_DSN}"'
+
+    monkeypatch.setattr(evidence.subprocess, "run", lambda *a, **k: Result())
+
+    with pytest.raises(SystemExit) as raised:
+        evidence.query(SQLALCHEMY_DSN, "select 1")
+
+    assert PASSWORD not in str(raised.value)
+    assert "query failed" in str(raised.value)
+
+
+def test_unrecognised_query_parameters_survive_rather_than_being_dropped(evidence):
+    environment = evidence.libpq_environment(
+        "postgresql://u:p@host/db?sslmode=require&channel_binding=require"
+    )
+    assert environment["PGCHANNEL_BINDING"] == "require"


### PR DESCRIPTION
## What

`scripts/promotion_evidence.py` shells out to `psql`. Two ways a live database password escaped, both now closed.

**Error output.** psql quotes the whole connection string back — password included — in errors like `invalid connection option`. `query()` raised that stderr verbatim, so the password reached whatever log, terminal or transcript the operator was running under. `redact_dsn()` now strips every connection-URI shape before raising.

**Process table.** The DSN was passed as `argv[1]`, world-readable through `ps` for the life of the call. It now goes through libpq's own `PG*` variables. Unrecognised query parameters are carried through rather than dropped, so a DSN needing `channel_binding` or `options` still connects.

## Why it fired

The provisioner stores its DSN for SQLAlchemy, so `PROVISIONER_DATABASE_URL` arrives as `postgresql+asyncpg://...?ssl=require`. libpq knows neither the dialect suffix nor asyncpg's `ssl` parameter, and rejects the string by quoting it back in full. `libpq_url()` normalises both, so the supported input no longer produces the error at all.

This is not hypothetical — it happened during the 0.73.1 promotion window today, against the real provisioner database.

## Verification

New `tests/test_promotion_evidence_dsn_handling.py`, 9 cases: dialect and `ssl` normalisation, redaction across three URI shapes and inside a longer message, the password reaching `PGPASSWORD` and not argv, a forced `query()` failure not raising the DSN, and pass-through of unrecognised parameters.

- Against `origin/main`: all 9 fail (the functions do not exist).
- Against this branch: `9 passed in 0.13s`.
- With neighbours: `tests/test_promotion_evidence_dsn_handling.py tests/test_hosted_plugin_promotion.py tests/test_public_artifact_privacy.py` → `107 passed in 36.27s`.

Also exercised end to end: `promotion_evidence.py observe --rehearse` against the live substrate and provisioner databases, passing the raw unmodified k8s DSN with no shell-side translation. Six counts all 1, field set matches the contract (41 fields).