### PR TITLE
feat(hosted): bind control-key handoff to BWS source

### DIFF
--- a/docs/runbooks/hosted/secrets.md
+++ b/docs/runbooks/hosted/secrets.md
@@ -2,8 +2,8 @@
 
 # Secret handoff and rotation
 
-This runbook is the only supported path from Terraform, an operator prompt, or
-a pipe into Vercel and the static K3s Secret set. The command validates the
+This runbook is the supported path from a bound BWS entry, Terraform, an operator
+prompt, or a pipe into Vercel and the static K3s Secret set. The command validates the
 versioned destination matrix before reading a value. Values never appear in
 arguments or successful output; provider CLI output is captured and discarded.
 
@@ -55,6 +55,56 @@ infra/scripts/secret_handoff.py \
   --source stdin \
   --dry-run
 ```
+
+## BWS-owned control-plane key
+
+The existing production wrapping key is recorded in
+`infra/contracts/bws-production-v1.json`. The normal handoff uses this exact
+entry through the shared yadm `bwsx-secret` command; no provider export or
+name-based secret search is required. Install the shared tooling and use
+`harness bws-auth` in an operator terminal if this machine needs authentication.
+
+Check custody identity and format without printing the value:
+
+```bash
+bwsx-secret check \
+  --bindings "$repo_root/infra/contracts/bws-production-v1.json" control-plane-key
+```
+
+For an authorized delivery, choose the next unused destination version from
+the retained receipts and set `next_version` before running:
+
+```bash
+infra/scripts/secret_handoff.py \
+  --matrix "$matrix" \
+  --repository-root "$repo_root" \
+  --secret control_plane_key \
+  --version "${next_version:?set the next unused destination version}" \
+  --destination vercel.substrate.production.control-plane.active \
+  --source bws \
+  --vercel-project "$substrate_root"
+```
+
+The BWS helper verifies entry ID, project, expected key and canonical 32-byte
+base64url shape. The handoff captures its value in memory and fails without a
+fallback if retrieval fails. Dry-run does not contact BWS. Stdin/prompt remain
+deliberate compatibility inputs, not recovery from a failed BWS source.
+
+Shape is not decryptability: accepting recovery or rotation still requires
+the Substrate consumer's authenticated decryption and digest checks against
+existing envelopes. The binding records the existing key; it does not authorize
+generating another one. Other credentials, including the production database
+DSN, are not certified or migrated by this first binding. Do not substitute a
+generic `DATABASE_URL` entry from another product. The dormant gateway's new
+destinations still require their governed deployment artifacts.
+
+Adopting this matrix changes its full-file digest, even though the existing
+ciphertexts and destination selection are unchanged. Before the next K3s
+secret apply, publish a new immutable signed registry/public-key pair using
+the active-registry procedure below and pass `--verify-only` against this
+matrix. Retain the previous pair; do not re-encrypt secrets or rotate keys
+just to refresh the registry signature. This source binding does not apply
+anything to a running cluster.
 
 ## Terraform-owned credentials
 

--- a/infra/contracts/bws-production-v1.json
+++ b/infra/contracts/bws-production-v1.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "product": "exomem-hosted",
+  "environment": "production",
+  "bindings": {
+    "control-plane-key": {
+      "project_id": "69843186-5161-40a2-951f-b487011122ce",
+      "secret_id": "1d9caad4-9eba-4c62-90ec-b4a0017805cf",
+      "expected_key": "EXOMEM_CONTROL_PLANE_KEY",
+      "env": "EXOMEM_CONTROL_PLANE_KEY",
+      "format": "base64url-32"
+    }
+  }
+}

--- a/infra/contracts/secret-destinations-v1.json
+++ b/infra/contracts/secret-destinations-v1.json
@@ -527,6 +527,11 @@
     "control_plane_key": {
       "sources": [
         {
+          "kind": "bws",
+          "bindings": "infra/contracts/bws-production-v1.json",
+          "binding": "control-plane-key"
+        },
+        {
           "kind": "stdin"
         },
         {

--- a/infra/scripts/secret_handoff.py
+++ b/infra/scripts/secret_handoff.py
@@ -34,6 +34,8 @@ class SourceSpec:
     kind: str
     root: str | None = None
     output: str | None = None
+    bindings: str | None = None
+    binding: str | None = None
 
 
 @dataclass(frozen=True)
@@ -183,6 +185,7 @@ def load_matrix(path: Path) -> HandoffMatrix:
                     "stdin",
                     "prompt",
                     "terraform",
+                    "bws",
                     "generated-ed25519-private",
                     "derived-ed25519-public",
                 }
@@ -192,6 +195,24 @@ def load_matrix(path: Path) -> HandoffMatrix:
             seen_source_kinds.add(kind)
             root = raw_source.get("root")
             output = raw_source.get("output")
+            bindings = raw_source.get("bindings")
+            binding = raw_source.get("binding")
+            if kind == "bws":
+                if set(raw_source) != {"kind", "bindings", "binding"}:
+                    raise HandoffError(f"secret matrix has invalid BWS binding for {name}")
+                if (
+                    not isinstance(bindings, str)
+                    or not bindings.startswith("infra/contracts/")
+                    or not bindings.endswith(".json")
+                    or any(
+                        part in {".", ".."} or not _SAFE_NAME.fullmatch(part)
+                        for part in bindings.split("/")
+                    )
+                ):
+                    raise HandoffError(f"secret matrix has invalid BWS binding path for {name}")
+                binding = _require_string(binding, "BWS binding name")
+            elif bindings is not None or binding is not None:
+                raise HandoffError(f"secret matrix has BWS binding fields on {kind} for {name}")
             if kind == "terraform":
                 root = _require_string(root, "Terraform root")
                 output = _require_string(output, "Terraform output")
@@ -199,7 +220,9 @@ def load_matrix(path: Path) -> HandoffMatrix:
                     raise HandoffError(f"secret matrix has unknown Terraform root for {name}")
             elif root is not None or output is not None:
                 raise HandoffError(f"secret matrix has source fields on {kind} for {name}")
-            sources.append(SourceSpec(kind=kind, root=root, output=output))
+            sources.append(
+                SourceSpec(kind=kind, root=root, output=output, bindings=bindings, binding=binding)
+            )
 
         destinations: dict[str, DestinationSpec] = {}
         for raw_id, raw_destination in raw_destinations.items():
@@ -344,6 +367,28 @@ def _read_secret(
         if secret_spec.value_shape == "file":
             raise HandoffError("a file-shaped secret cannot be read from a single-line prompt")
         return _normalize_secret(getpass.getpass("Secret value: ").encode("utf-8"))
+
+    if source_kind == "bws":
+        assert source.bindings is not None and source.binding is not None
+        root = repository_root.resolve()
+        try:
+            binding_path = (root / source.bindings).resolve(strict=True)
+            if (
+                root / "infra" / "contracts" not in binding_path.parents
+                or not binding_path.is_file()
+            ):
+                raise HandoffError("BWS binding path escapes infrastructure contracts")
+            result = subprocess.run(
+                ["bwsx-secret", "get", "--bindings", str(binding_path), source.binding],
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, RuntimeError, subprocess.TimeoutExpired):
+            raise HandoffError("BWS secret source failed") from None
+        if result.returncode != 0:
+            raise HandoffError("BWS secret source failed")
+        return _normalize_secret(result.stdout, secret_spec.value_shape)
 
     assert source.root is not None and source.output is not None
     terraform_root = repository_root / "infra" / "terraform" / source.root
@@ -967,7 +1012,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--secret", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--destination", action="append", required=True)
-    parser.add_argument("--source", choices=("terraform", "stdin", "prompt"), required=True)
+    parser.add_argument("--source", choices=("terraform", "stdin", "prompt", "bws"), required=True)
     parser.add_argument("--terraform-bin", default=os.environ.get("TERRAFORM_BIN", "terraform"))
     parser.add_argument("--sops-bin", default=os.environ.get("SOPS_BIN", "sops"))
     parser.add_argument("--vercel-bin", default=os.environ.get("VERCEL_BIN", "vercel"))

--- a/openspec/changes/bind-hosted-secret-sources-to-bws/.openspec.yaml
+++ b/openspec/changes/bind-hosted-secret-sources-to-bws/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/bind-hosted-secret-sources-to-bws/design.md
+++ b/openspec/changes/bind-hosted-secret-sources-to-bws/design.md
@@ -1,0 +1,20 @@
+## Context
+
+See proposal.md. The existing matrix already owns destination selection and source allowlists. BWS identity/shape checks belong to the shared yadm tool, not a second SDK implementation here.
+
+## Goals / Non-Goals
+
+Make the normal control-key handoff use its recorded source. Do not rotate credentials, infer a database source, change existing ciphertexts/receipts or add gateway destinations without the governed deployment inputs.
+
+## Decisions
+
+- Add source fields `bindings` (repository-relative JSON under `infra/contracts`) and `binding` (one alias). Resolve the path inside the repository before invoking `bwsx-secret get --bindings FILE NAME`; capture output and discard upstream errors. Do not fall back to stdin, prompt, inventory or a provider export if BWS fails.
+- Keep destination validation and dry-run ahead of source access. A dry-run performs no BWS call. Existing source kinds stay compatible; the documented control-key path chooses BWS.
+- The production binding records the existing verified BWS entry and canonical base64url-32 format. Authenticated decryptability remains the consumer's responsibility. No Python SDK or secret-manager credential is added to the runtime service.
+- The signed active-secret registry binds the full matrix digest, including source metadata. Adoption therefore requires a newly signed immutable registry pair and verify-only proof before the next K3s apply; existing ciphertexts, key material and selection do not change. Retain the previous pair. No cluster apply is part of adding the source adapter.
+
+## Risks / Trade-offs
+
+- Shared helper absent → explicit source failure before destination mutation; install the shared tooling rather than bypassing it.
+- Bound key has valid shape but cannot decrypt existing data → require the consumer proof before recovery/rotation acceptance; this adapter does not certify that proof.
+- Other secrets still use legacy sources → name the adoption boundary; do not claim a complete inventory migration.

--- a/openspec/changes/bind-hosted-secret-sources-to-bws/proposal.md
+++ b/openspec/changes/bind-hosted-secret-sources-to-bws/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The hosted handoff validates destinations but still requires operators to rediscover the source of the production control-plane key. Bind that source to its existing BWS entry so the routine path cannot substitute a same-named secret or a provider display placeholder.
+
+## What Changes
+
+- Add an explicit BWS source kind to the existing secret handoff matrix and CLI.
+- Record the production control-plane key's exact source binding and use the shared `bwsx-secret` validator for retrieval.
+- Document the BWS-first path while retaining deliberate stdin/prompt compatibility.
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-secret-custody`: identity-bound source retrieval for governed hosted secret delivery.
+
+### Modified Capabilities
+
+None. Destination, version, receipt and rotation rules are unchanged.
+
+## Impact
+
+Infrastructure handoff, matrix, binding data, tests and runbook only. The shared BWS tool is an operator prerequisite, not a server dependency. No live secret, database credential, encryption key, gateway destination or deployment changes in this delivery.

