### PR TITLE
fix: reject redacted values before hosted secret delivery

### DIFF
--- a/docs/runbooks/hosted/secrets.md
+++ b/docs/runbooks/hosted/secrets.md
@@ -7,6 +7,20 @@ a pipe into Vercel and the static K3s Secret set. The command validates the
 versioned destination matrix before reading a value. Values never appear in
 arguments or successful output; provider CLI output is captured and discarded.
 
+Provider exports are not a recovery store. The handoff rejects whole-value
+`[SENSITIVE]`, `<sensitive>`, `[REDACTED]`, and `<redacted>` display markers
+(case-insensitively, allowing surrounding whitespace) before any artifact,
+receipt reservation, or destination call. Real secret content is not trimmed
+or rewritten beyond the existing single trailing-newline handling. This guard
+does not validate an arbitrary token or prove its custody.
+
+Use the authoritative secret-manager value, not an environment-variable listing
+or a write-only provider export. A Vercel delivery receipt proves that a CLI
+write succeeded; it does not prove that a usable source value is recoverable.
+For an existing encryption key, check the consumer's format and authenticated
+decryption of existing ciphertext before accepting recovery. A generated
+replacement is a rotation, not recovery, and must follow the rotation procedure.
+
 ## Preconditions
 
 - Work from a clean infrastructure checkout with `terraform`, `sops`, `age`,

--- a/infra/scripts/secret_handoff.py
+++ b/infra/scripts/secret_handoff.py
@@ -22,6 +22,7 @@ from typing import Any
 _VERSION = re.compile(r"v[1-9][0-9]*\Z")
 _SAFE_NAME = re.compile(r"[a-zA-Z0-9_.-]+\Z")
 _MAX_SECRET_BYTES = 8192
+_REDACTION_PLACEHOLDERS = frozenset({"[sensitive]", "<sensitive>", "[redacted]", "<redacted>"})
 
 
 class HandoffError(RuntimeError):
@@ -316,6 +317,10 @@ def _normalize_secret(value: bytes, value_shape: str = "line") -> bytes:
         raise HandoffError("secret source has an invalid value")
     if value_shape == "file" and b"\r" in value:
         raise HandoffError("secret source has an invalid value")
+    # Provider exports may substitute display text for a write-only value.
+    # Classify the whole value without changing the bytes of a genuine secret.
+    if value.decode("utf-8", errors="replace").strip().casefold() in _REDACTION_PLACEHOLDERS:
+        raise HandoffError("secret source is a redaction placeholder")
     return value
 
 

--- a/tests/test_hosted_secret_handoff.py
+++ b/tests/test_hosted_secret_handoff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -947,6 +948,122 @@ def test_normalizer_holds_the_line_shape_and_rejects_carriage_returns() -> None:
     ):
         with pytest.raises(module.HandoffError):
             module._normalize_secret(value, shape)
