### PR TITLE
docs(skill): tell the recall skill which lane actually answers a search

### DIFF
--- a/plugins/claude-code/skills/exomem-capture/SKILL.md
+++ b/plugins/claude-code/skills/exomem-capture/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-capture
 description: Preserve a durable conclusion or recurring entity from a conversation without dumping transcripts into compiled memory.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-continue/SKILL.md
+++ b/plugins/claude-code/skills/exomem-continue/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-continue
 description: Resume prior project or session context from Exomem when the user wants to continue, pick something back up, or remember what was happening on a topic.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-curate/SKILL.md
+++ b/plugins/claude-code/skills/exomem-curate/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-curate
 description: Improve Exomem note quality by adding links, clarifying compiled notes, and organizing safely without editing raw Sources or Evidence.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.2.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-defrag/SKILL.md
+++ b/plugins/claude-code/skills/exomem-defrag/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-defrag
 description: Reconcile duplicate, stale, or conflicting Exomem memory while preserving history through review, merge, or supersession.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-ingest/SKILL.md
+++ b/plugins/claude-code/skills/exomem-ingest/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-ingest
 description: Ingest an external article, PDF, pasted note, dataset, image, audio, or video into Exomem while preserving raw evidence before compiling conclusions.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-media/SKILL.md
+++ b/plugins/claude-code/skills/exomem-media/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-media
 description: Search, inspect, cite, and preserve Exomem media artifacts such as PDFs, images, audio, and video.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-reflect/SKILL.md
+++ b/plugins/claude-code/skills/exomem-reflect/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-reflect
 description: Distill a session or project episode into decisions, failures, patterns, open questions, and next actions.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-research/SKILL.md
+++ b/plugins/claude-code/skills/exomem-research/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-research
 description: "Run a focused research loop with Exomem: gather sources, preserve evidence, compile attributed findings, and connect prior notes."
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/plugins/claude-code/skills/exomem-review/SKILL.md
+++ b/plugins/claude-code/skills/exomem-review/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-review
 description: Use Exomem's Epistemic Inbox and audit queues to surface stale conclusions, contradictions, relation debt, and unprocessed sources safely.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.2.0"
 ---
 

--- a/plugins/claude-code/skills/exomem/SKILL.md
+++ b/plugins/claude-code/skills/exomem/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem
 description: Use Exomem for governed knowledge-base recall, capture, compilation, connections, review, and preservation. Engage for Exomem, KB, vault, Obsidian or notes, including save, log, compile, "interesting, save it", and "what did I conclude"; consult prior project/domain knowledge and capture durable outcomes according to the active engagement policy. Sources and Evidence stay immutable; content outside the managed Knowledge Base stays read-only.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.32.0"
 ---
 

--- a/plugins/claude-code/skills/exomem/references/recall.md
+++ b/plugins/claude-code/skills/exomem/references/recall.md
@@ -19,6 +19,23 @@ Modes:
 
 Empty queries degrade to filtered-most-recent regardless of mode.
 
+### What actually answers a search
+
+Vector and BM25 are the **primary** lanes: together they produce the result set,
+and semantic similarity is what reaches pages that share no literal term with the
+query. Prefer `hybrid` and write queries as questions, not keyword soup — the
+vector lane is the reason a vague recollection finds the right page.
+
+The typed graph is an **additive** lane layered on top. It expands neighbours of
+strong matches and reorders; it never decides whether a page can be found. When
+the graph sidecar is unavailable or rebuilding, that lane falls back to plain
+wikilink expansion and recall keeps working — results may be ordered slightly
+differently, nothing disappears. A page written moments ago, with no edges built
+yet, is returned normally by the primary lanes.
+
+So: a graph rebuild is not a recall outage, and never a reason to stop searching
+or to report absence.
+
 **Scope — the vault is bigger than the KB:**
 - `scope="kb"` (default) searches `Knowledge Base/` first and **auto-widens to
   the whole vault** when the KB doesn't fill `limit`. Content in sibling folders
@@ -28,6 +45,29 @@ Empty queries degrade to filtered-most-recent regardless of mode.
 - **Never report a search-miss as absence.** An empty result means *"not found in
   what I searched,"* not *"it doesn't exist."* If you're sure something exists,
   try `scope="vault"`, vary the query terms, or `read_memory` a path you suspect.