--- a/openspec/changes/bind-hosted-secret-sources-to-bws/specs/hosted-secret-custody/spec.md
+++ b/openspec/changes/bind-hosted-secret-sources-to-bws/specs/hosted-secret-custody/spec.md
@@ -1,0 +1,25 @@
+## Purpose
+
+Bind hosted secret delivery to recoverable, explicitly identified source entries while preserving existing governed destination and rotation controls.
+
+## ADDED Requirements
+
+### Requirement: Matrix-owned BWS source
+
+The hosted handoff SHALL support an explicit BWS source with a repository-owned binding file and one named binding. It SHALL retrieve through the shared identity/shape validator without exposing plaintext in arguments or diagnostics. Binding paths SHALL remain inside the repository's infrastructure contracts. A failed source SHALL not fall back or mutate a destination.
+
+#### Scenario: BWS is unavailable or rejects the entry
+- **WHEN** the selected BWS source fails, times out or returns a rejected value
+- **THEN** the handoff emits a content-free failure and creates no receipt or destination write
+
+#### Scenario: Dry-run checks a BWS-backed route
+- **WHEN** the operator requests a dry-run
+- **THEN** matrix and destination checks run without contacting BWS
+
+### Requirement: Explicit first-adopter coverage
+
+The production control-plane wrapping key SHALL have a recorded exact BWS project, entry ID, expected key and base64url-32 format. Its normal runbook handoff SHALL use that binding. This source check SHALL not be represented as proof of authenticated decryption or migration of unrelated credentials.
+
+#### Scenario: Existing key is delivered again
+- **WHEN** the operator chooses the documented BWS-backed control-key route
+- **THEN** the existing bound value is used without generating or rotating a key

