### PR TITLE
chore(hosted): verify Neon budget controls

### DIFF
--- a/docs/runbooks/hosted/database-budget.md
+++ b/docs/runbooks/hosted/database-budget.md
@@ -1,0 +1,94 @@
+<!-- authority:non-specification -->
+
+# Hosted database budget controls
+
+Use this runbook before increasing hosted capacity or admitting more hosted
+load. The audit reads Neon management metadata only; it does not connect to
+PostgreSQL, wake compute, read credentials, or modify provider state.
+
+## Preflight
+
+Use a Neon CLI installation authenticated for the target project. The default
+command is `neonctl`; provide a pinned executable explicitly when needed.
+
+```bash
+uv run --frozen python infra/scripts/audit_hosted_database_budget.py \
+  --project-id "$NEON_PROJECT_ID" \
+  --neonctl /path/to/neonctl
+```
+
+The command uses only these Neon v2 GET paths: the project, its endpoints, its
+branches, and the organization spending limit derived from the returned
+project. It writes a sanitized JSON report. Treat `fail` and `unknown` as a
+failed preflight. An unknown result is incomplete provider evidence, not a
+safe default.
+
+The provider contracts are Neon's
+[project API reference](https://api-docs.neon.tech/reference/getprojectdetails)
+and
+[organization spending-limit API reference](https://api-docs.neon.tech/reference/setorganizationspendinglimit).
+The [branch-list API reference](https://api-docs.neon.tech/reference/listprojectbranches)
+is paginated; a report with incomplete branch inventory is non-passing rather
+than an assertion that one listed branch is the only branch.
+
+The default control policy requires exactly one endpoint and one default branch,
+minimum 0.25 CU, maximum no more than 1 CU, non-negative autosuspend timeout,
+and a positive spending alert at or
+below 500 cents. A timeout value of `0` is the provider default (currently five
+minutes), rather than disabled autosuspend. Extra branches are reported; this
+tool never deletes them.
+
+## Read, modify, read
+
+First run the preflight and retain its sanitized JSON result. Make an approved
+capacity or alert change in Neon using the target project and the organization
+derived from its identity-checked project API metadata. Re-run the same
+preflight immediately afterwards and require a passing result before expanding
+hosted load. The sanitized report intentionally does not emit the organization
+identifier.
+
+For the currently approved posture, set the one endpoint to 0.25 minimum CU,
+1 maximum CU, provider-default autosuspend, and the organization alert to 500
+cents. The alert configuration is not proof that an email was delivered; it
+only causes Neon to notify at its configured thresholds. It does not suspend
+compute.
+
+## Optional monthly compute cutoff
+
+A compute quota is a separate, provider-enforced whole-project control. To
+verify an already approved 100-CU-hour monthly quota, run:
+
+```bash
+uv run --frozen python infra/scripts/audit_hosted_database_budget.py \
+  --project-id "$NEON_PROJECT_ID" \
+  --monthly-compute-hours 100
+```
+
+The audit checks `settings.quota.compute_time_seconds`: 100 CU-hours is
+360000 CU-seconds. It never enables, changes, or removes the quota. Zero or a
+missing quota is unlimited, and only a positive quota at or below the requested
+limit passes this optional check.
+
+Choose a hard quota only with explicit acceptance that exhaustion suspends the
+shared database's compute. That stops hosted lifecycle, OAuth, billing and
+gateway SQL until the next billing period or an operator changes the quota.
+Storage and transfer remain billable, usage accounting can lag, and a compute
+quota is not a total-dollar ceiling.
+
+For Vercel-managed Neon organizations, a project-quota update can be rejected
+with `action restricted; reason: "organization is managed by Vercel"`. Read the
+project again after any rejected or ambiguous write. If the quota remains
+absent, the hard stop is **not enabled**, even when the capacity ceiling and
+spending alert pass. Resolve the restriction through the integration's account
+administration or provider support; do not silently transfer the project,
+change its billing plan, or substitute an unverified shutdown mechanism.
+[Vercel Spend Management](https://vercel.com/docs/spend-management) excludes
+Marketplace integrations, so its application-spend ceiling is not a substitute
+for a Neon compute quota.
+
+## Retained baseline
+
+The capacity ceiling does not make this database idle-free. Existing worker
+polling, SQL readiness checks and scheduled maintenance keep its compute active
+at the 0.25-CU minimum. Reducing that baseline requires a separately approved
+cross-service scheduler change; do not claim this budget control removes it.

--- a/infra/scripts/audit_hosted_database_budget.py
+++ b/infra/scripts/audit_hosted_database_budget.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Read Neon metadata and report whether hosted database budget controls hold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+_IDENTIFIER = re.compile(r"^[a-z0-9-]{1,60}$")
+_TIMEOUT_SECONDS = 20
+_Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _timestamp(value: object) -> str | None:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError:
+        return None
+    return value if parsed.tzinfo == UTC else None
+
+
+def _get(path: str, *, neonctl: str, runner: _Runner) -> dict[str, Any] | None:
+    try:
+        result = runner(
+            [neonctl, "api", path, "--output", "json", "--no-analytics"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0 or len(result.stdout) > 1024 * 1024:
+        return None
+    try:
+        value = json.loads(result.stdout)
+    except ValueError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _finding(code: str, status: str, **values: int | float) -> dict[str, object]:
+    return {"code": code, **values, "status": status}
+
+
+def _report(
+    findings: list[dict[str, object]],
+    *,
+    compute_time_seconds: int | None = None,
+    compute_quota_seconds: int | None = None,
+    billing_period: dict[str, str] | None = None,
+    monthly_compute_hours: int | None = None,
+    provider_enforced: bool | None = None,
+) -> dict[str, object]:
+    return {
+        "billingPeriod": billing_period,
+        "computeQuotaSeconds": compute_quota_seconds,
+        "computeTimeSeconds": compute_time_seconds,
+        "findings": findings,
+        "monthlyComputeQuota": {
+            "policyRequested": monthly_compute_hours is not None,
+            "providerEnforced": provider_enforced,
+            "requestedHours": monthly_compute_hours,
+            "seconds": compute_quota_seconds,
+        },
+        "observedAtUTC": datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "status": "pass" if all(item["status"] == "pass" for item in findings) else "fail",
+    }
+
+
+def _project_identity(response: dict[str, Any] | None, project_id: str) -> dict[str, Any] | None:
+    project = response.get("project") if response is not None else None
+    if not isinstance(project, dict) or project.get("id") != project_id:
+        return None
+    org_id = project.get("org_id")
+    if not isinstance(org_id, str) or _IDENTIFIER.fullmatch(org_id) is None:
+        return None
+    return project
+
+
+def _project_details(
+    project: dict[str, Any],
+) -> tuple[int | None, int | None, dict[str, str] | None, bool, bool]:
+    compute_time = _integer(project.get("compute_time_seconds"))
+    quota_value: int | None = None
+    quota_known = True
+    if "settings" in project:
+        settings = project["settings"]
+        if not isinstance(settings, dict):
+            quota_known = False
+        elif "quota" in settings:
+            quota = settings["quota"]
+            if not isinstance(quota, dict):
+                quota_known = False
+            elif "compute_time_seconds" in quota:
+                quota_value = _integer(quota["compute_time_seconds"])
+                if quota_value is None or quota_value < 0:
+                    quota_known = False
+    start = _timestamp(project.get("consumption_period_start"))
+    end = _timestamp(project.get("consumption_period_end"))
+    period = {"end": end, "start": start} if start is not None and end is not None else None
+    usage_known = False
+    if compute_time is not None and compute_time >= 0 and start is not None and end is not None:
+        usage_known = datetime.fromisoformat(start[:-1] + "+00:00") < datetime.fromisoformat(
+            end[:-1] + "+00:00"
+        )
+    return (
+        compute_time if usage_known else None,
+        quota_value if quota_known else None,
+        period if usage_known else None,
+        usage_known,
+        quota_known,
+    )
+
+
+def _endpoint_findings(response: dict[str, Any] | None, project_id: str) -> list[dict[str, object]]:
+    endpoints = response.get("endpoints") if response is not None else None
+    if not isinstance(endpoints, list):
+        return [
+            _finding("endpoint_capacity_unknown", "unknown"),
+            _finding("endpoint_count_unknown", "unknown"),
+        ]
+    if not all(
+        isinstance(endpoint, dict)
+        and endpoint.get("project_id") == project_id
+        and isinstance(endpoint.get("id"), str)
+        and _IDENTIFIER.fullmatch(endpoint["id"]) is not None
+        and isinstance(endpoint.get("branch_id"), str)
+        and _IDENTIFIER.fullmatch(endpoint["branch_id"]) is not None
+        for endpoint in endpoints
+    ):
+        return [
+            _finding("endpoint_capacity_unknown", "unknown"),
+            _finding("endpoint_count_unknown", "unknown"),
+        ]
+    count_status = "pass" if len(endpoints) == 1 else "fail"
+    capacities: list[tuple[float, float, int]] = []
+    for endpoint in endpoints:
+        minimum = _number(endpoint.get("autoscaling_limit_min_cu"))
+        maximum = _number(endpoint.get("autoscaling_limit_max_cu"))
+        autosuspend = _integer(endpoint.get("suspend_timeout_seconds"))
+        if minimum is None or maximum is None or autosuspend is None or autosuspend < -1:
+            return [
+                _finding("endpoint_capacity_unknown", "unknown"),
+                _finding("endpoint_count", count_status, observed=len(endpoints)),
+            ]
+        capacities.append((minimum, maximum, autosuspend))
+    if not capacities:
+        return [
+            _finding("endpoint_capacity", "fail"),
+            _finding("endpoint_count", count_status, observed=0),
+        ]
+    minimum = min(item[0] for item in capacities)
+    maximum = max(item[1] for item in capacities)
+    capacity_status = (
+        "pass"
+        if all(item[0] == 0.25 and 0 < item[0] <= item[1] <= 1 and item[2] >= 0 for item in capacities)
+        else "fail"
+    )
+    return [
+        _finding("endpoint_capacity", capacity_status, maxCu=maximum, minCu=minimum),
+        _finding("endpoint_count", count_status, observed=len(endpoints)),
+    ]
+
+
+def _branch_findings(response: dict[str, Any] | None, project_id: str) -> list[dict[str, object]]:
+    branches = response.get("branches") if response is not None else None
+    if not isinstance(branches, list) or not all(
+        isinstance(branch, dict)
+        and branch.get("project_id") == project_id
+        and isinstance(branch.get("id"), str)
+        and _IDENTIFIER.fullmatch(branch["id"]) is not None
+        and isinstance(branch.get("default"), bool)
+        for branch in branches
+    ):
+        return [_finding("branch_inventory_unknown", "unknown")]
+    if not _branch_inventory_complete(response) and len(branches) <= 1:
+        return [_finding("branch_inventory_unknown", "unknown")]
+    default_count = sum(branch.get("default") is True for branch in branches)
+    return [
+        _finding("branch_count", "pass" if len(branches) == 1 else "fail", observed=len(branches)),
+        _finding("production_branch", "pass" if default_count == 1 else "fail", observed=default_count),
+    ]
+
+
+def _branch_inventory_complete(response: dict[str, Any] | None) -> bool:
+    if response is None:
+        return False
+    if "pagination" not in response:
+        return True
+    pagination = response["pagination"]
+    return isinstance(pagination, dict) and "next" not in pagination
+
+
+def _inventory_link_finding(
+    endpoints_response: dict[str, Any] | None,
+    branches_response: dict[str, Any] | None,
+    project_id: str,
+) -> dict[str, object] | None:
+    endpoints = endpoints_response.get("endpoints") if endpoints_response is not None else None
+    branches = branches_response.get("branches") if branches_response is not None else None
+    if (
+        not isinstance(endpoints, list)
+        or not isinstance(branches, list)
+        or len(endpoints) != 1
+        or len(branches) != 1
+        or not _branch_inventory_complete(branches_response)
+        or not isinstance(endpoints[0], dict)
+        or not isinstance(branches[0], dict)
+        or endpoints[0].get("project_id") != project_id
+        or branches[0].get("project_id") != project_id
+        or not isinstance(endpoints[0].get("id"), str)
+        or _IDENTIFIER.fullmatch(endpoints[0]["id"]) is None
+        or not isinstance(endpoints[0].get("branch_id"), str)
+        or _IDENTIFIER.fullmatch(endpoints[0]["branch_id"]) is None
+        or not isinstance(branches[0].get("id"), str)
+        or _IDENTIFIER.fullmatch(branches[0]["id"]) is None
+        or not isinstance(branches[0].get("default"), bool)
+    ):
+        return None
+    if endpoints[0].get("branch_id") != branches[0].get("id"):
+        return _finding("inventory_link_unknown", "unknown")
+    return None
+
+
+def audit(
+    project_id: str,
+    *,
+    neonctl: str = "neonctl",
+    monthly_compute_hours: int | None = None,
+    runner: _Runner = subprocess.run,
+) -> dict[str, object]:
+    """Return a sanitized audit report after only Neon API GET metadata calls."""
+
+    if _IDENTIFIER.fullmatch(project_id) is None:
+        return _report([_finding("project_unknown", "unknown")])
+
+    project_response = _get(f"/projects/{project_id}", neonctl=neonctl, runner=runner)
+    endpoints_response = _get(f"/projects/{project_id}/endpoints", neonctl=neonctl, runner=runner)
+    branches_response = _get(f"/projects/{project_id}/branches", neonctl=neonctl, runner=runner)
+    project = _project_identity(project_response, project_id)
+    findings = _endpoint_findings(endpoints_response, project_id)
+    findings.extend(_branch_findings(branches_response, project_id))
+    if project is None:
+        findings.append(_finding("project_unknown", "unknown"))
+        return _report(findings, monthly_compute_hours=monthly_compute_hours)
+
+    compute_time, quota_seconds, period, usage_known, quota_known = _project_details(project)
+    link_finding = _inventory_link_finding(endpoints_response, branches_response, project_id)
+    if link_finding is not None:
+        findings.append(link_finding)
+
+    org_id = project["org_id"]
+    assert isinstance(org_id, str)
+    spending = _get(
+        f"/organizations/{org_id}/billing/spending_limit", neonctl=neonctl, runner=runner
+    )
+    if spending is None or "spending_limit_cents" not in spending:
+        findings.append(_finding("spending_alert_unknown", "unknown"))
+    elif spending["spending_limit_cents"] is None:
+        findings.append(_finding("spending_alert", "fail"))
+    else:
+        cents = _integer(spending["spending_limit_cents"])
+        if cents is None:
+            findings.append(_finding("spending_alert_unknown", "unknown"))
+        else:
+            findings.append(
+                _finding("spending_alert", "pass" if 0 < cents <= 500 else "fail", cents=cents)
+            )
+    if not usage_known:
+        findings.append(_finding("project_usage_unknown", "unknown"))
+    if not quota_known:
+        findings.append(_finding("compute_quota_unknown", "unknown"))
+    elif monthly_compute_hours is not None:
+        if quota_seconds is None:
+            findings.append(_finding("monthly_compute_quota", "fail"))
+        else:
+            maximum = monthly_compute_hours * 3600
+            findings.append(
+                _finding(
+                    "monthly_compute_quota",
+                    "pass" if 0 < quota_seconds <= maximum else "fail",
+                )
+            )
+    if not quota_known:
+        provider_enforced = None
+    elif quota_seconds is None:
+        provider_enforced = False
+    else:
+        provider_enforced = quota_seconds > 0
+    return _report(
+        findings,
+        compute_time_seconds=compute_time,
+        compute_quota_seconds=quota_seconds,
+        billing_period=period,
+        monthly_compute_hours=monthly_compute_hours,
+        provider_enforced=provider_enforced,
+    )
+
+
+def _positive_hours(value: str) -> int:
+    try:
+        hours = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive whole number") from exc
+    if hours <= 0:
+        raise argparse.ArgumentTypeError("must be a positive whole number")
+    return hours
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-id", required=True)
+    parser.add_argument("--neonctl", default="neonctl")
+    parser.add_argument("--monthly-compute-hours", type=_positive_hours)
+    return parser
+
+
+def main(arguments: list[str] | None = None, *, runner: _Runner = subprocess.run) -> int:
+    args = _parser().parse_args(arguments)
+    report = audit(
+        args.project_id,
+        neonctl=args.neonctl,
+        monthly_compute_hours=args.monthly_compute_hours,
+        runner=runner,
+    )
+    print(json.dumps(report, separators=(",", ":"), sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openspec/changes/bound-hosted-database-spend/.openspec.yaml
+++ b/openspec/changes/bound-hosted-database-spend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/bound-hosted-database-spend/design.md
+++ b/openspec/changes/bound-hosted-database-spend/design.md
@@ -1,0 +1,33 @@
+## Context
+
+See proposal.md. The shared Neon database serves Substrate and hosted lifecycle/OAuth state. Existing one-second worker polling, SQL-backed readiness and minute maintenance keep it awake. The measured minimum 0.25 CU consumes 180 CU-hours over 30 days, independently of the small stored data set.
+
+## Goals / Non-Goals
+
+**Goals:** Verify cost controls without querying PostgreSQL, creating previews or changing provider state. Distinguish capacity, warning thresholds and actual consumption cutoffs. Make the preflight rerunnable by an agent.
+
+**Non-Goals:** Automatic quota changes, hard-stop consent, email inbox access, invoice reconciliation, idle scheduling, database migration or a new monitoring daemon.
+
+## Decisions
+
+Use a small standard-library Python command, `infra/scripts/audit_hosted_database_budget.py`, over the authenticated Neon CLI's API v2 GET operations. The CLI owns OAuth refresh and credential storage; the audit never reads credential files or prints provider bodies/errors. An explicit `--neonctl` executable path supports pinned installations. No shell execution, arbitrary API URL, write verb or database connection is accepted. Bound each child invocation with a timeout.
+
+Read project metadata, endpoint inventory, branch inventory and the owning organization's spending threshold. Derive the organization from the returned, identity-checked project; validate identifiers before interpolation. Each unavailable/malformed response becomes a named unknown finding and a nonzero exit. Independent inventory reads continue after another read fails where their target is still known.
+
+Default policy is one endpoint and one production branch, minimum 0.25 CU, endpoint maximum at most 1 CU, autosuspend not disabled and an enabled spending alert no higher than 500 cents. A stricter positive setting passes. Report unexpected branches; never delete them. The optional `--monthly-compute-hours` checks an already authorized project quota, in weighted CU-seconds (hours multiplied by 3600). Omitting this option does not require or authorize a cutoff. A zero/missing provider quota is unlimited, not zero spend.
+
+Emit only a bounded JSON report with status, finding codes, numerical observations, billing-period dates and control semantics. Distinguish confirmed failures from unknown state. The native alert's configuration can be verified, but email delivery cannot be inferred from that configuration. Current provider usage can lag; report its period without promising real-time accounting or a total-dollar ceiling.
+
+The operational runbook makes this audit a preflight before changing database capacity or expanding hosted load. Provider-side alerts and any explicitly selected quota operate continuously; the audit itself is on demand, not background monitoring. It documents the currently applied 0.25–1 CU / $5 posture, safe read-modify-read operations and a separately approved hard-stop choice. No personal IDs or credential values are committed.
+
+## Risks / Trade-offs
+
+- Shared-database quota exhaustion stops OAuth, billing, lifecycle and gateway SQL → require explicit whole-service cutoff acceptance; do not enable a quota from this audit.
+- Native spending alerts do not stop usage and compute quotas do not cap storage/transfer → report those semantics explicitly.
+- A capacity cap retains the always-awake baseline → do not claim an idle-cost fix or Free-plan fit.
+- Provider settings can drift after a successful read → timestamp reports and repeat at deployment; native controls remain the enforcement authority.
+- Authenticated provider output can contain sensitive data → whitelist report fields, suppress raw subprocess output, and test sentinel redaction on failures.
+
+## Migration Plan
+
+Ship the read-only command and runbook without changing any running application or schedule. Run it against the existing project and preserve its sanitized result. Reverting this tooling does not alter live provider controls; reverting a control requires its own explicit operator change and verification.

--- a/openspec/changes/bound-hosted-database-spend/proposal.md
+++ b/openspec/changes/bound-hosted-database-spend/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The hosted control plane keeps its serverless database active even with no user traffic. A tiny data set therefore does not imply Free-tier compute usage, and an unconstrained autoscaling maximum permits avoidable spend spikes.
+
+## What Changes
+
+- Define explicit, separately verified endpoint capacity, monthly spending-alert and optional monthly compute-quota controls.
+- Add a read-only provider audit and operational runbook; use provider metadata rather than SQL so the audit cannot itself wake compute.
+- Report unknown provider state as a failed audit, never as a passing budget check. Never automatically delete branches or change production settings.
+- Preserve existing lifecycle, authorization renewal, magic-link delivery and backup schedules. True idle suspension needs a separately approved cross-service scheduler design; this change does not claim to remove the measured always-awake baseline.
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-database-budget`: Verifiable database cost guardrails and explicit whole-control-plane cutoff semantics.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Adds an infrastructure audit script, focused tests and a hosted operations runbook. Reads Neon API v2 through the authenticated Neon CLI. No application schema, runtime, workload schedule, credential, DNS or database migration; no model or paid preview creation.

--- a/openspec/changes/bound-hosted-database-spend/specs/hosted-database-budget/spec.md
+++ b/openspec/changes/bound-hosted-database-spend/specs/hosted-database-budget/spec.md
@@ -1,0 +1,52 @@
+## Purpose
+
+Make hosted database spending controls verifiable without waking database compute, exposing credentials or silently trading service availability for a budget target.
+
+## ADDED Requirements
+
+### Requirement: Read-only budget verification
+
+The hosted budget preflight SHALL read provider management metadata only, SHALL perform no SQL or provider mutation, and SHALL verify endpoint capacity, branch inventory and an enabled spending-alert threshold against explicit policy. Default policy SHALL allow one endpoint, one production branch, a 0.25-CU minimum, a maximum no greater than 1 CU, enabled autosuspend and a spending threshold no greater than 500 cents. It SHALL never automatically delete branches.
+
+#### Scenario: Current constrained project
+
+- **WHEN** the project has one production branch and endpoint, 0.25–1 CU, provider-default autosuspend and a 500-cent alert
+- **THEN** the preflight reports those controls as passing without waking PostgreSQL
+
+#### Scenario: Capacity or inventory drift
+
+- **WHEN** an endpoint can scale beyond policy or an additional branch or endpoint appears
+- **THEN** the preflight reports a failed control and exits nonzero without altering any resource
+
+### Requirement: Honest incomplete evidence and secret-free output
+
+The preflight SHALL report an unreadable, missing, malformed or unauthenticated provider response as unknown and non-passing. It SHALL retain independent findings from other readable endpoints. Its report SHALL contain only allowlisted control observations, not credential values, raw provider errors, database URLs or arbitrary response fields.
+
+#### Scenario: Expired credentials
+
+- **WHEN** provider authentication fails
+- **THEN** the preflight exits nonzero with a named unavailable check and no raw credential or provider error output
+
+#### Scenario: Partial inventory failure
+
+- **WHEN** branch inventory cannot be read but project, endpoint and spending data can
+- **THEN** those available controls remain evaluated and the overall result is non-passing because branch inventory is unknown
+
+### Requirement: Separate capacity alerts and hard consumption cutoff
+
+The preflight SHALL distinguish an endpoint capacity ceiling, an alert-only monthly spending threshold and an optional provider-enforced monthly compute quota. A requested compute quota SHALL be verified in weighted CU-seconds; zero or missing means unlimited. The preflight SHALL not enable or modify a quota. Operator guidance SHALL state that quota exhaustion stops the shared control plane, storage and transfer remain billable, provider usage can lag and alert configuration is not proof of email delivery.
+
+#### Scenario: No hard cutoff selected
+
+- **WHEN** the operator has not requested monthly compute-quota verification
+- **THEN** the preflight reports the observed quota without treating an alert as a hard stop
+
+#### Scenario: Explicit 100-CU-hour quota policy
+
+- **WHEN** the operator requests a 100-CU-hour quota check
+- **THEN** a positive provider compute quota no greater than 360000 CU-seconds passes and an unlimited or larger quota fails
+
+#### Scenario: Ongoing background work
+
+- **WHEN** existing maintenance keeps the database active at its minimum
+- **THEN** the runbook identifies the retained compute baseline and does not claim the capacity ceiling makes idle usage free

--- a/openspec/changes/bound-hosted-database-spend/tasks.md
+++ b/openspec/changes/bound-hosted-database-spend/tasks.md
@@ -1,0 +1,9 @@
+## 1. Read-only audit
+
+- [x] 1.1 Add red-first tests for passing controls, capacity/inventory drift, absent alerts, optional quota units, malformed/partial provider data, command timeout and secret-sentinel suppression; implement the minimal audit and pass `pytest -q tests/test_hosted_database_budget.py`.
+- [x] 1.2 Add the operational runbook with read-modify-read controls, cutoff semantics and retained idle baseline; verify its commands against Neon v2 and pass `tests/test_openspec_only.py`.
+
+## 2. Delivery
+
+- [ ] 2.1 Independently review the diff and rerun the negative audit cases; run the real read-only audit, relevant hosted infra/static suites and strict OpenSpec validation, retaining sanitized output.
+- [ ] 2.2 Merge the reviewed PR after required checks, confirm default-branch state, then synchronize/archive this change with merge evidence and strict validation; remove the clean task worktree and branch.

--- a/tests/test_hosted_database_budget.py
+++ b/tests/test_hosted_database_budget.py
@@ -1,0 +1,403 @@
+"""Regression coverage for the read-only Neon database budget audit."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "infra" / "scripts" / "audit_hosted_database_budget.py"
+
+
+def _module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("audit_hosted_database_budget", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def responses() -> dict[str, object]:
+    return {
+        "/projects/project-1": {
+            "project": {
+                "id": "project-1",
+                "org_id": "org-1",
+                "compute_time_seconds": 123,
+                "consumption_period_start": "2026-09-01T00:00:00Z",
+                "consumption_period_end": "2026-10-01T00:00:00Z",
+                "settings": {"quota": {"compute_time_seconds": 360000}},
+                "untrusted": "SECRET-SENTINEL",
+            }
+        },
+        "/projects/project-1/endpoints": {
+            "endpoints": [
+                {
+                    "id": "ep-1",
+                    "project_id": "project-1",
+                    "branch_id": "br-1",
+                    "autoscaling_limit_min_cu": 0.25,
+                    "autoscaling_limit_max_cu": 1,
+                    "suspend_timeout_seconds": 0,
+                    "host": "SECRET-SENTINEL",
+                }
+            ]
+        },
+        "/projects/project-1/branches": {
+            "branches": [
+                {"id": "br-1", "project_id": "project-1", "default": True}
+            ]
+        },
+        "/organizations/org-1/billing/spending_limit": {
+            "spending_limit_cents": 500,
+            "untrusted": "SECRET-SENTINEL",
+        },
+    }
+
+
+def _runner(responses: dict[str, object], calls: list[list[str]]):
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        assert kwargs == {
+            "capture_output": True,
+            "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+            "timeout": 20,
+            "check": False,
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(responses[command[2]]), "")
+
+    return run
+
+
+def test_audit_reports_current_constrained_project_without_provider_details(
+    responses: dict[str, object], capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _module()
+    calls: list[list[str]] = []
+
+    result = module.main(["--project-id", "project-1"], runner=_runner(responses, calls))
+
+    report = json.loads(capsys.readouterr().out)
+    assert result == 0
+    observed_at = report.pop("observedAtUTC")
+    assert re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", observed_at)
+    assert report == {
+        "billingPeriod": {"end": "2026-10-01T00:00:00Z", "start": "2026-09-01T00:00:00Z"},
+        "computeQuotaSeconds": 360000,
+        "computeTimeSeconds": 123,
+        "findings": [
+            {"code": "endpoint_capacity", "maxCu": 1, "minCu": 0.25, "status": "pass"},
+            {"code": "endpoint_count", "observed": 1, "status": "pass"},
+            {"code": "branch_count", "observed": 1, "status": "pass"},
+            {"code": "production_branch", "observed": 1, "status": "pass"},
+            {"code": "spending_alert", "cents": 500, "status": "pass"},
+        ],
+        "monthlyComputeQuota": {
+            "policyRequested": False,
+            "providerEnforced": True,
+            "requestedHours": None,
+            "seconds": 360000,
+        },
+        "status": "pass",
+    }
+    assert calls == [
+        ["neonctl", "api", "/projects/project-1", "--output", "json", "--no-analytics"],
+        [
+            "neonctl",
+            "api",
+            "/projects/project-1/endpoints",
+            "--output",
+            "json",
+            "--no-analytics",
+        ],
+        [
+            "neonctl",
+            "api",
+            "/projects/project-1/branches",
+            "--output",
+            "json",
+            "--no-analytics",
+        ],
+        [
+            "neonctl",
+            "api",
+            "/organizations/org-1/billing/spending_limit",
+            "--output",
+            "json",
+            "--no-analytics",
+        ],
+    ]
+    assert "SECRET-SENTINEL" not in capsys.readouterr().err
+
+
+def test_audit_reports_capacity_and_inventory_drift(responses: dict[str, object]) -> None:
+    module = _module()
+    responses["/projects/project-1/endpoints"] = {
+        "endpoints": [
+            {
+                "id": "ep-1",
+                "project_id": "project-1",
+                "branch_id": "br-1",
+                "autoscaling_limit_min_cu": 0.25,
+                "autoscaling_limit_max_cu": 2,
+                "suspend_timeout_seconds": -1,
+            },
+            {
+                "id": "ep-2",
+                "project_id": "project-1",
+                "branch_id": "br-2",
+                "autoscaling_limit_min_cu": 0.25,
+                "autoscaling_limit_max_cu": 1,
+                "suspend_timeout_seconds": 0,
+            },
+        ]
+    }
+    responses["/projects/project-1/branches"] = {
+        "branches": [
+            {"id": "br-1", "project_id": "project-1", "default": True},
+            {"id": "br-2", "project_id": "project-1", "default": False},
+        ]
+    }
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"] if finding["status"] == "fail"} == {
+        "endpoint_capacity",
+        "endpoint_count",
+        "branch_count",
+    }
+
+
+def test_audit_requires_configured_alert_and_requested_quota(
+    responses: dict[str, object]
+) -> None:
+    module = _module()
+    responses["/organizations/org-1/billing/spending_limit"] = {"spending_limit_cents": None}
+    responses["/projects/project-1"]["project"]["settings"] = {
+        "quota": {"compute_time_seconds": 0}
+    }
+
+    report = module.audit("project-1", monthly_compute_hours=100, runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"] if finding["status"] == "fail"} == {
+        "spending_alert",
+        "monthly_compute_quota",
+    }
+    assert report["monthlyComputeQuota"] == {
+        "policyRequested": True,
+        "providerEnforced": False,
+        "requestedHours": 100,
+        "seconds": 0,
+    }
+
+
+def test_missing_quota_is_reported_as_unlimited_until_a_cutoff_is_requested(
+    responses: dict[str, object]
+) -> None:
+    module = _module()
+    responses["/projects/project-1"]["project"]["settings"] = {}
+
+    without_cutoff = module.audit("project-1", runner=_runner(responses, []))
+    with_cutoff = module.audit("project-1", monthly_compute_hours=100, runner=_runner(responses, []))
+
+    assert without_cutoff["status"] == "pass"
+    assert without_cutoff["monthlyComputeQuota"] == {
+        "policyRequested": False,
+        "providerEnforced": False,
+        "requestedHours": None,
+        "seconds": None,
+    }
+    assert {finding["code"] for finding in with_cutoff["findings"] if finding["status"] == "fail"} == {
+        "monthly_compute_quota"
+    }
+
+
+@pytest.mark.parametrize("settings", ["not-an-object", {"quota": []}])
+def test_audit_fails_closed_on_malformed_quota_settings(
+    responses: dict[str, object], settings: object
+) -> None:
+    module = _module()
+    responses["/projects/project-1"]["project"]["settings"] = settings
+
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert report["monthlyComputeQuota"] == {
+        "policyRequested": False,
+        "providerEnforced": None,
+        "requestedHours": None,
+        "seconds": None,
+    }
+    assert {finding["code"] for finding in report["findings"] if finding["status"] == "unknown"} >= {
+        "compute_quota_unknown"
+    }
+
+
+def test_audit_rejects_invalid_negative_autosuspend(responses: dict[str, object]) -> None:
+    module = _module()
+    responses["/projects/project-1/endpoints"]["endpoints"][0]["suspend_timeout_seconds"] = -2
+
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"]} >= {"endpoint_capacity_unknown"}
+
+
+@pytest.mark.parametrize("pagination", [None, {"next": None}, {"next": ""}, {"next": "next-page"}])
+def test_audit_rejects_incomplete_branch_pagination(
+    responses: dict[str, object], pagination: object
+) -> None:
+    module = _module()
+    responses["/projects/project-1/branches"]["pagination"] = pagination
+
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"]} >= {"branch_inventory_unknown"}
+
+
+def test_audit_accepts_absent_or_terminal_branch_pagination(responses: dict[str, object]) -> None:
+    module = _module()
+
+    absent = module.audit("project-1", runner=_runner(responses, []))
+    responses["/projects/project-1/branches"]["pagination"] = {}
+    terminal = module.audit("project-1", runner=_runner(responses, []))
+
+    assert absent["status"] == terminal["status"] == "pass"
+    assert all(finding["code"] != "branch_inventory_unknown" for finding in terminal["findings"])
+
+
+def test_audit_rejects_endpoint_not_linked_to_the_only_branch(
+    responses: dict[str, object]
+) -> None:
+    module = _module()
+    responses["/projects/project-1/endpoints"]["endpoints"][0]["branch_id"] = "br-other"
+
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"]} >= {"inventory_link_unknown"}
+
+
+def test_audit_keeps_spending_alert_when_project_usage_is_malformed(
+    responses: dict[str, object]
+) -> None:
+    module = _module()
+    calls: list[list[str]] = []
+    responses["/projects/project-1"]["project"]["compute_time_seconds"] = "not-a-number"
+
+    report = module.audit("project-1", runner=_runner(responses, calls))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"]} >= {"project_usage_unknown"}
+    assert any(finding["code"] == "spending_alert" and finding["status"] == "pass" for finding in report["findings"])
+    assert calls[-1][2] == "/organizations/org-1/billing/spending_limit"
+
+
+def test_audit_rejects_reversed_billing_period_but_keeps_spending_alert(
+    responses: dict[str, object]
+) -> None:
+    module = _module()
+    responses["/projects/project-1"]["project"]["consumption_period_start"] = "2026-10-01T00:00:00Z"
+    responses["/projects/project-1"]["project"]["consumption_period_end"] = "2026-09-01T00:00:00Z"
+
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert report["billingPeriod"] is None
+    assert {finding["code"] for finding in report["findings"]} >= {"project_usage_unknown"}
+    assert any(finding["code"] == "spending_alert" and finding["status"] == "pass" for finding in report["findings"])
+
+
+def test_audit_reports_requested_quota_limit_separately_from_provider_quota(
+    responses: dict[str, object]
+) -> None:
+    module = _module()
+
+    hundred = module.audit("project-1", monthly_compute_hours=100, runner=_runner(responses, []))
+    two_hundred = module.audit("project-1", monthly_compute_hours=200, runner=_runner(responses, []))
+
+    assert hundred["monthlyComputeQuota"]["requestedHours"] == 100
+    assert two_hundred["monthlyComputeQuota"]["requestedHours"] == 200
+    assert hundred["computeQuotaSeconds"] == two_hundred["computeQuotaSeconds"] == 360000
+
+
+def test_audit_handles_integer_too_large_for_float_conversion() -> None:
+    module = _module()
+
+    assert module._number(10**10000) is None
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [True, float("nan"), float("inf"), "one"],
+)
+def test_audit_rejects_invalid_numeric_provider_values(
+    responses: dict[str, object], bad_value: object
+) -> None:
+    module = _module()
+    responses["/projects/project-1/endpoints"]["endpoints"][0]["autoscaling_limit_max_cu"] = bad_value
+
+    report = module.audit("project-1", runner=_runner(responses, []))
+
+    assert report["status"] == "fail"
+    assert {finding["code"] for finding in report["findings"]} >= {"endpoint_capacity_unknown"}
+
+
+def test_audit_preserves_independent_findings_after_timeout_without_leaking_errors(
+    responses: dict[str, object], capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _module()
+    calls: list[list[str]] = []
+
+    def timeout_runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[2].endswith("/branches"):
+            raise subprocess.TimeoutExpired(command, 20, output="SECRET-SENTINEL")
+        return _runner(responses, [])(command, **kwargs)
+
+    result = module.main(["--project-id", "project-1"], runner=timeout_runner)
+
+    output = capsys.readouterr()
+    report = json.loads(output.out)
+    assert result == 1
+    assert any(finding == {"code": "branch_inventory_unknown", "status": "unknown"} for finding in report["findings"])
+    assert any(finding["code"] == "endpoint_capacity" and finding["status"] == "pass" for finding in report["findings"])
+    assert "SECRET-SENTINEL" not in output.out + output.err
+    assert len(calls) == 4
+
+
+def test_audit_rejects_invalid_project_id_without_running_command() -> None:
+    module = _module()
+    calls: list[list[str]] = []
+
+    report = module.audit("project-1;DELETE", runner=_runner({}, calls))
+
+    assert re.fullmatch(
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",
+        report.pop("observedAtUTC"),
+    )
+    assert report == {
+        "billingPeriod": None,
+        "computeQuotaSeconds": None,
+        "computeTimeSeconds": None,
+        "findings": [{"code": "project_unknown", "status": "unknown"}],
+        "monthlyComputeQuota": {
+            "policyRequested": False,
+            "providerEnforced": None,
+            "requestedHours": None,
+            "seconds": None,
+        },
+        "status": "fail",
+    }
+    assert calls == []


### PR DESCRIPTION
## Summary

Add an agent-runnable, read-only Neon budget preflight before increasing hosted capacity or load. It verifies endpoint size, complete production-branch inventory, native spending alerts, and an optional monthly compute quota without querying PostgreSQL or changing provider state.

Missing or malformed evidence fails closed. Output is allowlisted and omits credentials and raw provider errors. The runbook distinguishes the capacity ceiling, alert-only threshold, whole-project compute cutoff, and retained always-awake baseline.

## Verification

- Independent review: no outstanding findings, including the Vercel-managed quota restriction.
- Focused audit and OpenSpec-authority tests: 26 passed.
- Complete local hosted test set on the integrated branch: 1232 passed, 112 skipped (platform/deployment-gated cases).
- Ruff and Mypy: clean; public-artifact privacy gate: clean.
- Pinned OpenSpec 1.10 validation: 186 passed, 0 failed; archive-discipline check passed.
- Live metadata audit: one endpoint, one production branch, 0.25–1 CU, default autosuspend, and a 500-cent alert pass.
- Live quota negative case: requesting 100 CU-hours returns a nonzero result with monthly_compute_quota failed and providerEnforced=false.

The approved quota write was rejected because the Neon organization is managed by Vercel; readback confirms no quota. This PR does not claim the hard stop is enabled. It makes that missing control visible and documents the account-administration escalation.

OpenSpec: bound-hosted-database-spend. Synchronize and archive after merge evidence is available.