+
+### Two cases where a retry, not a conclusion, is the right move
+
+Recall answers from what is indexed, and in two bounded situations it says so
+rather than pretending. Both are explicit in the response — you never have to
+inspect index internals to notice them.
+
+- **`warming` names `embeddings`.** Right after a process start the embedding
+  model may still be loading, and semantic upserts for very recent writes queue
+  until it is up. Keyword and BM25 still answer, so a write is findable
+  immediately by its literal terms — but a *semantic* query may under-return for
+  that window. Retry once `warming` stops appearing (usually well under a
+  minute) before concluding anything is missing.
+- **`RETRIEVAL_INDEX_WARMING` on a relation-filtered recall.** `relations=` and
+  `relation_of=` are answered only from the typed graph sidecar, so they are the
+  one read that refuses rather than degrades while that sidecar rebuilds. The
+  error carries a retry hint. Retry it, or drop the relation filter and search
+  normally — do not read the refusal as "no such relation."
+
+Everything else degrades quietly and correctly. If a plain recall returns
+results, trust them; if it returns none and nothing is warming, the honest
+reading is that nothing matched the query you asked — so vary the query before
+you doubt the vault.
 
 ### Referents
 

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem
 description: Use Exomem for governed knowledge-base recall, capture, compilation, connections, review, and preservation. Engage for Exomem, KB, vault, Obsidian or notes, including save, log, compile, "interesting, save it", and "what did I conclude"; consult prior project/domain knowledge and capture durable outcomes according to the active engagement policy. Sources and Evidence stay immutable; content outside the managed Knowledge Base stays read-only.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.32.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/references/recall.md
+++ b/src/exomem/_scaffold/_Schema/references/recall.md
@@ -19,6 +19,23 @@ Modes:
 
 Empty queries degrade to filtered-most-recent regardless of mode.
 
+### What actually answers a search
+
+Vector and BM25 are the **primary** lanes: together they produce the result set,
+and semantic similarity is what reaches pages that share no literal term with the
+query. Prefer `hybrid` and write queries as questions, not keyword soup — the
+vector lane is the reason a vague recollection finds the right page.
+
+The typed graph is an **additive** lane layered on top. It expands neighbours of
+strong matches and reorders; it never decides whether a page can be found. When
+the graph sidecar is unavailable or rebuilding, that lane falls back to plain
+wikilink expansion and recall keeps working — results may be ordered slightly
+differently, nothing disappears. A page written moments ago, with no edges built
+yet, is returned normally by the primary lanes.
+
+So: a graph rebuild is not a recall outage, and never a reason to stop searching
+or to report absence.
+
 **Scope — the vault is bigger than the KB:**
 - `scope="kb"` (default) searches `Knowledge Base/` first and **auto-widens to
   the whole vault** when the KB doesn't fill `limit`. Content in sibling folders
@@ -28,6 +45,29 @@ Empty queries degrade to filtered-most-recent regardless of mode.
 - **Never report a search-miss as absence.** An empty result means *"not found in
   what I searched,"* not *"it doesn't exist."* If you're sure something exists,
   try `scope="vault"`, vary the query terms, or `read_memory` a path you suspect.
+
+### Two cases where a retry, not a conclusion, is the right move
+
+Recall answers from what is indexed, and in two bounded situations it says so
+rather than pretending. Both are explicit in the response — you never have to
+inspect index internals to notice them.
+
+- **`warming` names `embeddings`.** Right after a process start the embedding
+  model may still be loading, and semantic upserts for very recent writes queue
+  until it is up. Keyword and BM25 still answer, so a write is findable
+  immediately by its literal terms — but a *semantic* query may under-return for
+  that window. Retry once `warming` stops appearing (usually well under a
+  minute) before concluding anything is missing.
+- **`RETRIEVAL_INDEX_WARMING` on a relation-filtered recall.** `relations=` and
+  `relation_of=` are answered only from the typed graph sidecar, so they are the
+  one read that refuses rather than degrades while that sidecar rebuilds. The
+  error carries a retry hint. Retry it, or drop the relation filter and search
+  normally — do not read the refusal as "no such relation."
+
+Everything else degrades quietly and correctly. If a plain recall returns
+results, trust them; if it returns none and nothing is warming, the honest
+reading is that nothing matched the query you asked — so vary the query before
+you doubt the vault.
 
 ### Referents
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-capture/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-capture/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-capture
 description: Preserve a durable conclusion or recurring entity from a conversation without dumping transcripts into compiled memory.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-continue/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-continue/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-continue
 description: Resume prior project or session context from Exomem when the user wants to continue, pick something back up, or remember what was happening on a topic.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-curate/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-curate/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-curate
 description: Improve Exomem note quality by adding links, clarifying compiled notes, and organizing safely without editing raw Sources or Evidence.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.2.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-defrag/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-defrag/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-defrag
 description: Reconcile duplicate, stale, or conflicting Exomem memory while preserving history through review, merge, or supersession.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-ingest/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-ingest/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-ingest
 description: Ingest an external article, PDF, pasted note, dataset, image, audio, or video into Exomem while preserving raw evidence before compiling conclusions.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-media/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-media/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-media
 description: Search, inspect, cite, and preserve Exomem media artifacts such as PDFs, images, audio, and video.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-reflect/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-reflect/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-reflect
 description: Distill a session or project episode into decisions, failures, patterns, open questions, and next actions.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-research/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-research/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-research
 description: "Run a focused research loop with Exomem: gather sources, preserve evidence, compile attributed findings, and connect prior notes."
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.1.0"
 ---
 

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-review/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-review/SKILL.md
@@ -2,7 +2,7 @@
 name: exomem-review
 description: Use Exomem's Epistemic Inbox and audit queues to surface stale conclusions, contradictions, relation debt, and unprocessed sources safely.
 metadata:
