### PR TITLE
fix(vocabulary): keep effect defaults compatible with Python 3.11

### DIFF
--- a/src/exomem/vocabulary_effects.py
+++ b/src/exomem/vocabulary_effects.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import Any
@@ -70,7 +70,7 @@ class Effect:
     action: str
     path: str
     key: str | None = None
-    details: Mapping[str, str] = MappingProxyType({})
+    details: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.action not in _ALLOWED_ACTIONS:

--- a/tests/test_vocabulary_effects.py
+++ b/tests/test_vocabulary_effects.py
@@ -2,8 +2,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from exomem import semantic_contract
-from exomem.vocabulary_effects import CanonicalWriteImage, classify_additive_effects
+from exomem.vocabulary_effects import CanonicalWriteImage, Effect, classify_additive_effects
+
+
+def test_effect_details_are_immutable_snapshots_with_an_empty_default() -> None:
+    default = Effect("entity.create", "entity.md")
+    supplied = {"relation": "supports"}
+    populated = Effect("edge.add", "note.md", details=supplied)
+    supplied["relation"] = "links_to"
+
+    assert default.as_dict()["details"] == {}
+    assert populated.as_dict()["details"] == {"relation": "supports"}
+    for effect in (default, populated):
+        with pytest.raises(TypeError):
+            effect.details["relation"] = "links_to"
 
 
 def _image(path: str, before: str | None, after: str | None) -> CanonicalWriteImage:


### PR DESCRIPTION
Python 3.11 could not import the server because the vocabulary effect dataclass used a mapping proxy as its field default. Create the default per instance and retain the defensive immutable copy made during initialization.

Verified the original import failure, successful server import after the fix, 48 affected tests on Python 3.11, and 14 effect tests on Python 3.13. Independent review reproduced the failure and fix and checked immutability and receipt shape. The public-artifact privacy gate passes.