+
+
+@pytest.mark.parametrize("value_shape", ["line", "file"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"[SENSITIVE]",
+        b"[Sensitive]\n",
+        b" [sensitive] \r\n",
+        b"<sensitive>",
+        b"[REDACTED]",
+        b"<redacted>",
+        "\u00a0[SENSITIVE]\u00a0".encode(),
+        "\u2009[REDACTED]\u202f".encode(),
+    ],
+)
+def test_normalizer_rejects_whole_value_redaction_markers(value: bytes, value_shape: str) -> None:
+    module = _load_module()
+    with pytest.raises(module.HandoffError, match="redaction placeholder"):
+        module._normalize_secret(value, value_shape)
+
+
+@pytest.mark.parametrize("source_kind", ["stdin", "prompt", "terraform"])
+@pytest.mark.parametrize(
+    ("secret_name", "destination_id"),
+    [
+        ("cloudflare_tunnel_token", "k3s.cloudflared.active"),
+        (
+            "cloudflare_access_client_secret",
+            "vercel.substrate.production.access.active.client-secret",
+        ),
+    ],
+)
+def test_redacted_source_is_rejected_before_any_handoff_side_effect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_kind: str,
+    secret_name: str,
+    destination_id: str,
+) -> None:
+    module = _load_module()
+    _link_vercel_project(tmp_path)
+    marker = b"[SENSITIVE]"
+    monkeypatch.setattr(module.sys, "stdin", io.TextIOWrapper(io.BytesIO(marker + b"\n")))
+    monkeypatch.setattr(module.getpass, "getpass", lambda _prompt: marker.decode())
+    monkeypatch.setenv("SOPS_AGE_RECIPIENTS", "age1testrecipient")
+    destination_calls: list[list[str]] = []
+
+    def _runner(command, **_kwargs):
+        if command[0] != "terraform":
+            destination_calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, stdout=marker, stderr=b"")
+
+    monkeypatch.setattr(module.subprocess, "run", _runner)
+    with pytest.raises(module.HandoffError, match="redaction placeholder"):
+        module.execute_handoff(
+            matrix_path=MATRIX,
+            repository_root=tmp_path,
+            secret_name=secret_name,
+            version="v1",
+            destination_ids=(destination_id,),
+            source_kind=source_kind,
+            terraform_bin="terraform",
+            sops_bin="sops",
+            vercel_bin="vercel",
+            vercel_project=tmp_path,
+            dry_run=False,
+        )
+    assert destination_calls == []
+    assert not (tmp_path / "infra").exists()
+
+
+@pytest.mark.parametrize("marker", [b"[SENSITIVE]", "\u00a0[SENSITIVE]\u00a0".encode()])
+def test_cli_rejects_redacted_control_plane_key_without_echo_or_receipt(
+    tmp_path: Path, marker: bytes
+) -> None:
+    require_posix_only_stdlib()
+    _link_vercel_project(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--matrix",
+            str(MATRIX),
+            "--repository-root",
+            str(tmp_path),
+            "--secret",
+            "control_plane_key",
+            "--version",
+            "v1",
+            "--destination",
+            "vercel.substrate.production.control-plane.active",
+            "--source",
+            "stdin",
+            "--vercel-project",
+            str(tmp_path),
+            "--vercel-bin",
+            str(tmp_path / "must-not-run-vercel"),
+        ],
+        input=marker + b"\n",
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert result.stdout == b""
+    assert result.stderr == b"handoff rejected: secret source is a redaction placeholder\n"
+    assert not (tmp_path / "infra").exists()
+
+
+def test_placeholder_detection_does_not_rewrite_real_secret_content() -> None:
+    module = _load_module()
+    assert module._normalize_secret(b"  opaque-token  \n") == b"  opaque-token  "
+    assert module._normalize_secret(b"token-[SENSITIVE]-suffix") == b"token-[SENSITIVE]-suffix"
+    assert module._normalize_secret(b"[service]\npassword=opaque\n", "file") == (
+        b"[service]\npassword=opaque"
+    )
 
 
 def test_matrix_never_routes_a_file_shaped_secret_to_vercel(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Reject whole-value sensitive/redacted provider display markers before the hosted secret handoff creates artifacts, reserves receipts, or calls a destination. Detection handles case differences and Unicode surrounding whitespace while preserving genuine secret bytes.

The runbook now distinguishes successful delivery from recoverable custody and explains why replacing an existing encryption key is a rotation, not recovery. This change does not read or modify live credentials.

## Verification

- Regression tests failed before the fix, including the independently reproduced non-breaking-space bypass.
- Secret handoff and Ansible secret runner: 57 passed, including the real encryption/decryption round trip with pinned SOPS 3.13.2 and age 1.3.1.
- Ruff 0.15.21 and mypy 2.3.0 passed for the affected code.
- OpenSpec 1.10.0 strict validation: 187 passed.
- Public-artifact privacy validation passed.
