### PR TITLE
fix(benchmarks): report blocked export validation stages

### DIFF
--- a/benchmarks/memorybench/export.py
+++ b/benchmarks/memorybench/export.py
@@ -13,6 +13,7 @@ import shutil
 import signal
 import stat
 import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1670,23 +1671,30 @@ def run_export(
     signal_installer: Callable[[Callable[[int, object | None], None]], Callable[[], None]] = _install_signals,
     utc_now: Callable[[], datetime] = _current_utc,
 ) -> ExportResult:
+    validation_stage = "run-plan"
     try:
         run_plan_bytes = _secure_read(run_plan_path, private=True)
         plan = MemoryBenchRunPlan.model_validate(_load_json_bytes(run_plan_bytes, "run plan"))
     except Exception:
+        print(f"memorybench-export: BLOCKED during {validation_stage} validation", file=sys.stderr)
         return ExportResult("BLOCKED", 2)
     try:
+        validation_stage = "preregistration"
         preregistration_identity = derive_preregistration_identity(
             Path(__file__).resolve().parents[2],
             contract_revision=plan.contract_revision,
         )
         if plan.preregistration_sha256 != preregistration_identity.original.sha256:
             raise ValueError("pre-registration digest assertion differs from derived original")
+        validation_stage = "provider-variant"
         _validate_registered_variant(plan)
+        validation_stage = "output-root"
         output_root = Path(plan.output_root)
         if output_root.exists():
             raise ValueError("output root already exists")
+        validation_stage = "toolchain"
         bun_executable, controlled_path = _resolve_toolchain()
+        validation_stage = "harness-checkout"
         state = checkout_verifier(
             memorybench_home=Path(plan.memorybench_home),
             expected_commit=plan.harness.commit,
@@ -1695,12 +1703,20 @@ def run_export(
         )
         if state != "materialized":
             raise ValueError("MemoryBench checkout is not materialized")
+        validation_stage = "provider-checkout"
         provider_checkout_verifier(plan.provider_checkout.model_dump(mode="json"))
+        validation_stage = "dataset"
         dataset_verifier(Path(plan.dataset_path), plan.dataset.model_dump(mode="json"))
+        validation_stage = "native-dataset"
         _, rows = _native_dataset(plan)
+        validation_stage = "selection"
         selection_pins = _canonical_selection_pins(plan, rows)
+        validation_stage = "runtime-freshness"
         _verify_fresh_runtime(plan)
     except Exception:
+        # Exception text can contain private plan fields or runtime paths.
+        # Emit only the code-owned stage, including when validation itself fails.
+        print(f"memorybench-export: BLOCKED during {validation_stage} validation", file=sys.stderr)
         return ExportResult("BLOCKED", 2)
 
     output_root.mkdir(mode=0o700, parents=True)

--- a/tests/test_memorybench_export.py
+++ b/tests/test_memorybench_export.py
@@ -685,7 +685,7 @@ def test_preregistration_plan_digest_is_only_an_assertion_against_derived_identi
     assert main(["--plan", str(plan)]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert captured.err == ""
+    assert captured.err == "memorybench-export: BLOCKED during preregistration validation\n" * 2
 
 
 def test_production_default_calls_the_real_setup_verifier(
@@ -717,6 +717,47 @@ def test_production_default_calls_the_real_setup_verifier(
     )
     assert result.status == "VALID"
     assert observed and observed[0][0] == tmp_path / "memorybench"
+
+
+def test_preflight_reports_failed_provider_binding_without_private_exception(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan = _plan(tmp_path)
+    stage_calls: list[object] = []
+
+    def refuse_provider(_identity: dict[str, Any]) -> None:
+        raise ValueError(f"lock differs: {HMAC_KEY_HEX} at {tmp_path}")
+
+    result = _run(
+        plan,
+        checkout_verifier=lambda **_kwargs: "materialized",
+        provider_checkout_verifier=refuse_provider,
+        stage_runner=lambda *args, **kwargs: stage_calls.append((args, kwargs)),
+    )
+
+    assert result.status == "BLOCKED" and result.exit_code == 2
+    assert stage_calls == []
+    assert not (tmp_path / "output").exists()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "memorybench-export: BLOCKED during provider-checkout validation\n"
+
+
+def test_cli_reports_invalid_plan_without_echoing_private_values(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    from memorybench.export import main
+
+    plan = _plan(tmp_path)
+    payload = json.loads(plan.read_text())
+    payload["provider"] = HMAC_KEY_HEX
+    plan.write_text(json.dumps(payload))
+
+    assert main(["--plan", str(plan)]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "memorybench-export: BLOCKED during run-plan validation\n"
+    assert not (tmp_path / "output").exists()
 
 
 @pytest.mark.parametrize(
@@ -2104,7 +2145,7 @@ def test_python_rejects_duplicate_json_members_at_every_source_and_depth(
     "condition",
     ["missing", "symlink", "mode", "owner", "writable-parent", "malformed", "duplicate"],
 )
-def test_every_invalid_run_plan_is_a_quiet_blocked_result(
+def test_every_invalid_run_plan_has_a_constant_blocked_diagnostic(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -2136,7 +2177,8 @@ def test_every_invalid_run_plan_is_a_quiet_blocked_result(
     assert result.status == "BLOCKED" and result.exit_code == 2
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert combined == ""
+    assert captured.out == ""
+    assert captured.err == "memorybench-export: BLOCKED during run-plan validation\n"
     assert "Traceback" not in combined
     assert str(tmp_path) not in combined
     assert "private-exception-text" not in combined


### PR DESCRIPTION
MemoryBench could return BLOCKED before creating a manifest and leave both output streams empty. A stale provider lockfile hash in a 25-case run made that refusal difficult to diagnose.

Report the failed validation stage on stderr using fixed labels. Private plan values and exception text remain excluded, and status codes and acceptance checks are unchanged.

Validation: 182 export tests passed, including invalid-plan and private-exception regressions; 44 adjacent protocol/projection tests passed; 183 strict OpenSpec validations passed. Independent review found no issues. Required CI is green, including all 12 core and four harness test shards. A fresh two-case run completed through both runners, cleanup, projection, and the blocking equivalence gate with zero blocking differences.