-  skill_contract: 99932223e2135024a3e1d4d2ae085f4e66d6c8eb33ee6a1ac2cb458fd1cd1ee1
+  skill_contract: 128c8794792ac000e5dda40d0273f1b14c65e31ab50dcc666990529c449377df
   version: "0.2.0"
 ---
 


### PR DESCRIPTION
## What changed

`src/exomem/_scaffold/_Schema/references/recall.md` — the recall guidance shipped to every user's skill.

Two additions:

1. **Which lane answers a search.** The reference listed hybrid mode's ingredients but never said which of them decides findability. Vector and BM25 are the *primary* lanes and produce the result set; the typed graph is *additive* and only reorders. A graph rebuild degrades ranking, not availability, and a page written moments ago with no edges yet is returned normally.

2. **The two cases where a retry beats a conclusion.** Both are stated in the response itself, so a client never inspects index internals:
   - `warming` naming `embeddings` — right after a process start the embedding model may still be loading and semantic upserts for very recent writes queue behind it, so literal-term matching answers but a semantic query can under-return.
   - `RETRIEVAL_INDEX_WARMING` on `relations=` / `relation_of=` — the one read answered solely from the graph sidecar, so it refuses rather than degrades during a rebuild.

Everything else degrades quietly and correctly, so the reference now says to trust a non-empty result and vary the query before doubting the vault.

## Why

Traced through `src/exomem/` while diagnosing whether hosted onboarding roughness was a retrieval problem. It is not — retrieval is sound, and the guidance simply did not say so, which makes a quiet graph rebuild look like a broken vault to an agent reading the skill.

Established in code:

- Primary set assembled from vector + BM25 + keyword + CLIP at `find_candidates.py:560`; graph appended after at `:691` / `:732`.
- Unavailable graph falls back to wikilink expansion at `find_candidates.py:693-737` — no exception, no empty result.
- `embeddings.py`, `embedding_index.py`, `vecstore.py`, `lexstore.py`, `bm25.py` import neither `epistemic_graph` nor `graph_sync`.
- Read path takes no lock; `await_active_rebuild` is documented as deliberately unreachable from it (`graph_sync.py:2979-3000`). Intent stated at `graph_sync.py:3736-3741`: derived reads degrade rather than break, none of them block.
- Relation filters answered only from the graph sidecar, never scanning the corpus (`epistemic_graph.py:4729-4732`); the refusal is raised at `find.py:3088-3101`.
- Lexical is written inline after a write (`index_sync.py:1292`, `lexstore.upsert_after_write`); embeddings defer only while the model is warming (`embeddings.py:1126-1136`, `readiness.should_defer("embeddings")`).

## Verification

Documentation only — no source or behaviour change.

The scaffold leak gate resolves `SOURCE` from the *installed* package rather than the checkout, so running it from a worktree scans the primary tree and not these bytes. Ran the gate's own assertion directly against the worktree scaffold instead:

```
scanning 37 scaffold files from the worktree
SCAFFOLD CLEAN
```

Note for whoever runs the suite locally: `test_complete_public_inventory_ships_no_private_context` currently fails on clean `main` in the primary checkout because it scans `REPO_ROOT` and picks up untracked local artifacts (`.playwright-mcp/`, `infra/secrets/receipts/**`). Unrelated to this change.