### PR TITLE
feat(hosted): smoke a live cell from inside its pod, with no client involved

### DIFF
--- a/infra/scripts/smoke_hosted_cell.py
+++ b/infra/scripts/smoke_hosted_cell.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Smoke a live hosted cell from inside its pod, with no client involved.
+
+Verifying a hosted release used to mean driving real Claude and real ChatGPT
+through seven manual operations and reading the answers off screenshots. That
+ceremony exists for a reason -- `promotion_evidence.py` attests that a genuine
+client did those things, and signing it without performing it forges the gate.
+But it answers "did a client work", and most release questions are "does the
+cell work". Those are different jobs, and only the first one needs a human.
+
+On 2026-09-06 three questions -- is the write durable, is it indexed, is it
+findable -- cost an evening of screenshots and were then resolved in four
+read-only commands against the pod. This is those commands, with assertions.
+
+WHAT THIS DOES NOT DO, AND WHY
+------------------------------
+It does not write. Writing straight into the vault bypasses the service's own
+write path, so it would prove nothing about indexing; and driving the CLI
+in-pod takes locks the running service holds -- an out-of-process
+`exomem index --scope vault` against a live cell is a measured soft-deadlock,
+~2,100 receipts in 40 minutes. A write tier belongs on the MCP surface with a
+real token, not here. This tier is read-only and safe against production.
+
+    smoke_hosted_cell.py --namespace exo-abc123
+    smoke_hosted_cell.py --namespace exo-abc123 --expect-image sha256:fb6ebd66...
+    smoke_hosted_cell.py --namespace exo-abc123 --expect-note five-users --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+VAULT = "/var/lib/exomem/vault"
+STATE = "/var/lib/exomem/state"
+# The index stores moved out of the vault under `relocate-machine-local-state`;
+# a `.sqlite` found under the vault is a dual-state leftover, not the live one.
+VAULT_STATE_GLOB = f"{STATE}/vault-state/vault-*"
+
+
+@dataclass
+class Check:
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class Report:
+    checks: list[Check] = field(default_factory=list)
+
+    def add(self, name: str, ok: bool, detail: str) -> None:
+        self.checks.append(Check(name, ok, detail))
+
+    @property
+    def failed(self) -> list[Check]:
+        return [c for c in self.checks if not c.ok]
+
+    def render(self) -> str:
+        lines = [f"  {'ok  ' if c.ok else 'FAIL'}  {c.name}: {c.detail}" for c in self.checks]
+        return "\n".join(lines)
+
+
+def kubectl(namespace: str, *args: str, kubeconfig: str, binary: str) -> str:
+    command = [*shlex.split(binary), "-n", namespace, *args]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"KUBECONFIG": kubeconfig, "PATH": "/usr/local/bin:/usr/bin:/bin"},
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"kubectl failed: {' '.join(args)[:80]}: {result.stderr.strip()[:300]}")
+    return result.stdout
+
+
+def in_pod(namespace: str, pod: str, script: str, **kw) -> str:
+    return kubectl(namespace, "exec", pod, "-c", "exomem", "--", "sh", "-c", script, **kw)
+
+
+def evaluate_pod(status: dict, expect_image: str | None, report: Report) -> None:
+    """Container health, the renewal sidecar, and the running image."""
+    containers = status.get("status", {}).get("containerStatuses") or []
+    inits = status.get("status", {}).get("initContainerStatuses") or []
+
+    restarts = sum(int(c.get("restartCount", 0)) for c in containers + inits)
+    report.add("no restarts", restarts == 0, f"{restarts} across {len(containers + inits)} containers")
+
+    ready = all(c.get("ready") for c in containers) and bool(containers)
+    report.add("containers ready", ready, f"{sum(1 for c in containers if c.get('ready'))}/{len(containers)}")
+
+    # Two init containers is the admission rule the cell chart pins: custody
+    # seeds the projected authorization, refresh is the native sidecar that
+    # renews it before the one-hour attestation lapses.
+    names = {c.get("name") for c in inits}
+    report.add(
+        "renewal sidecar present",
+        "authorization-session-refresh" in names,
+        ", ".join(sorted(names)) or "none",
+    )
+    refresh = next((c for c in inits if c.get("name") == "authorization-session-refresh"), None)
+    report.add(
+        "renewal sidecar running",
+        bool(refresh and refresh.get("started")),
+        f"started={refresh.get('started') if refresh else 'absent'}",
+    )
+
+    if expect_image:
+        # `status.containerStatuses[].image` is the local CONFIG digest and never
+        # matches the manifest digest you deployed -- checking it reports a
+        # mismatch against a correctly-rolled pod. `imageID` carries the manifest
+        # digest, and unlike `spec` it is what is actually running rather than
+        # what was asked for, so a cached or mutated image cannot pass.
+        running = {c.get("imageID", "") for c in containers + inits}
+        matched = any(expect_image in image for image in running)
+        report.add(
+            "image matches",
+            matched,
+            expect_image if matched else ", ".join(sorted(i for i in running if i))[:140],
+        )
+
+
+def evaluate_index(counts: dict, pages: list[str], expect_note: str | None, report: Report) -> None:
+    """The write -> index -> recall chain, which is the thing worth smoking."""
+    # An empty deferred queue means indexing finished. A backlog here with the
+    # graph in recovery is the accounting funnel, not a fresh regression.
+    pending = sum(counts.get(t, 0) for t in ("semantic_upserts", "full_upserts", "graph_upserts"))
+    report.add("index queue drained", pending == 0, f"{pending} pending upsert(s)")
+
+    report.add("lexical index populated", counts.get("pages", 0) > 0, f"{counts.get('pages', 0)} page(s)")
+    report.add(
+        "embeddings populated",
+        counts.get("chunks", 0) > 0,
+        f"{counts.get('chunks', 0)} chunk(s)",
+    )
+
+    if expect_note:
+        hit = [p for p in pages if expect_note in p]
+        report.add(
+            "expected note indexed",
+            bool(hit),
+            hit[0] if hit else f"{expect_note!r} not among {len(pages)} indexed page(s)",
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--namespace", required=True, help="cell namespace, e.g. exo-fd31c845...")
+    parser.add_argument("--kubeconfig", default="/etc/rancher/k3s/k3s.yaml")
+    parser.add_argument(
+        "--kubectl",
+        default="/usr/local/bin/k3s kubectl",
+        help="kubectl invocation; k3s ships it as a subcommand and installs no `kubectl` binary",
+    )
+    parser.add_argument("--expect-image", help="substring of the runtime image digest that must be running")
+    parser.add_argument("--expect-note", help="substring of a vault path that must be present AND indexed")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable results")
+    args = parser.parse_args()
+
+    kw = {"kubeconfig": args.kubeconfig, "binary": args.kubectl}
+    report = Report()
+
+    pods = json.loads(kubectl(args.namespace, "get", "pods", "-o", "json", **kw))
+    running = [p for p in pods.get("items", []) if p.get("status", {}).get("phase") == "Running"]
+    if not running:
+        print(f"no Running pod in {args.namespace}", file=sys.stderr)
+        return 2
+    pod = running[0]["metadata"]["name"]
+    evaluate_pod(running[0], args.expect_image, report)
+
+    notes = [
+        line
+        for line in in_pod(
+            args.namespace, pod, f"find {VAULT!r} -name '*.md' -not -path '*/.exomem/*'", **kw
+        ).splitlines()
+        if line.strip()
+    ]
+    report.add("vault has notes", bool(notes), f"{len(notes)} markdown file(s)")
+
+    if args.expect_note:
+        on_disk = [n for n in notes if args.expect_note in n]
+        report.add(
+            "expected note on disk",
+            bool(on_disk),
+            on_disk[0].replace(VAULT + "/", "") if on_disk else f"{args.expect_note!r} not found",
+        )
+
+    probe = f"""
+import glob, json, sqlite3
+root = sorted(glob.glob({VAULT_STATE_GLOB!r}))
+if not root:
+    print(json.dumps({{"error": "no vault-state directory"}}))
+    raise SystemExit(0)
+root = root[-1]
+counts, pages = {{}}, []
+for name, tables in ((".lexical.sqlite", ("pages",)),
+                     (".embeddings.sqlite", ("chunks",)),
+                     (".deferred-index.sqlite", ("semantic_upserts", "full_upserts", "graph_upserts"))):
+    try:
+        con = sqlite3.connect("file:%s/%s?mode=ro" % (root, name), uri=True)
+        for table in tables:
+            counts[table] = con.execute("select count(*) from " + table).fetchone()[0]
+        if name == ".lexical.sqlite":
+            pages = [r[0] for r in con.execute("select path from pages")]
+    except Exception as exc:
+        counts[name] = "ERR: %s" % exc
+print(json.dumps({{"counts": counts, "pages": pages}}))
+"""
+    raw = in_pod(args.namespace, pod, f"python3 -c {shlex.quote(probe)}", **kw)
+    parsed = json.loads(raw.strip().splitlines()[-1])
+    if "error" in parsed:
+        report.add("index stores found", False, parsed["error"])
+    else:
+        report.add("index stores found", True, f"{len(parsed['pages'])} indexed page(s)")
+        evaluate_index(
+            {k: v for k, v in parsed["counts"].items() if isinstance(v, int)},
+            parsed["pages"],
+            args.expect_note,
+            report,
+        )
+
+    if args.json:
+        print(json.dumps({"namespace": args.namespace, "pod": pod,
+                          "checks": [vars(c) for c in report.checks]}, indent=2))
+    else:
+        print(f"smoke {args.namespace} ({pod}):")
+        print(report.render())
+
+    if report.failed:
+        print(f"\n{len(report.failed)} check(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_hosted_cell.py
+++ b/tests/test_smoke_hosted_cell.py
@@ -1,0 +1,159 @@
+"""The smoke harness must fail for the right reasons, and pass for real ones.
+
+The assertion logic is kept free of kubectl so it can be tested against fixture
+pod status and index counts. Two traps are pinned here because each produced a
+wrong answer against a live cell:
+
+* `status.containerStatuses[].image` is the local *config* digest and never
+  equals the manifest digest that was deployed. Checking it reports a mismatch
+  against a correctly-rolled pod. `imageID` carries the manifest digest.
+* A harness that only ever prints `ok` is worthless, so every check has a
+  negative case here as well as a positive one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "infra/scripts/smoke_hosted_cell.py"
+
+RUNTIME = "ghcr.io/artexis10/exomem@sha256:fb6ebd669aa60832ddb135948b58762975639bfc7a642274c722848ae576c430"
+CONFIG_DIGEST = "sha256:87df8a72aa810e440824efdb184dc7da3e254d8d527af65f418bba5a5a838a16"
+
+
+@pytest.fixture(scope="module")
+def smoke():
+    # Deliberately a path insert and a real import, not
+    # `spec_from_file_location`: a module loaded that way is absent from
+    # `sys.modules`, and @dataclass then fails resolving its own module with
+    # `AttributeError: 'NoneType' object has no attribute '__dict__'`. The same
+    # trap already cost time on `hosted_composition_lock.py`.
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        import smoke_hosted_cell
+
+        return smoke_hosted_cell
+    finally:
+        sys.path.pop(0)
+
+
+def healthy_pod():
+    return {
+        "status": {
+            "containerStatuses": [
+                {"name": "exomem", "ready": True, "restartCount": 0,
+                 "image": CONFIG_DIGEST, "imageID": RUNTIME}
+            ],
+            "initContainerStatuses": [
+                {"name": "authorization-session-custody", "ready": True, "started": False,
+                 "restartCount": 0, "image": CONFIG_DIGEST, "imageID": RUNTIME},
+                {"name": "authorization-session-refresh", "ready": True, "started": True,
+                 "restartCount": 0, "image": CONFIG_DIGEST, "imageID": RUNTIME},
+            ],
+        }
+    }
+
+
+def results(report):
+    return {c.name: c.ok for c in report.checks}
+
+
+def test_a_healthy_cell_passes_every_pod_check(smoke):
+    report = smoke.Report()
+    smoke.evaluate_pod(healthy_pod(), RUNTIME, report)
+    assert report.failed == [], report.render()
+
+
+def test_image_check_reads_imageID_not_the_config_digest(smoke):
+    """The trap: `image` holds a config digest that never matches the deployment."""
+    report = smoke.Report()
+    smoke.evaluate_pod(healthy_pod(), RUNTIME, report)
+    assert results(report)["image matches"] is True
+
+    # A pod genuinely running something else must fail, so the check is not
+    # passing merely because it looks at a field that happens to be present.
+    stale = healthy_pod()
+    for container in stale["status"]["containerStatuses"] + stale["status"]["initContainerStatuses"]:
+        container["imageID"] = "ghcr.io/artexis10/exomem@sha256:aa61a1cd1f70308c1b702384ebc98e1bb5e3e70b"
+    report = smoke.Report()
+    smoke.evaluate_pod(stale, RUNTIME, report)
+    assert results(report)["image matches"] is False
+
+
+def test_a_restarted_pod_fails(smoke):
+    pod = healthy_pod()
+    pod["status"]["containerStatuses"][0]["restartCount"] = 2
+    report = smoke.Report()
+    smoke.evaluate_pod(pod, None, report)
+    assert results(report)["no restarts"] is False
+
+
+def test_a_missing_renewal_sidecar_fails(smoke):
+    """A cell without the 0.73.1 sidecar goes read-only an hour after provisioning."""
+    pod = healthy_pod()
+    pod["status"]["initContainerStatuses"] = [
+        c for c in pod["status"]["initContainerStatuses"] if "refresh" not in c["name"]
+    ]
+    report = smoke.Report()
+    smoke.evaluate_pod(pod, None, report)
+    assert results(report)["renewal sidecar present"] is False
+
+
+def test_a_stopped_renewal_sidecar_fails(smoke):
+    pod = healthy_pod()
+    for container in pod["status"]["initContainerStatuses"]:
+        if "refresh" in container["name"]:
+            container["started"] = False
+    report = smoke.Report()
+    smoke.evaluate_pod(pod, None, report)
+    assert results(report)["renewal sidecar running"] is False
+
+
+def test_a_converged_index_passes_and_finds_the_expected_note(smoke):
+    report = smoke.Report()
+    smoke.evaluate_index(
+        {"pages": 9, "chunks": 16, "semantic_upserts": 0, "full_upserts": 0, "graph_upserts": 0},
+        ["Knowledge Base/Notes/Insights/hosted-alpha-held-at-five-users-pending-clean-renewal-week.md"],
+        "five-users",
+        report,
+    )
+    assert report.failed == [], report.render()
+
+
+def test_a_backlogged_index_queue_fails(smoke):
+    report = smoke.Report()
+    smoke.evaluate_index(
+        {"pages": 9, "chunks": 16, "semantic_upserts": 3, "full_upserts": 7, "graph_upserts": 0},
+        [],
+        None,
+        report,
+    )
+    assert results(report)["index queue drained"] is False
+
+
+def test_a_note_on_disk_but_absent_from_the_index_fails(smoke):
+    """The failure mode worth catching: durable write, unfindable by recall."""
+    report = smoke.Report()
+    smoke.evaluate_index(
+        {"pages": 9, "chunks": 16, "semantic_upserts": 0, "full_upserts": 0, "graph_upserts": 0},
+        ["Knowledge Base/Notes/index.md"],
+        "five-users",
+        report,
+    )
+    assert results(report)["expected note indexed"] is False
+
+
+def test_an_empty_index_fails_even_with_a_drained_queue(smoke):
+    report = smoke.Report()
+    smoke.evaluate_index(
+        {"pages": 0, "chunks": 0, "semantic_upserts": 0, "full_upserts": 0, "graph_upserts": 0},
+        [],
+        None,
+        report,
+    )
+    assert results(report)["lexical index populated"] is False
+    assert results(report)["embeddings populated"] is False


### PR DESCRIPTION
## Why

Verifying a hosted release currently means driving real Claude and real ChatGPT through seven manual operations and reading the answers off screenshots.

That ceremony is correct for what it is. `promotion_evidence.py` attests that a genuine client completed install, authorization, discovery, recall, citation, durable capture and fresh-chat recall, and signing those without performing them would forge the gate rather than pass it. But it answers *"did a client work"*, and most release questions are *"does the cell work"*. Only the first needs a human, and only once per promotion.

On 2026-09-06, three questions — is the write durable, is it indexed, is it findable — cost an evening of screenshots and were then settled in four read-only commands against the pod. This is those commands, with assertions.

## What it checks

| check | catches |
|---|---|
| no restarts, containers ready | a crashlooping or degraded cell |
| renewal sidecar present + started | a cell that will go read-only an hour after provisioning |
| running image matches | a rollout that did not actually land |
| vault has notes | an empty or unmounted volume |
| index stores found, queue drained | indexing stalled or the accounting funnel |
| lexical + embeddings populated | a cell that accepts writes but indexes nothing |
| named note on disk **and** in the index | the real failure: durable write, unfindable by recall |

## Read-only by design

It does not write. Writing into the vault bypasses the service's own write path so it would prove nothing about indexing, and driving the CLI in-pod takes locks the running service holds — an out-of-process index against a live cell is a measured soft-deadlock (~2,100 receipts in 40 minutes). A write tier belongs on the MCP surface with a real token; this tier is safe against production.

## One trap pinned

The image check reads `imageID`, not `image`. `status.containerStatuses[].image` is the local **config** digest (`sha256:87df8a72…`) and never equals the deployed manifest digest (`sha256:fb6ebd66…`), so checking it reports a mismatch against a correctly-rolled pod — the first run of this script did exactly that. `imageID` carries the manifest digest and, unlike `spec`, reflects what is actually running rather than what was requested.

## Verification

Against the live 0.73.1 reviewer cell `exo-fd31c845…`:

```
ok    no restarts: 0 across 3 containers
ok    renewal sidecar running: started=True
ok    image matches: sha256:fb6ebd669aa60832ddb135948b58762975639bfc7a642274c722848ae576c430
ok    expected note on disk: Knowledge Base/Notes/Insights/hosted-alpha-held-at-five-users-...md
ok    index queue drained: 0 pending upsert(s)
ok    expected note indexed: Knowledge Base/Notes/Insights/hosted-alpha-held-at-five-users-...md
EXIT=0
```

12/12 pass. Negative control naming an absent note fails exactly the two note checks and exits 1, so it is not merely printing `ok`.

`tests/test_smoke_hosted_cell.py` — 9 cases over the kubectl-free assertion logic, each with a positive and a negative: `9 passed in 0.16s`. Includes a regression case pinning the `imageID` vs `image` trap.