--- a/openspec/changes/bind-hosted-secret-sources-to-bws/tasks.md
+++ b/openspec/changes/bind-hosted-secret-sources-to-bws/tasks.md
@@ -1,0 +1,8 @@
+## 1. Source adoption
+
+- [x] 1.1 Add red-first matrix/source tests, implement the bounded BWS reader and verify no fallback, no plaintext diagnostics and no access on dry-run.
+- [x] 1.2 Record the existing production control-key binding and document its BWS-backed route; verify exact matrix/binding agreement and a read-only shared-helper check.
+
+## 2. Delivery
+
+- [ ] 2.1 Run hosted handoff/infrastructure tests, privacy and strict spec validation; obtain independent security review and deliver a ready PR with evidence, closing OpenSpec after shipped completion.

--- a/tests/harness_modules.txt
+++ b/tests/harness_modules.txt
@@ -27,6 +27,7 @@ tests/test_equivalence_selection.py
 tests/test_harness_capture_caching.py
 tests/test_hcp_backend_verifier.py
 tests/test_hosted_ansible_secret_runner.py
+tests/test_hosted_bws_source.py
 tests/test_hosted_database_migration.py
 tests/test_hosted_operator.py
 tests/test_hosted_platform_operations.py

--- a/tests/test_hosted_bws_source.py
+++ b/tests/test_hosted_bws_source.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_hosted_secret_handoff import _load_module, _matrix
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_production_control_key_declares_a_matching_bws_binding():
+    module = _load_module()
+    matrix = module.load_matrix(ROOT / "infra/contracts/secret-destinations-v1.json")
+    sources = matrix.secrets["control_plane_key"].sources
+    assert sources[0].kind == "bws"
+    document = json.loads((ROOT / sources[0].bindings).read_text())
+    binding = document["bindings"][sources[0].binding]
+    assert document["environment"] == "production"
+    assert binding["format"] == "base64url-32"
+    destination = next(iter(matrix.secrets["control_plane_key"].destinations.values()))
+    assert binding["env"] == destination.fields["name"]
+
+
+def source_matrix(tmp_path: Path, **overrides: object) -> Path:
+    matrix = _matrix()
+    matrix["secrets"]["control_plane_key"]["sources"] = [
+        {
+            "kind": "bws",
+            "bindings": "infra/contracts/bws-production-v1.json",
+            "binding": "control-plane-key",
+            **overrides,
+        }
+    ]
+    path = tmp_path / "matrix.json"
+    path.write_text(json.dumps(matrix))
+    binding = tmp_path / "infra/contracts/bws-production-v1.json"
+    binding.parent.mkdir(parents=True, exist_ok=True)
+    binding.write_text("{}")
+    return path
+
+
+def test_bws_source_uses_only_the_matrix_binding(tmp_path, monkeypatch):
+    module = _load_module()
+    matrix = module.load_matrix(source_matrix(tmp_path))
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command, 0, stdout=b"fixture-control-key", stderr=b"ignored"
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    result = module._read_secret(
+        source_kind="bws",
+        secret_spec=matrix.secrets["control_plane_key"],
+        repository_root=tmp_path,
+        terraform_bin="must-not-run",
+    )
+    assert result == b"fixture-control-key"
+    assert calls == [
+        (
+            [
+                "bwsx-secret",
+                "get",
+                "--bindings",
+                str(tmp_path / "infra/contracts/bws-production-v1.json"),
+                "control-plane-key",
+            ],
+            {"capture_output": True, "check": False, "timeout": 30},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "bindings",
+    [
+        "../other.json",
+        "/tmp/other.json",
+        "infra/contracts/../other.json",
+        "infra/not-contracts/other.json",
+        "infra/contracts/file.txt",
+        "infra/contracts\\other.json",
+    ],
+)
+def test_bws_matrix_rejects_non_contract_paths(tmp_path, bindings):
+    module = _load_module()
+    with pytest.raises(module.HandoffError, match="BWS binding"):
+        module.load_matrix(source_matrix(tmp_path, bindings=bindings))
+
+
+@pytest.mark.parametrize("failure", ["exit", "timeout", "missing", "placeholder"])
+def test_bws_source_failure_is_content_free_and_never_falls_back(tmp_path, monkeypatch, failure):
+    module = _load_module()
+    matrix = module.load_matrix(source_matrix(tmp_path))
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(command, 30, output=b"private-value")
+        if failure == "missing":
+            raise FileNotFoundError("private-value")
+        return subprocess.CompletedProcess(
+            command, 1 if failure == "exit" else 0, stdout=b"[SENSITIVE]", stderr=b"private-value"
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    with pytest.raises(module.HandoffError) as error:
+        module._read_secret(
+            source_kind="bws",
+            secret_spec=matrix.secrets["control_plane_key"],
+            repository_root=tmp_path,
+            terraform_bin="must-not-run",
+        )
+    assert "private-value" not in str(error.value)
+    assert len(calls) == 1
+
+
+def test_bws_dry_run_reads_no_secret(tmp_path, monkeypatch):
+    module = _load_module()
+    matrix_path = source_matrix(tmp_path)
+    # A valid existing local destination lets this test isolate dry-run ordering.
+    raw = json.loads(matrix_path.read_text())
+    raw["secrets"]["control_plane_key"]["destinations"] = {
+        "escrow.control.active": {
+            "kind": "sops_escrow",
+            "slot": "active",
+            "target": "infra/secrets/key.{version}.sops.json",
+            "secret_key": "key",
+        },
+    }
+    matrix_path.write_text(json.dumps(raw))
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("dry-run contacted a secret source")
+
+    monkeypatch.setattr(module.subprocess, "run", forbidden)
+    module.execute_handoff(
+        matrix_path=matrix_path,
+        repository_root=tmp_path,
+        secret_name="control_plane_key",
+        version="v1",
+        destination_ids=("escrow.control.active",),
+        source_kind="bws",
+        terraform_bin="terraform",
+        sops_bin="sops",
+        vercel_bin="vercel",
+        vercel_project=None,
+        dry_run=True,
+    )
+    assert not (tmp_path / "infra/secrets").exists()


### PR DESCRIPTION
## Summary

Make the existing production control-plane key discoverable through a recorded BWS binding and the normal secret handoff command. This removes manual source rediscovery without changing the key or its consumers.

- Add a bounded `bws` source that captures the shared helper's output and fails without fallback or destination writes.
- Record the existing entry identity and document custody checks versus authenticated decryptability.
- Preserve dry-run, destination validation, receipts and explicit stdin/prompt compatibility.

Requires the shared `bwsx-secret` tooling from [yadm #365](https://github.com/Artexis10/yadm/pull/365). Before the next K3s secret apply, re-sign and verify an immutable active registry pair: its signature binds the changed full matrix digest. Existing ciphertexts and selection stay unchanged.

## Verification

- Hosted suite: **1314 passed, 112 skipped** (platform-specific and opt-in infrastructure checks).
- Focused source/handoff tests: **57 passed**, one opt-in real-SOPS skip.
- Read-only production binding check: **validated 1 secret binding**; no value printed and no provider write performed.
- Independent security review: no blocking findings.
- Ruff, mypy, repository privacy, 49 ciphertext-artifact validation, and strict OpenSpec validation (**188 items**) pass.

No credentials were rotated, deployed or migrated beyond recording this source binding. OpenSpec closure remains tied to shipped completion.
