### PR TITLE
fix(tests): reset readiness after the warm-up node instead of only unmanaging

### DIFF
--- a/tests/test_semantic_write_latency_gate.py
+++ b/tests/test_semantic_write_latency_gate.py
@@ -681,7 +681,21 @@ def test_managed_recall_warmup_actually_admits(tmp_path) -> None:
         # The proof itself, not merely a finished warm window.
         assert module.readiness.is_ready("retrieval_catalog")
     finally:
-        module.readiness.unmanage_runtime()
+        # `reset()`, not `unmanage_runtime()`. This node deliberately drives a
+        # real warm-up to completion, so on the way out it leaves `_warm_finished`
+        # set and the `retrieval_catalog` event published -- the two pieces of
+        # module state its own docstring is about. `unmanage_runtime()` clears
+        # neither; it only drops `_runtime_managed`.
+        #
+        # `readiness` is process-global, so that residue is inherited by whatever
+        # runs next in the same worker. Shards are cut by measured duration
+        # (`pytest-split --splitting-algorithm=least_duration`), so which test
+        # that is changes whenever timings shift -- and when it landed on
+        # `test_server_runtime.py::test_disable_warmup_preserves_unverified_lazy_runtime_admission`,
+        # which asserts the clean-start value, that node read `unavailable`
+        # instead of `unverified` and failed. It passes alone and fails in the
+        # shard, which is exactly the shape that reads as CI flakiness.
+        module.readiness.reset()
 
 
 def test_the_file_watcher_switch_does_not_gate_admission(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

One line in `tests/test_semantic_write_latency_gate.py`, plus a comment explaining why it matters: `test_managed_recall_warmup_actually_admits` now cleans up with `readiness.reset()` rather than `readiness.unmanage_runtime()`.

## Why

That node deliberately drives a real warm-up to completion, so it exits leaving `_warm_finished` set and the `retrieval_catalog` event published — the two pieces of state its own docstring is about. `unmanage_runtime()` clears neither; it only drops `_runtime_managed`. `reset()` is the documented "return to the never-warmed state" hook.

`readiness` is process-global, so the residue is inherited by whatever runs next in the same worker. Core shards are cut by measured duration (`pytest-split --splitting-algorithm=least_duration`), so the neighbour changes whenever the collected set or its timings shift. It landed next to `tests/test_server_runtime.py::test_disable_warmup_preserves_unverified_lazy_runtime_admission`, which asserts the clean-start value:

```
E   AssertionError: assert {'admitted': ...'unavailable'} == {'admitted': ... 'unverified'}
E     {'state': 'unavailable'} != {'state': 'unverified'}
```

Both tests pass in isolation, which is what makes this read as CI flakiness rather than a defect.

## Verification

Reproduced deterministically — the pair, in shard order, before the fix:

```
$ pytest -q tests/test_semantic_write_latency_gate.py::test_managed_recall_warmup_actually_admits \
          tests/test_server_runtime.py::test_disable_warmup_preserves_unverified_lazy_runtime_admission
1 failed, 1 passed in 0.65s
```

After the fix: `2 passed`. Both files in full: `68 passed`.

Full shard 8, reproducing the CI split exactly:

| | clean `main` | this branch |
|---|---|---|
| `test_server_runtime::test_disable_warmup_preserves_unverified_lazy_runtime_admission` | **FAILED** | **passes** |
| total | 5 failed, 1182 passed | 4 failed, 1183 passed |

So this is pre-existing on `main`, not introduced by whichever PR happened to go red.

## The other failures in that shard are not this, and not new

Confirmed against the same clean-`main` baseline:

- `tests/test_demo.py::test_env_restore_no_bleed_for_in_process_callers` — fails on `main` too.
- `tests/test_setup_wizard.py::test_http_route_registers_native_claude_and_codex_clients` and `::test_codex_is_skipped_when_not_installed` — fail on `main` too; look environment-sensitive.
- `tests/test_scaffold_no_leak.py::test_complete_public_inventory_ships_no_private_context` — fails only in a checkout carrying untracked local artifacts, since it scans `REPO_ROOT`.
- `tests/test_hosted_v5_candidate.py::test_a_demote_and_re_promote_cycle_cannot_correct_a_promoted_candidate` — **genuinely flaky**, independent of ordering: run standalone three times it passed, passed, failed. Worth its own issue; not addressed here.