### PR TITLE
feat(governance): add consolidation admission and response guards

### DIFF
--- a/openspec/changes/add-governed-vault-consolidation/design.md
+++ b/openspec/changes/add-governed-vault-consolidation/design.md
@@ -198,7 +198,8 @@ pending fence into its permanent post-retirement rollback rule. `recover`
 resumes only a recorded operation journal; it is not an
 alternate unreviewed plan path.
 
-The generated command schema is a closed discriminated union
+The generated structural command schema and mandatory runtime validator derive
+from one closed discriminated union
 `exomem.consolidate-memory-request/v1`, not one flat bag of optional fields. All
 variants require `schema` and `action`; all strings are NFC and bounded to 512
 UTF-8 bytes unless a smaller bound is stated; ids are canonical lowercase UUIDv4
@@ -219,6 +220,19 @@ contingency facts behind it. Opaque refs/cursors/render-session
 refs are 1..512 UTF-8 bytes, contain no NUL, and are never path-interpreted.
 Revisions and page ordinals are JSON integers (not strings/floats), with page
 ordinals 0..2^31-1. The enum spellings in the table are closed.
+
+JSON Schema describes the closed wire structure and standard-keyword bounds;
+it is not the complete admission boundary. The same mandatory semantic validator
+runs on MCP, REST, CLI, and Hosted after trusted owner admission and before
+coercion or action-specific work. It enforces valid UTF-8, NFC, byte limits,
+exact decoded integers excluding booleans/integral floats, and conditions that
+require authoritative run state. Raw decoders reject duplicate keys before
+object construction loses them. Adapters preserve decoded values rather than
+normalizing/coercing rejected input into validity, and no shape-only validator
+can authorize dispatch. Generated descriptions document these semantic checks;
+they do not claim that stock JSON Schema enforces byte/NFC/decoded-number
+semantics. Parity tests compare full admission across all surfaces, separately
+covering structural negatives and structurally admissible semantic negatives.
 
 | Action | Required action fields | Optional action fields | Forbidden notes |
 |---|---|---|---|

--- a/openspec/changes/add-governed-vault-consolidation/specs/command-surface/spec.md
+++ b/openspec/changes/add-governed-vault-consolidation/specs/command-surface/spec.md
@@ -238,7 +238,8 @@ transition SHALL be identical.
 
 ### Requirement: Every action is one closed tagged request with explicit retry identity
 
-Generated and runtime validation SHALL use the same closed discriminated union
+Generated structural schemas and mandatory runtime validation SHALL derive from
+the same closed discriminated union
 `exomem.consolidate-memory-request/v1`. Every variant SHALL require `schema` and
 `action`, reject unknown/duplicate/null/cross-action fields, accept NFC bounded
 strings and canonical lowercase UUIDv4 ids, and treat artifact/token/attestation
@@ -262,6 +263,20 @@ bytes, contain no NUL, and SHALL not be interpreted as a filesystem path. Enum
 spellings shown below are exhaustive. Revisions, page ordinals, and limits SHALL
 be JSON integers, never strings or floats; limits are 1..200, page ordinals are
 0..2^31-1, and revisions are 0..2^53-1.
+
+Generated JSON Schema SHALL describe the closed request structure, action
+branches, required/forbidden fields, enums, and standard-keyword bounds. Passing
+that structural schema alone SHALL NOT admit a request. Every MCP, REST, CLI,
+and Hosted adapter SHALL invoke the same mandatory semantic validator, after
+trusted owner admission and before coercion or action-specific work, to enforce
+valid UTF-8, NFC, byte-length bounds, exact decoded integer types (excluding
+booleans and integral floats), and conditions derived from trusted run state.
+The raw decoder SHALL reject duplicate keys before object construction loses
+them. Adapters SHALL preserve decoded string and numeric values for semantic
+validation rather than normalizing or coercing an invalid request into validity.
+These checks SHALL remain unconditional; no schema-only or shape-only path may
+dispatch work. Generated descriptions SHALL identify the mandatory semantic
+checks without claiming that standard JSON Schema keywords enforce them.
 
 | Action | Required fields beyond `schema`,`action` | Optional/conditional fields | Forbidden |
 |---|---|---|---|
@@ -677,6 +692,21 @@ content-free sealed outcomes, idempotent retry terminals, and trusted-context
 handling across MCP, REST, CLI, and v5 Hosted. OpenAPI and generated capability
 documentation SHALL describe the same finite schemas, owner-inclusive seal,
 three distinct approvals, and Exomem-mediated enforcement boundary.
+
+Parity SHALL mean identical full admission outcomes across surfaces, using the
+shared structural definition, raw duplicate-key rejection, and mandatory semantic
+validator together. Tests SHALL distinguish structurally invalid requests from
+structurally admissible values that fail semantic validation. They SHALL include
+non-NFC strings, invalid UTF-8 strings, multibyte strings exceeding their byte
+bound, booleans and integral floats in integer fields, and missing or mismatched
+trusted run-state conditions. A stock JSON Schema validator accepting a semantic
+negative SHALL NOT count as full admission or justify weakening a runtime rule.
+
+#### Scenario: Structural acceptance cannot bypass semantic validation
+
+- **WHEN** a request passes the generated structural schema but violates a required byte, Unicode, exact-integer, or trusted-run-state rule
+- **THEN** the mandatory shared validator refuses it on MCP, REST, CLI, and Hosted before action-specific work
+- **AND** adapters neither coerce it into validity nor dispatch through a shape-only validation path
 
 #### Scenario: Generated schema changes are reviewed
 

--- a/openspec/changes/add-governed-vault-consolidation/tasks.md
+++ b/openspec/changes/add-governed-vault-consolidation/tasks.md
@@ -944,8 +944,17 @@ binds that reference and observed digest; no caller field selects K.
   `nonterminal-contingency|terminal-plan`, and retire clearance/finalize branches,
   bounded UUID/ref/SHA-256/int/string types, shared envelope/errors, conservative
   write-capable annotation, and `invocation_is_read_only == true` only for `status`.
-  Generated JSON Schema and runtime must implement the same closed tagged
-  `oneOf`; omitted/unknown/null/duplicate/cross-action fields fail closed. All ten
+  Generated structural JSON Schema and mandatory runtime validation must derive
+  from the same closed tagged `oneOf`; omitted/unknown/null/cross-action fields
+  fail structural validation and raw decoders refuse duplicate keys before
+  object construction. Add separate semantic-negative fixtures for invalid
+  UTF-8, non-NFC strings, multibyte byte-limit overflow, booleans/integral floats
+  in integer fields, and missing/mismatched trusted run-state conditions. Prove
+  every surface calls the same mandatory semantic validator after owner admission
+  and before coercion or action-specific work; schema-only/shape-only validation
+  never permits dispatch, and adapters never normalize invalid input into validity.
+  Generated descriptions document this structural/semantic split without claiming
+  stock-schema enforcement of the semantic rules. All ten
   other actions require explicit operation id (CLI persists/prints any generated
   id before request), expected run revision, writer/control admission,
   idempotency, and the action-tagged stable `exomem.consolidation-terminal/v1`
@@ -957,7 +966,8 @@ binds that reference and observed digest; no caller field selects K.
   `trusted_outputs` keys/types. Status uses `outcome=observed`; every mutation's
   durable logical terminal uses `outcome=committed`. Required missing keys,
   extras, wrong branch, forbidden nulls, unknown next action, or wrong count/ref
-  types fail generated and runtime validation. Test
+  structural types fail generated and runtime validation; exact integer and
+  Unicode/byte constraints also pass the mandatory semantic fixture gate. Test
   status cursor; the exact successor-context ref/digest required together on
   every shared-table product terminal (including both rollback-complete modes,
   repair targets, retirement finalize, and status-only pending-forward),

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -3607,7 +3607,9 @@ def _core_op_main(argv: list[str]) -> int:
 
     preverified_root = None
     preverified_admission = None
-    if not authorization_carrier.is_absent and argv and argv[0] in cmds:
+    if argv and argv[0] in cmds and (
+        not authorization_carrier.is_absent or argv[0] == "consolidate_memory"
+    ):
         try:
             preverified_root, preverified_admission = (
                 product_invoke.verify_local_authorization_transport(
@@ -3674,6 +3676,7 @@ def _core_op_main(argv: list[str]) -> int:
                 cmd,
                 raw,
                 preverified_admission,
+                vault_root=root,
             )
         if cmd.name == "edit_memory":
             kwargs = _normalize_cli_edit(cmd, raw, cli_ops)

--- a/src/exomem/governance/authorization_transport.py
+++ b/src/exomem/governance/authorization_transport.py
@@ -240,6 +240,15 @@ def _pair_values(pairs: _ObjectPairs, key: str) -> list[object]:
     return [value for candidate, value in pairs if candidate == key]
 
 
+def _has_duplicate_keys(value: object) -> bool:
+    if isinstance(value, _ObjectPairs):
+        keys = [key for key, _item in value]
+        return len(keys) != len(set(keys)) or any(_has_duplicate_keys(item) for _key, item in value)
+    if isinstance(value, list):
+        return any(_has_duplicate_keys(item) for item in value)
+    return False
+
+
 def _sanitize_call(value: _ObjectPairs) -> tuple[object, CredentialCarrier, str | None, dict[str, object]]:
     method_values = _pair_values(value, "method")
     if "tools/call" not in method_values:
@@ -273,7 +282,12 @@ def _sanitize_call(value: _ObjectPairs) -> tuple[object, CredentialCarrier, str 
         or len(params_values) != 1
         or len(arguments_values) != 1
     )
-    if ambiguous_envelope or len(carrier_values) > 1:
+    consolidation_call = any(
+        "consolidate_memory" in _pair_values(item, "name")
+        for item in params_values if isinstance(item, _ObjectPairs)
+    )
+    if (ambiguous_envelope or len(carrier_values) > 1
+            or (consolidation_call and _has_duplicate_keys(value))):
         carrier = CredentialCarrier.invalid()
     elif len(carrier_values) == 1:
         carrier = CredentialCarrier.from_value(carrier_values[0])
@@ -314,7 +328,7 @@ def sanitize_mcp_http_body(raw: bytes) -> SanitizedMcpRequest:
     if not isinstance(raw, bytes) or len(raw) > _MAX_MCP_JSON_BYTES:
         raise AuthorizationEnvelopeUnavailable
     try:
-        parsed = json.loads(raw, object_pairs_hook=_ObjectPairs)
+        parsed = json.loads(raw.decode("utf-8"), object_pairs_hook=_ObjectPairs)
     except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
         raise AuthorizationEnvelopeUnavailable from None
 
@@ -332,13 +346,13 @@ def sanitize_mcp_http_body(raw: bytes) -> SanitizedMcpRequest:
                 sanitized_items.append(_pairs_to_value(item))
         if has_tool_call:
             raise AtomicMcpBatchRefusal
-        body = json.dumps(sanitized_items, separators=(",", ":"), ensure_ascii=False).encode()
+        body = json.dumps(sanitized_items, separators=(",", ":"), ensure_ascii=True).encode()
         return SanitizedMcpRequest(body, CredentialCarrier.absent(), None, {})
 
     if not isinstance(parsed, _ObjectPairs):
         raise AuthorizationEnvelopeUnavailable
     sanitized, carrier, tool_name, arguments = _sanitize_call(parsed)
-    body = json.dumps(sanitized, separators=(",", ":"), ensure_ascii=False).encode()
+    body = json.dumps(sanitized, separators=(",", ":"), ensure_ascii=True).encode()
     return SanitizedMcpRequest(body, carrier, tool_name, arguments)
 
 
@@ -702,7 +716,9 @@ class AuthorizationSessionMiddleware(Middleware):
         context: MiddlewareContext[mcp.types.CallToolRequestParams],
         call_next,
     ):
-        arguments = dict(context.message.arguments or {})
+        from . import consolidation_owner, consolidation_request
+
+        arguments = context.message.arguments or {}
         request_context = context.fastmcp_context.request_context
         protected_carrier = None
         if request_context is not None:
@@ -712,7 +728,7 @@ class AuthorizationSessionMiddleware(Middleware):
                 protected_carrier = candidate
         if MCP_CREDENTIAL_PARAMETER in arguments:
             carrier = CredentialCarrier.from_value(
-                arguments.pop(MCP_CREDENTIAL_PARAMETER)
+                arguments[MCP_CREDENTIAL_PARAMETER]
             )
         elif protected_carrier is not None:
             carrier = protected_carrier
@@ -729,15 +745,27 @@ class AuthorizationSessionMiddleware(Middleware):
                     now=int(time.time()),
                 )
             )
-            rule = credential_rule(context.message.name, arguments)
-            bound = enforce_credential_rule(admission, rule)
+            sanitized_arguments = dict(arguments)
+            sanitized_arguments.pop(MCP_CREDENTIAL_PARAMETER, None)
+            if context.message.name == "consolidate_memory":
+                bound = await anyio.to_thread.run_sync(
+                    partial(
+                        consolidation_owner.bind_local_owner,
+                        self.vault_root, principal=admission.principal,
+                        arguments=sanitized_arguments, now=int(time.time()),
+                    )
+                )
+            else:
+                rule = credential_rule(context.message.name, sanitized_arguments)
+                bound = enforce_credential_rule(admission, rule)
+        except (consolidation_owner.ConsolidationOwnerUnavailable,
+                consolidation_request.ConsolidationRequestUnavailable) as error:
+            raise McpError(ErrorData(code=-32000, message=str(error))) from None
         except AuthorizationContextUnavailable as error:
             raise McpError(ErrorData(code=-32000, message=str(error))) from None
         except AuthorizationRouteUnclassified as error:
             raise McpError(ErrorData(code=-32000, message=str(error))) from None
 
-        sanitized_message = context.message.model_copy(
-            update={"arguments": arguments}
-        )
+        sanitized_message = context.message.model_copy(update={"arguments": sanitized_arguments})
         with principal_module.request_scope(bound):
             return await call_next(context.copy(message=sanitized_message))

--- a/src/exomem/governance/authorization_transport.py
+++ b/src/exomem/governance/authorization_transport.py
@@ -485,7 +485,7 @@ async def sanitized_stdio_server(
 
     if stdin is None:
         stdin = anyio.wrap_file(
-            TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")
+            TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="surrogateescape")
         )
     if stdout is None:
         stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))

--- a/src/exomem/governance/consolidation_owner.py
+++ b/src/exomem/governance/consolidation_owner.py
@@ -13,7 +13,7 @@ import secrets
 import sqlite3
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, cast
 
 from . import authorization_custody, authorization_session_lifecycle, consolidation_identity, store
 from .authorization_session_lifecycle import AuthorizationSessionContext
@@ -71,6 +71,8 @@ class ConsolidationOwnerContext:
     """Opaque internal capability, never a product argument or serialized value."""
 
     __slots__ = ("__facts", "__seal")
+    __facts: _OwnerFacts
+    __seal: object
 
     def __init__(self, facts: _OwnerFacts, *, seal: object) -> None:
         if seal is not _SEAL or type(facts) is not _OwnerFacts:
@@ -108,20 +110,21 @@ class ConsolidationOwnerContext:
 def _session(who: object, *, now: int) -> AuthorizationSessionContext:
     if type(now) is not int or now < 1 or type(who) is not RequestPrincipal:
         _fail()
+    principal = cast(RequestPrincipal, who)
     if (
-        not who.resolved
-        or who.audience_id != OWNER_AUDIENCE
-        or who.surface not in _LOCAL_SURFACES
-        or who.issuer_family != _LOCAL_SURFACES[who.surface]
+        not principal.resolved
+        or principal.audience_id != OWNER_AUDIENCE
+        or principal.surface not in _LOCAL_SURFACES
+        or principal.issuer_family != _LOCAL_SURFACES[principal.surface]
     ):
         _fail()
-    session = who.verified_authorization_session
+    session = principal.verified_authorization_session
     if (
         type(session) is not AuthorizationSessionContext
-        or session.principal_id != who.audience_id
-        or session.issuer_family != who.issuer_family
+        or session.principal_id != principal.audience_id
+        or session.issuer_family != principal.issuer_family
         or not session.session_id
-        or session.session_id != who.authorization_session_id
+        or session.session_id != principal.authorization_session_id
         or type(session.expires_at) is not int
         or now >= session.expires_at
         or type(session.credential_generation) is not int
@@ -141,15 +144,20 @@ def _action(arguments: object) -> str:
     schema = arguments.get("schema")
     action = arguments.get("action")
     if (
-        type(schema) is not str or schema != REQUEST_SCHEMA_NAME
-        or type(action) is not str or action not in ACTIONS
+        type(schema) is not str
+        or schema != REQUEST_SCHEMA_NAME
+        or type(action) is not str
+        or action not in ACTIONS
     ):
         _fail()
     return action
 
 
 def _durable_session(
-    vault_root: Path, *, principal: RequestPrincipal, now: int,
+    vault_root: Path,
+    *,
+    principal: RequestPrincipal,
+    now: int,
 ) -> AuthorizationSessionContext:
     """Recheck issuance and current custody; public context fields are not proof."""
     session = _session(principal, now=now)
@@ -158,13 +166,19 @@ def _durable_session(
         custody = authorization_custody.load_authorization_custody(vault_root, now=now)
         connection = store.open_authorization_session_connection(vault_root)
         return authorization_session_lifecycle.status_verified_session(
-            connection, custody=custody, context=session, now=now,
+            connection,
+            custody=custody,
+            context=session,
+            now=now,
         )
     except (
         authorization_custody.AuthorizationCustodyUnavailable,
         authorization_session_lifecycle.AuthorizationSessionUnavailable,
         store.UnsupportedGovernanceSchema,
-        OSError, sqlite3.Error, TypeError, ValueError,
+        OSError,
+        sqlite3.Error,
+        TypeError,
+        ValueError,
     ):
         _fail()
     finally:
@@ -176,21 +190,23 @@ def _durable_session(
 
 
 def _check_identity(
-    identity: object, session: AuthorizationSessionContext,
+    identity: object,
+    session: AuthorizationSessionContext,
 ) -> consolidation_identity.ConsolidationCellIdentity:
     if type(identity) is not consolidation_identity.ConsolidationCellIdentity:
         _fail()
+    checked = cast(consolidation_identity.ConsolidationCellIdentity, identity)
     if (
-        identity.schema != consolidation_identity.IDENTITY_SCHEMA
-        or identity.vault_id != session.logical_vault_id
-        or identity.cell_id != session.cell_id
-        or identity.cell_id == identity.vault_id
-        or identity.installation_id in {identity.vault_id, identity.cell_id}
-        or type(identity.installation_generation) is not int
-        or identity.installation_generation < 1
+        checked.schema != consolidation_identity.IDENTITY_SCHEMA
+        or checked.vault_id != session.logical_vault_id
+        or checked.cell_id != session.cell_id
+        or checked.cell_id == checked.vault_id
+        or checked.installation_id in {checked.vault_id, checked.cell_id}
+        or type(checked.installation_generation) is not int
+        or checked.installation_generation < 1
     ):
         _fail()
-    return identity
+    return checked
 
 
 def admit_local_owner(
@@ -218,12 +234,15 @@ def admit_local_owner(
     except (
         consolidation_identity.ConsolidationIdentityUnavailable,
         authorization_custody.AuthorizationCustodyUnavailable,
-        OSError, TypeError, ValueError,
+        OSError,
+        TypeError,
+        ValueError,
     ):
         _fail()
     facts = _OwnerFacts(
         schema="ConsolidationOwnerContext/v1",
-        vault_id=identity.vault_id, cell_id=identity.cell_id,
+        vault_id=identity.vault_id,
+        cell_id=identity.cell_id,
         installation_id=identity.installation_id,
         installation_generation=identity.installation_generation,
         active_fence_digest=identity.active_fence_digest,
@@ -231,13 +250,14 @@ def admit_local_owner(
         principal_id=principal.audience_id,
         authorization_session_id=session.session_id,
         credential_generation=session.credential_generation,
-        purpose="vault-consolidation", action=action,
-        issuer_family=session.issuer_family, surface=principal.surface,
-        issued_at=now, expires_at=min(now + _CONTEXT_TTL_SECONDS, session.expires_at),
+        purpose="vault-consolidation",
+        action=action,
+        issuer_family=session.issuer_family,
+        surface=principal.surface,
+        issued_at=now,
+        expires_at=min(now + _CONTEXT_TTL_SECONDS, session.expires_at),
         nonce=secrets.token_hex(16),
-        verifier_fingerprint=hashlib.sha256(
-            identity.machine_key_id.encode("utf-8")
-        ).hexdigest(),
+        verifier_fingerprint=hashlib.sha256(identity.machine_key_id.encode("utf-8")).hexdigest(),
     )
     return ConsolidationOwnerContext(facts, seal=_SEAL)
 
@@ -270,20 +290,26 @@ def require_owner_context(
         or facts.credential_generation != session.credential_generation
         or facts.issuer_family != principal.issuer_family
         or facts.surface != principal.surface
-        or facts.verifier_fingerprint != hashlib.sha256(
-            identity.machine_key_id.encode("utf-8")
-        ).hexdigest()
+        or facts.verifier_fingerprint
+        != hashlib.sha256(identity.machine_key_id.encode("utf-8")).hexdigest()
     ):
         _fail()
     return facts
 
 
 def bind_local_owner(
-    vault_root: Path, *, principal: RequestPrincipal, arguments: object, now: int,
+    vault_root: Path,
+    *,
+    principal: RequestPrincipal,
+    arguments: object,
+    now: int,
 ) -> RequestPrincipal:
     """Inject the exact owner capability into an already-authenticated principal."""
     context = admit_local_owner(
-        vault_root, principal=principal, arguments=arguments, now=now,
+        vault_root,
+        principal=principal,
+        arguments=arguments,
+        now=now,
     )
     _validate_admitted_request(vault_root, arguments, context._verified_facts())
     return replace(principal, consolidation_owner_context=context)
@@ -306,7 +332,11 @@ def require_local_owner_session(principal: RequestPrincipal, *, now: int) -> Non
 
 
 def require_bound_request(
-    vault_root: Path, *, principal: RequestPrincipal, arguments: object, now: int,
+    vault_root: Path,
+    *,
+    principal: RequestPrincipal,
+    arguments: object,
+    now: int,
 ) -> None:
     """Revalidate the selected installation before dispatch or writer admission."""
     require_injected_owner(principal, now=now)
@@ -317,8 +347,11 @@ def require_bound_request(
     except (consolidation_identity.ConsolidationIdentityUnavailable, OSError):
         _fail()
     facts = require_owner_context(
-        principal.consolidation_owner_context, principal=principal,
-        identity=identity, action=action, now=now,
+        principal.consolidation_owner_context,
+        principal=principal,
+        identity=identity,
+        action=action,
+        now=now,
     )
     _validate_admitted_request(vault_root, arguments, facts)
 
@@ -329,17 +362,24 @@ def _validate_admitted_request(vault_root: Path, arguments: object, facts: _Owne
 
     request = consolidation_request._validate_request_fields(arguments)  # noqa: SLF001
     mode = None
-    if (request["action"] == "plan" and request["operation"] == "materialize"
-            and request["plan_kind"] == "cutover"):
+    if (
+        request["action"] == "plan"
+        and request["operation"] == "materialize"
+        and request["plan_kind"] == "cutover"
+    ):
         try:
-            record = consolidation_run_state.ConsolidationRunStore(vault_root).load(request["run_id"])
+            record = consolidation_run_state.ConsolidationRunStore(vault_root).load(
+                request["run_id"]
+            )
         except consolidation_run_state.ConsolidationRunUnavailable:
             raise consolidation_request.ConsolidationRequestUnavailable from None
         identity = record.identity
-        if (identity.destination_vault_id != facts.vault_id
-                or identity.destination_installation_id != facts.installation_id
-                or identity.destination_generation != facts.installation_generation
-                or identity.destination_fence_digest != facts.active_fence_digest):
+        if (
+            identity.destination_vault_id != facts.vault_id
+            or identity.destination_installation_id != facts.installation_id
+            or identity.destination_generation != facts.installation_generation
+            or identity.destination_fence_digest != facts.active_fence_digest
+        ):
             raise consolidation_request.ConsolidationRequestUnavailable
         mode = identity.run_mode
     consolidation_request.validate_request(request, trusted_run_mode=mode)

--- a/src/exomem/governance/consolidation_owner.py
+++ b/src/exomem/governance/consolidation_owner.py
@@ -1,0 +1,345 @@
+"""Bearer-free, request-scoped owner admission for consolidation adapters.
+
+Trusted transports call this after verifying their protected session carrier,
+before normal argument validation. Neither an ordinary owner principal nor an
+unbound library invocation is sufficient. This capability does not acknowledge
+a rendered page or provide the separate human confirmation for approval.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import sqlite3
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import NoReturn
+
+from . import authorization_custody, authorization_session_lifecycle, consolidation_identity, store
+from .authorization_session_lifecycle import AuthorizationSessionContext
+from .principal import OWNER_AUDIENCE, RequestPrincipal
+
+_SEAL = object()
+_CONTEXT_TTL_SECONDS = 60
+_LOCAL_SURFACES = {
+    "cli": "cli-local-owner",
+    "mcp": "mcp-local-stdio",
+    "rest": "rest-api-key",
+}
+
+
+class ConsolidationOwnerUnavailable(RuntimeError):
+    """Equivalent refusal for all missing, expired, or cross-bound owners."""
+
+    code = "CONSOLIDATION_OWNER_UNAVAILABLE"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation owner is unavailable")
+
+    def as_public_dict(self) -> dict[str, str | None]:
+        return {"code": self.code, "message": str(self), "remediation": None}
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationOwnerUnavailable from None
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _OwnerFacts:
+    schema: str
+    vault_id: str
+    cell_id: str
+    installation_id: str
+    installation_generation: int
+    active_fence_digest: str
+    root_binding_digest: str
+    principal_id: str
+    authorization_session_id: str
+    credential_generation: int
+    purpose: str
+    action: str
+    issuer_family: str
+    surface: str
+    issued_at: int
+    expires_at: int
+    nonce: str
+    verifier_fingerprint: str
+    human_confirmation: bool = False
+
+
+class ConsolidationOwnerContext:
+    """Opaque internal capability, never a product argument or serialized value."""
+
+    __slots__ = ("__facts", "__seal")
+
+    def __init__(self, facts: _OwnerFacts, *, seal: object) -> None:
+        if seal is not _SEAL or type(facts) is not _OwnerFacts:
+            _fail()
+        object.__setattr__(self, "_ConsolidationOwnerContext__facts", facts)
+        object.__setattr__(self, "_ConsolidationOwnerContext__seal", seal)
+
+    def __repr__(self) -> str:
+        return "<ConsolidationOwnerContext process-local>"
+
+    def __setattr__(self, _name: str, _value: object) -> NoReturn:
+        raise TypeError("consolidation owner context is immutable")
+
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("consolidation owner context is process-local")
+
+    def __reduce_ex__(self, _protocol: object) -> NoReturn:
+        raise TypeError("consolidation owner context is process-local")
+
+    def __copy__(self) -> NoReturn:
+        raise TypeError("consolidation owner context is process-local")
+
+    def __deepcopy__(self, _memo: object) -> NoReturn:
+        raise TypeError("consolidation owner context is process-local")
+
+    def _verified_facts(self) -> _OwnerFacts:
+        try:
+            if self.__seal is _SEAL and type(self.__facts) is _OwnerFacts:
+                return self.__facts
+        except AttributeError:
+            pass
+        _fail()
+
+
+def _session(who: object, *, now: int) -> AuthorizationSessionContext:
+    if type(now) is not int or now < 1 or type(who) is not RequestPrincipal:
+        _fail()
+    if (
+        not who.resolved
+        or who.audience_id != OWNER_AUDIENCE
+        or who.surface not in _LOCAL_SURFACES
+        or who.issuer_family != _LOCAL_SURFACES[who.surface]
+    ):
+        _fail()
+    session = who.verified_authorization_session
+    if (
+        type(session) is not AuthorizationSessionContext
+        or session.principal_id != who.audience_id
+        or session.issuer_family != who.issuer_family
+        or not session.session_id
+        or session.session_id != who.authorization_session_id
+        or type(session.expires_at) is not int
+        or now >= session.expires_at
+        or type(session.credential_generation) is not int
+        or session.credential_generation < 1
+    ):
+        _fail()
+    return session
+
+
+def _action(arguments: object) -> str:
+    # No iteration, copying, coercion, hashing, or validation of action fields.
+    # A dict subclass is not a transport-decoded envelope.
+    from .consolidation_request import ACTIONS, REQUEST_SCHEMA_NAME
+
+    if type(arguments) is not dict:
+        _fail()
+    schema = arguments.get("schema")
+    action = arguments.get("action")
+    if (
+        type(schema) is not str or schema != REQUEST_SCHEMA_NAME
+        or type(action) is not str or action not in ACTIONS
+    ):
+        _fail()
+    return action
+
+
+def _durable_session(
+    vault_root: Path, *, principal: RequestPrincipal, now: int,
+) -> AuthorizationSessionContext:
+    """Recheck issuance and current custody; public context fields are not proof."""
+    session = _session(principal, now=now)
+    connection: sqlite3.Connection | None = None
+    try:
+        custody = authorization_custody.load_authorization_custody(vault_root, now=now)
+        connection = store.open_authorization_session_connection(vault_root)
+        return authorization_session_lifecycle.status_verified_session(
+            connection, custody=custody, context=session, now=now,
+        )
+    except (
+        authorization_custody.AuthorizationCustodyUnavailable,
+        authorization_session_lifecycle.AuthorizationSessionUnavailable,
+        store.UnsupportedGovernanceSchema,
+        OSError, sqlite3.Error, TypeError, ValueError,
+    ):
+        _fail()
+    finally:
+        if connection is not None:
+            try:
+                connection.close()
+            except sqlite3.Error:
+                pass
+
+
+def _check_identity(
+    identity: object, session: AuthorizationSessionContext,
+) -> consolidation_identity.ConsolidationCellIdentity:
+    if type(identity) is not consolidation_identity.ConsolidationCellIdentity:
+        _fail()
+    if (
+        identity.schema != consolidation_identity.IDENTITY_SCHEMA
+        or identity.vault_id != session.logical_vault_id
+        or identity.cell_id != session.cell_id
+        or identity.cell_id == identity.vault_id
+        or identity.installation_id in {identity.vault_id, identity.cell_id}
+        or type(identity.installation_generation) is not int
+        or identity.installation_generation < 1
+    ):
+        _fail()
+    return identity
+
+
+def admit_local_owner(
+    vault_root: Path,
+    *,
+    principal: RequestPrincipal,
+    arguments: object,
+    now: int,
+) -> ConsolidationOwnerContext:
+    """Bind a transport-verified local owner session to one exact request action.
+
+    CLI's session must originate in the protected descriptor adapter; the normal
+    local-owner default has no verified session and is refused. Loading the
+    authenticated identity also verifies the held root's actual OS owner and
+    current registration. No adoption, enrollment, or session issuance occurs.
+    Hosted entitlement is a separate trust source and cannot enter this adapter.
+    """
+    session = _durable_session(vault_root, principal=principal, now=now)
+    action = _action(arguments)
+    try:
+        identity = _check_identity(
+            consolidation_identity.load_local_identity(Path(vault_root), now=now),
+            session,
+        )
+    except (
+        consolidation_identity.ConsolidationIdentityUnavailable,
+        authorization_custody.AuthorizationCustodyUnavailable,
+        OSError, TypeError, ValueError,
+    ):
+        _fail()
+    facts = _OwnerFacts(
+        schema="ConsolidationOwnerContext/v1",
+        vault_id=identity.vault_id, cell_id=identity.cell_id,
+        installation_id=identity.installation_id,
+        installation_generation=identity.installation_generation,
+        active_fence_digest=identity.active_fence_digest,
+        root_binding_digest=identity.root_binding_digest,
+        principal_id=principal.audience_id,
+        authorization_session_id=session.session_id,
+        credential_generation=session.credential_generation,
+        purpose="vault-consolidation", action=action,
+        issuer_family=session.issuer_family, surface=principal.surface,
+        issued_at=now, expires_at=min(now + _CONTEXT_TTL_SECONDS, session.expires_at),
+        nonce=secrets.token_hex(16),
+        verifier_fingerprint=hashlib.sha256(
+            identity.machine_key_id.encode("utf-8")
+        ).hexdigest(),
+    )
+    return ConsolidationOwnerContext(facts, seal=_SEAL)
+
+
+def require_owner_context(
+    context: object,
+    *,
+    principal: RequestPrincipal,
+    identity: consolidation_identity.ConsolidationCellIdentity,
+    action: str,
+    now: int,
+) -> _OwnerFacts:
+    """Recheck an injected capability against the current trusted binding."""
+    session = _session(principal, now=now)
+    identity = _check_identity(identity, session)
+    if type(context) is not ConsolidationOwnerContext:
+        _fail()
+    facts = context._verified_facts()
+    if (
+        not facts.issued_at <= now < facts.expires_at
+        or facts.action != action
+        or facts.vault_id != identity.vault_id
+        or facts.cell_id != identity.cell_id
+        or facts.installation_id != identity.installation_id
+        or facts.installation_generation != identity.installation_generation
+        or facts.active_fence_digest != identity.active_fence_digest
+        or facts.root_binding_digest != identity.root_binding_digest
+        or facts.principal_id != principal.audience_id
+        or facts.authorization_session_id != session.session_id
+        or facts.credential_generation != session.credential_generation
+        or facts.issuer_family != principal.issuer_family
+        or facts.surface != principal.surface
+        or facts.verifier_fingerprint != hashlib.sha256(
+            identity.machine_key_id.encode("utf-8")
+        ).hexdigest()
+    ):
+        _fail()
+    return facts
+
+
+def bind_local_owner(
+    vault_root: Path, *, principal: RequestPrincipal, arguments: object, now: int,
+) -> RequestPrincipal:
+    """Inject the exact owner capability into an already-authenticated principal."""
+    context = admit_local_owner(
+        vault_root, principal=principal, arguments=arguments, now=now,
+    )
+    _validate_admitted_request(vault_root, arguments, context._verified_facts())
+    return replace(principal, consolidation_owner_context=context)
+
+
+def require_injected_owner(principal: RequestPrincipal, *, now: int) -> None:
+    """Refuse an unbound library call before resolving its selected vault."""
+    _session(principal, now=now)
+    context = principal.consolidation_owner_context
+    if type(context) is not ConsolidationOwnerContext:
+        _fail()
+    facts = context._verified_facts()
+    if not facts.issued_at <= now < facts.expires_at:
+        _fail()
+
+
+def require_local_owner_session(principal: RequestPrincipal, *, now: int) -> None:
+    """Check a verified carrier before CLI parsing can inspect action fields."""
+    _session(principal, now=now)
+
+
+def require_bound_request(
+    vault_root: Path, *, principal: RequestPrincipal, arguments: object, now: int,
+) -> None:
+    """Revalidate the selected installation before dispatch or writer admission."""
+    require_injected_owner(principal, now=now)
+    _durable_session(vault_root, principal=principal, now=now)
+    action = _action(arguments)
+    try:
+        identity = consolidation_identity.load_local_identity(vault_root, now=now)
+    except (consolidation_identity.ConsolidationIdentityUnavailable, OSError):
+        _fail()
+    facts = require_owner_context(
+        principal.consolidation_owner_context, principal=principal,
+        identity=identity, action=action, now=now,
+    )
+    _validate_admitted_request(vault_root, arguments, facts)
+
+
+def _validate_admitted_request(vault_root: Path, arguments: object, facts: _OwnerFacts) -> None:
+    """Apply the shared semantic contract only after current owner admission."""
+    from . import consolidation_request, consolidation_run_state
+
+    request = consolidation_request._validate_request_fields(arguments)  # noqa: SLF001
+    mode = None
+    if (request["action"] == "plan" and request["operation"] == "materialize"
+            and request["plan_kind"] == "cutover"):
+        try:
+            record = consolidation_run_state.ConsolidationRunStore(vault_root).load(request["run_id"])
+        except consolidation_run_state.ConsolidationRunUnavailable:
+            raise consolidation_request.ConsolidationRequestUnavailable from None
+        identity = record.identity
+        if (identity.destination_vault_id != facts.vault_id
+                or identity.destination_installation_id != facts.installation_id
+                or identity.destination_generation != facts.installation_generation
+                or identity.destination_fence_digest != facts.active_fence_digest):
+            raise consolidation_request.ConsolidationRequestUnavailable
+        mode = identity.run_mode
+    consolidation_request.validate_request(request, trusted_run_mode=mode)

--- a/src/exomem/governance/consolidation_request.py
+++ b/src/exomem/governance/consolidation_request.py
@@ -1,0 +1,516 @@
+"""Closed, pure request validation for governed vault consolidation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import NoReturn
+
+REQUEST_SCHEMA_NAME = "exomem.consolidate-memory-request/v1"
+ACTIONS = (
+    "start",
+    "status",
+    "reconcile",
+    "plan",
+    "approve",
+    "apply",
+    "verify",
+    "recover",
+    "abort",
+    "rollback",
+    "retire-source",
+)
+
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MAX_PAGE_ORDINAL = (1 << 31) - 1
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+
+
+class ConsolidationRequestUnavailable(RuntimeError):
+    """Content-free refusal for an invalid consolidation request."""
+
+    code = "CONSOLIDATION_REQUEST_INVALID"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation request is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class _Object:
+    required: tuple[tuple[str, object], ...]
+    optional: tuple[tuple[str, object], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _OneOf:
+    choices: tuple[_Object, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _Variant:
+    action: str
+    required: tuple[tuple[str, object], ...]
+    optional: tuple[tuple[str, object], ...] = ()
+
+
+def _fields(**fields: object) -> tuple[tuple[str, object], ...]:
+    return tuple(fields.items())
+
+
+_DIGEST_FIELDS = {
+    "expected_reconciliation_digest": "digest",
+    "expected_policy_bundle_digest": "digest",
+    "expected_principal_attestation_set_digest": "digest",
+    "expected_verification_plan_digest": "digest",
+    "expected_rollback_contingency_digest": "digest",
+    "expected_source_retention_digest": "digest",
+    "expected_control_basis_digest": "digest",
+}
+_CUTOVER_OPTIONS = _Object(
+    _fields(**_DIGEST_FIELDS),
+    _fields(expected_rehearsal_proof_digest="digest"),
+)
+_ROLLBACK_OPTIONS = _Object(
+    _fields(
+        target_kind=("enum", ("pre-cutover", "post-cutover-forward")),
+        target_snapshot_ref="ref",
+        target_snapshot_digest="digest",
+        expected_current_census_digest="digest",
+        treatment_set_ref="ref",
+        treatment_set_digest="digest",
+        surviving_copy_ledger_digest="digest",
+        expected_retirement_state_digest="digest",
+    )
+)
+_RETIREMENT_OPTION_FIELDS = _fields(
+    archive_artifact_ref="ref",
+    archive_artifact_digest="digest",
+    archive_terms_digest="digest",
+    source_retention_proof_ref="ref",
+    source_retention_proof_digest="digest",
+    surviving_copy_ledger_digest="digest",
+    retained_irrecoverable_statement_digest="digest",
+)
+
+
+def _retirement_options(
+    disposition: str, rollback_mode: str
+) -> _Object:
+    conditional: tuple[tuple[str, object], ...] = ()
+    if disposition == "transfer":
+        conditional += _fields(custodian_receipt_ref="ref", custodian_receipt_digest="digest")
+    if rollback_mode == "forward-only":
+        conditional += _fields(forward_snapshot_ref="ref", forward_snapshot_digest="digest")
+    return _Object(
+        _RETIREMENT_OPTION_FIELDS
+        + _fields(
+            archive_disposition=("const", disposition),
+            post_retirement_rollback_mode=("const", rollback_mode),
+        )
+        + conditional
+    )
+
+
+_RETIREMENT_OPTIONS = _OneOf(
+    tuple(
+        _retirement_options(disposition, rollback_mode)
+        for disposition in ("retain", "transfer", "external-destruction")
+        for rollback_mode in ("pre-cutover-reversible", "forward-only")
+    )
+)
+
+_BASE = _fields(schema=("const", REQUEST_SCHEMA_NAME))
+_MUTATION = _fields(operation_id="uuid", run_id="uuid", expected_run_revision="revision")
+_CONTEXT = _fields(successor_context_ref="ref", successor_context_digest="digest")
+
+
+def _join(*parts: tuple[tuple[str, object], ...]) -> tuple[tuple[str, object], ...]:
+    return tuple(item for part in parts for item in part)
+
+
+_VARIANTS = (
+    _Variant(
+        "start",
+        _join(
+            _BASE,
+            _fields(
+                action=("const", "start"),
+                operation_id="uuid",
+                expected_run_revision=("const", 0),
+                run_mode=("const", "cloned-rehearsal"),
+                source_artifact_ref="ref",
+                source_attestation_ref="ref",
+            ),
+        ),
+        _fields(clone_binding_ref="ref"),
+    ),
+    _Variant(
+        "start",
+        _join(
+            _BASE,
+            _fields(
+                action=("const", "start"),
+                operation_id="uuid",
+                expected_run_revision=("const", 0),
+                run_mode=("const", "real-cutover"),
+                source_artifact_ref="ref",
+                source_attestation_ref="ref",
+            ),
+        ),
+    ),
+    _Variant(
+        "status",
+        _join(_BASE, _fields(action=("const", "status"), run_id="uuid")),
+        _fields(
+            expected_run_revision="revision",
+            detail=("enum", ("summary", "owner-detail")),
+            cursor="ref",
+            limit="limit",
+        ),
+    ),
+    _Variant(
+        "reconcile",
+        _join(
+            _BASE,
+            _MUTATION,
+            _fields(expected_inventory_digest="digest", decision_set_ref="ref", decision_set_digest="digest"),
+            _fields(action=("const", "reconcile")),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("const", "cutover"), operation=("const", "materialize"), cutover_options=_CUTOVER_OPTIONS),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("const", "rollback"), operation=("const", "materialize"), rollback_options=_ROLLBACK_OPTIONS),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("const", "retirement"), operation=("const", "materialize"), retirement_options=_RETIREMENT_OPTIONS),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "begin"), plan_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "page"), plan_digest="digest", render_session_ref="ref", page_ordinal="page"),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "acknowledge"), plan_digest="digest", render_session_ref="ref", page_ordinal="page", acknowledged_page_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "plan",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "complete"), plan_digest="digest", render_session_ref="ref"),
+        ),
+    ),
+    _Variant(
+        "approve",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "approve"), plan_kind=("enum", ("cutover", "rollback", "retirement")), plan_digest="digest", rendering_completeness_ref="ref", rendering_completeness_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "apply",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "apply"), cutover_plan_digest="digest", approval_token_ref="ref", approval_token_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "verify",
+        _join(
+            _BASE, _MUTATION,
+            _fields(action=("const", "verify"), verification_kind=("enum", ("in-process", "transport")), expected_plan_digest="digest", expected_verification_basis_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "recover",
+        _join(
+            _BASE, _MUTATION,
+            _fields(action=("const", "recover"), expected_journal_digest="digest"),
+        ),
+        _fields(expected_intent_event_id="digest"),
+    ),
+    _Variant(
+        "abort",
+        _join(
+            _BASE, _MUTATION,
+            _fields(action=("const", "abort"), expected_journal_digest="digest", reason_code=("enum", ("owner-cancelled", "preimage-unavailable", "verification-failed", "maintenance-window-expired"))),
+        ),
+        _fields(reason="reason"),
+    ),
+    _Variant(
+        "rollback",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "rollback"), rollback_mode=("const", "nonterminal-contingency")),
+        ),
+    ),
+    _Variant(
+        "rollback",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "rollback"), rollback_mode=("const", "terminal-plan"), rollback_plan_digest="digest", rollback_token_ref="ref", rollback_token_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "retire-source",
+        _join(
+            _BASE, _MUTATION, _CONTEXT,
+            _fields(action=("const", "retire-source"), phase=("const", "clearance"), retirement_plan_digest="digest", retirement_token_ref="ref", retirement_token_digest="digest"),
+        ),
+    ),
+    _Variant(
+        "retire-source",
+        _join(
+            _BASE, _MUTATION,
+            _fields(action=("const", "retire-source"), phase=("const", "finalize"), retirement_plan_digest="digest", retirement_lifecycle_ref="ref", completion_attestation_ref="ref", completion_attestation_digest="digest"),
+        ),
+    ),
+)
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationRequestUnavailable from None
+
+
+def _text(value: object, *, maximum: int, minimum: int = 1) -> str:
+    if not isinstance(value, str) or len(value) < minimum or "\x00" in value:
+        _fail()
+    if unicodedata.normalize("NFC", value) != value:
+        _fail()
+    try:
+        if len(value.encode("utf-8")) > maximum:
+            _fail()
+    except UnicodeEncodeError:
+        _fail()
+    return value
+
+
+def _rule_schema(rule: object) -> dict[str, object]:
+    if isinstance(rule, _Object):
+        return _object_schema(rule)
+    if isinstance(rule, _OneOf):
+        return {"oneOf": [_object_schema(choice) for choice in rule.choices]}
+    if rule == "uuid":
+        return {"$ref": "#/$defs/uuid4"}
+    if rule == "digest":
+        return {"$ref": "#/$defs/digest"}
+    if rule == "ref":
+        return {"$ref": "#/$defs/ref"}
+    if rule == "revision":
+        return {"$ref": "#/$defs/revision"}
+    if rule == "page":
+        return {"$ref": "#/$defs/page_ordinal"}
+    if rule == "limit":
+        return {"$ref": "#/$defs/limit"}
+    if rule == "reason":
+        return {"$ref": "#/$defs/reason"}
+    kind, argument = rule
+    if kind == "const":
+        schema: dict[str, object] = {"const": argument}
+        if isinstance(argument, int):
+            schema["type"] = "integer"
+        return schema
+    if kind == "enum":
+        return {"type": "string", "enum": list(argument)}
+    raise AssertionError(rule)
+
+
+def _object_schema(spec: _Object | _Variant) -> dict[str, object]:
+    required = dict(spec.required)
+    optional = dict(spec.optional)
+    properties = required.copy()
+    properties.update(optional)
+    return {
+        "type": "object",
+        "properties": {name: _rule_schema(rule) for name, rule in properties.items()},
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+def _build_schema() -> dict[str, object]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": REQUEST_SCHEMA_NAME,
+        "oneOf": [_object_schema(variant) for variant in _VARIANTS],
+        "$defs": {
+            "uuid4": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?![\\s\\S])"},
+            "digest": {"type": "string", "pattern": "^[0-9a-f]{64}(?![\\s\\S])"},
+            "ref": {"type": "string", "minLength": 1, "maxLength": 512, "not": {"pattern": "\\u0000"}},
+            "revision": {"type": "integer", "minimum": 0, "maximum": _MAX_SAFE_INTEGER},
+            "page_ordinal": {"type": "integer", "minimum": 0, "maximum": _MAX_PAGE_ORDINAL},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 200},
+            "reason": {"type": "string", "minLength": 0, "maxLength": 500, "not": {"pattern": "\\u0000"}},
+        },
+    }
+
+
+REQUEST_SCHEMA = _build_schema()
+
+
+def request_schema() -> dict[str, object]:
+    """Return a fresh JSON Schema for the closed request union."""
+
+    return copy.deepcopy(REQUEST_SCHEMA)
+
+
+def _validate_rule(value: object, rule: object) -> object:
+    if isinstance(rule, _Object):
+        return _validate_object(value, rule)
+    if isinstance(rule, _OneOf):
+        for choice in rule.choices:
+            try:
+                return _validate_object(value, choice)
+            except ConsolidationRequestUnavailable:
+                continue
+        _fail()
+    if rule == "uuid":
+        if not isinstance(value, str) or _UUID4.fullmatch(value) is None:
+            _fail()
+        return value
+    if rule == "digest":
+        if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+            _fail()
+        return value
+    if rule == "ref":
+        return _text(value, maximum=512)
+    if rule == "reason":
+        return _text(value, maximum=500, minimum=0)
+    if rule == "revision":
+        maximum = _MAX_SAFE_INTEGER
+    elif rule == "page":
+        maximum = _MAX_PAGE_ORDINAL
+    elif rule == "limit":
+        maximum = 200
+    else:
+        kind, argument = rule
+        if kind == "const":
+            if value != argument or (isinstance(argument, int) and type(value) is not int):
+                _fail()
+            return value
+        if kind == "enum":
+            if not isinstance(value, str) or value not in argument:
+                _fail()
+            return value
+        raise AssertionError(rule)
+    minimum = 1 if rule == "limit" else 0
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        _fail()
+    return value
+
+
+def _validate_object(value: object, spec: _Object | _Variant) -> dict[str, object]:
+    if type(value) is not dict:
+        _fail()
+    required = dict(spec.required)
+    optional = dict(spec.optional)
+    if not set(required) <= set(value) <= set(required) | set(optional):
+        _fail()
+    return {
+        name: _validate_rule(item, required[name] if name in required else optional[name])
+        for name, item in value.items()
+    }
+
+
+def _validate_cutover_condition(request: dict[str, object], trusted_run_mode: str | None) -> None:
+    if request.get("action") != "plan" or request.get("operation") != "materialize" or request.get("plan_kind") != "cutover":
+        return
+    options = request["cutover_options"]
+    assert type(options) is dict
+    has_proof = "expected_rehearsal_proof_digest" in options
+    if trusted_run_mode is None:
+        _fail()
+    if trusted_run_mode == "real-cutover" and not has_proof:
+        _fail()
+    if trusted_run_mode == "cloned-rehearsal" and has_proof:
+        _fail()
+
+
+def decode_request_json(raw: bytes) -> dict[str, object]:
+    """Decode UTF-8 JSON without discarding duplicate fields or numeric types."""
+    def unique_fields(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                _fail()
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=unique_fields)
+    except (UnicodeError, ValueError, RecursionError):
+        _fail()
+    if type(value) is not dict:
+        _fail()
+    return value
+
+
+def _validate_request_fields(value: object) -> dict[str, object]:
+    """Validate fields before a trusted adapter can use a run identifier.
+
+    This is not admission: the adapter must still call ``validate_request``
+    with the authenticated stored run mode before dispatch.
+    """
+    if type(value) is not dict or type(value.get("action")) is not str or value["action"] not in ACTIONS:
+        _fail()
+    for variant in _VARIANTS:
+        if variant.action != value["action"]:
+            continue
+        try:
+            return _validate_object(value, variant)
+        except ConsolidationRequestUnavailable:
+            continue
+    _fail()
+
+
+def validate_request(value: object, *, trusted_run_mode: str | None = None) -> dict[str, object]:
+    """Validate decoded input without coercion or granting authority.
+
+    Cutover materialization requires the authenticated stored run mode; absent
+    state refuses admission instead of skipping the rehearsal-proof condition.
+    """
+    if trusted_run_mode not in {None, "cloned-rehearsal", "real-cutover"}:
+        _fail()
+    request = _validate_request_fields(value)
+    _validate_cutover_condition(request, trusted_run_mode)
+    return request
+
+
+__all__ = [
+    "ACTIONS",
+    "ConsolidationRequestUnavailable",
+    "REQUEST_SCHEMA",
+    "request_schema",
+    "decode_request_json",
+    "validate_request",
+]

--- a/src/exomem/governance/consolidation_request.py
+++ b/src/exomem/governance/consolidation_request.py
@@ -7,7 +7,7 @@ import json
 import re
 import unicodedata
 from dataclasses import dataclass
-from typing import NoReturn
+from typing import NoReturn, cast
 
 REQUEST_SCHEMA_NAME = "exomem.consolidate-memory-request/v1"
 ACTIONS = (
@@ -97,9 +97,7 @@ _RETIREMENT_OPTION_FIELDS = _fields(
 )
 
 
-def _retirement_options(
-    disposition: str, rollback_mode: str
-) -> _Object:
+def _retirement_options(disposition: str, rollback_mode: str) -> _Object:
     conditional: tuple[tuple[str, object], ...] = ()
     if disposition == "transfer":
         conditional += _fields(custodian_receipt_ref="ref", custodian_receipt_digest="digest")
@@ -177,84 +175,169 @@ _VARIANTS = (
         _join(
             _BASE,
             _MUTATION,
-            _fields(expected_inventory_digest="digest", decision_set_ref="ref", decision_set_digest="digest"),
+            _fields(
+                expected_inventory_digest="digest",
+                decision_set_ref="ref",
+                decision_set_digest="digest",
+            ),
             _fields(action=("const", "reconcile")),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("const", "cutover"), operation=("const", "materialize"), cutover_options=_CUTOVER_OPTIONS),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("const", "cutover"),
+                operation=("const", "materialize"),
+                cutover_options=_CUTOVER_OPTIONS,
+            ),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("const", "rollback"), operation=("const", "materialize"), rollback_options=_ROLLBACK_OPTIONS),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("const", "rollback"),
+                operation=("const", "materialize"),
+                rollback_options=_ROLLBACK_OPTIONS,
+            ),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("const", "retirement"), operation=("const", "materialize"), retirement_options=_RETIREMENT_OPTIONS),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("const", "retirement"),
+                operation=("const", "materialize"),
+                retirement_options=_RETIREMENT_OPTIONS,
+            ),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "begin"), plan_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("enum", ("cutover", "rollback", "retirement")),
+                operation=("const", "render"),
+                render_step=("const", "begin"),
+                plan_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "page"), plan_digest="digest", render_session_ref="ref", page_ordinal="page"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("enum", ("cutover", "rollback", "retirement")),
+                operation=("const", "render"),
+                render_step=("const", "page"),
+                plan_digest="digest",
+                render_session_ref="ref",
+                page_ordinal="page",
+            ),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "acknowledge"), plan_digest="digest", render_session_ref="ref", page_ordinal="page", acknowledged_page_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("enum", ("cutover", "rollback", "retirement")),
+                operation=("const", "render"),
+                render_step=("const", "acknowledge"),
+                plan_digest="digest",
+                render_session_ref="ref",
+                page_ordinal="page",
+                acknowledged_page_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "plan",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "plan"), plan_kind=("enum", ("cutover", "rollback", "retirement")), operation=("const", "render"), render_step=("const", "complete"), plan_digest="digest", render_session_ref="ref"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "plan"),
+                plan_kind=("enum", ("cutover", "rollback", "retirement")),
+                operation=("const", "render"),
+                render_step=("const", "complete"),
+                plan_digest="digest",
+                render_session_ref="ref",
+            ),
         ),
     ),
     _Variant(
         "approve",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "approve"), plan_kind=("enum", ("cutover", "rollback", "retirement")), plan_digest="digest", rendering_completeness_ref="ref", rendering_completeness_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "approve"),
+                plan_kind=("enum", ("cutover", "rollback", "retirement")),
+                plan_digest="digest",
+                rendering_completeness_ref="ref",
+                rendering_completeness_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "apply",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "apply"), cutover_plan_digest="digest", approval_token_ref="ref", approval_token_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "apply"),
+                cutover_plan_digest="digest",
+                approval_token_ref="ref",
+                approval_token_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "verify",
         _join(
-            _BASE, _MUTATION,
-            _fields(action=("const", "verify"), verification_kind=("enum", ("in-process", "transport")), expected_plan_digest="digest", expected_verification_basis_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _fields(
+                action=("const", "verify"),
+                verification_kind=("enum", ("in-process", "transport")),
+                expected_plan_digest="digest",
+                expected_verification_basis_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "recover",
         _join(
-            _BASE, _MUTATION,
+            _BASE,
+            _MUTATION,
             _fields(action=("const", "recover"), expected_journal_digest="digest"),
         ),
         _fields(expected_intent_event_id="digest"),
@@ -262,37 +345,78 @@ _VARIANTS = (
     _Variant(
         "abort",
         _join(
-            _BASE, _MUTATION,
-            _fields(action=("const", "abort"), expected_journal_digest="digest", reason_code=("enum", ("owner-cancelled", "preimage-unavailable", "verification-failed", "maintenance-window-expired"))),
+            _BASE,
+            _MUTATION,
+            _fields(
+                action=("const", "abort"),
+                expected_journal_digest="digest",
+                reason_code=(
+                    "enum",
+                    (
+                        "owner-cancelled",
+                        "preimage-unavailable",
+                        "verification-failed",
+                        "maintenance-window-expired",
+                    ),
+                ),
+            ),
         ),
         _fields(reason="reason"),
     ),
     _Variant(
         "rollback",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "rollback"), rollback_mode=("const", "nonterminal-contingency")),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "rollback"), rollback_mode=("const", "nonterminal-contingency")
+            ),
         ),
     ),
     _Variant(
         "rollback",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "rollback"), rollback_mode=("const", "terminal-plan"), rollback_plan_digest="digest", rollback_token_ref="ref", rollback_token_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "rollback"),
+                rollback_mode=("const", "terminal-plan"),
+                rollback_plan_digest="digest",
+                rollback_token_ref="ref",
+                rollback_token_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "retire-source",
         _join(
-            _BASE, _MUTATION, _CONTEXT,
-            _fields(action=("const", "retire-source"), phase=("const", "clearance"), retirement_plan_digest="digest", retirement_token_ref="ref", retirement_token_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _CONTEXT,
+            _fields(
+                action=("const", "retire-source"),
+                phase=("const", "clearance"),
+                retirement_plan_digest="digest",
+                retirement_token_ref="ref",
+                retirement_token_digest="digest",
+            ),
         ),
     ),
     _Variant(
         "retire-source",
         _join(
-            _BASE, _MUTATION,
-            _fields(action=("const", "retire-source"), phase=("const", "finalize"), retirement_plan_digest="digest", retirement_lifecycle_ref="ref", completion_attestation_ref="ref", completion_attestation_digest="digest"),
+            _BASE,
+            _MUTATION,
+            _fields(
+                action=("const", "retire-source"),
+                phase=("const", "finalize"),
+                retirement_plan_digest="digest",
+                retirement_lifecycle_ref="ref",
+                completion_attestation_ref="ref",
+                completion_attestation_digest="digest",
+            ),
         ),
     ),
 )
@@ -334,14 +458,14 @@ def _rule_schema(rule: object) -> dict[str, object]:
         return {"$ref": "#/$defs/limit"}
     if rule == "reason":
         return {"$ref": "#/$defs/reason"}
-    kind, argument = rule
+    kind, argument = cast(tuple[str, object], rule)
     if kind == "const":
         schema: dict[str, object] = {"const": argument}
         if isinstance(argument, int):
             schema["type"] = "integer"
         return schema
     if kind == "enum":
-        return {"type": "string", "enum": list(argument)}
+        return {"type": "string", "enum": list(cast(tuple[str, ...], argument))}
     raise AssertionError(rule)
 
 
@@ -364,13 +488,29 @@ def _build_schema() -> dict[str, object]:
         "title": REQUEST_SCHEMA_NAME,
         "oneOf": [_object_schema(variant) for variant in _VARIANTS],
         "$defs": {
-            "uuid4": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?![\\s\\S])"},
+            "uuid4": {
+                "type": "string",
+                "pattern": (
+                    "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-"
+                    "[89ab][0-9a-f]{3}-[0-9a-f]{12}(?![\\s\\S])"
+                ),
+            },
             "digest": {"type": "string", "pattern": "^[0-9a-f]{64}(?![\\s\\S])"},
-            "ref": {"type": "string", "minLength": 1, "maxLength": 512, "not": {"pattern": "\\u0000"}},
+            "ref": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "not": {"pattern": "\\u0000"},
+            },
             "revision": {"type": "integer", "minimum": 0, "maximum": _MAX_SAFE_INTEGER},
             "page_ordinal": {"type": "integer", "minimum": 0, "maximum": _MAX_PAGE_ORDINAL},
             "limit": {"type": "integer", "minimum": 1, "maximum": 200},
-            "reason": {"type": "string", "minLength": 0, "maxLength": 500, "not": {"pattern": "\\u0000"}},
+            "reason": {
+                "type": "string",
+                "minLength": 0,
+                "maxLength": 500,
+                "not": {"pattern": "\\u0000"},
+            },
         },
     }
 
@@ -413,13 +553,13 @@ def _validate_rule(value: object, rule: object) -> object:
     elif rule == "limit":
         maximum = 200
     else:
-        kind, argument = rule
+        kind, argument = cast(tuple[str, object], rule)
         if kind == "const":
             if value != argument or (isinstance(argument, int) and type(value) is not int):
                 _fail()
             return value
         if kind == "enum":
-            if not isinstance(value, str) or value not in argument:
+            if not isinstance(value, str) or value not in cast(tuple[str, ...], argument):
                 _fail()
             return value
         raise AssertionError(rule)
@@ -443,7 +583,11 @@ def _validate_object(value: object, spec: _Object | _Variant) -> dict[str, objec
 
 
 def _validate_cutover_condition(request: dict[str, object], trusted_run_mode: str | None) -> None:
-    if request.get("action") != "plan" or request.get("operation") != "materialize" or request.get("plan_kind") != "cutover":
+    if (
+        request.get("action") != "plan"
+        or request.get("operation") != "materialize"
+        or request.get("plan_kind") != "cutover"
+    ):
         return
     options = request["cutover_options"]
     assert type(options) is dict
@@ -458,6 +602,7 @@ def _validate_cutover_condition(request: dict[str, object], trusted_run_mode: st
 
 def decode_request_json(raw: bytes) -> dict[str, object]:
     """Decode UTF-8 JSON without discarding duplicate fields or numeric types."""
+
     def unique_fields(pairs: list[tuple[str, object]]) -> dict[str, object]:
         result: dict[str, object] = {}
         for key, value in pairs:
@@ -481,7 +626,11 @@ def _validate_request_fields(value: object) -> dict[str, object]:
     This is not admission: the adapter must still call ``validate_request``
     with the authenticated stored run mode before dispatch.
     """
-    if type(value) is not dict or type(value.get("action")) is not str or value["action"] not in ACTIONS:
+    if (
+        type(value) is not dict
+        or type(value.get("action")) is not str
+        or value["action"] not in ACTIONS
+    ):
         _fail()
     for variant in _VARIANTS:
         if variant.action != value["action"]:

--- a/src/exomem/governance/consolidation_terminal.py
+++ b/src/exomem/governance/consolidation_terminal.py
@@ -1,0 +1,619 @@
+"""Closed logical terminals for governed vault consolidation.
+
+This module is a pure serializer and grants no authority.  The command
+coordinator must supply its complete validated request, exact resulting state,
+and any already-resolved successor projection.  Authenticated owner, run, and
+context resolution remain an integration dependency of that coordinator.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import NoReturn
+
+from . import consolidation_plan, consolidation_request, consolidation_successor
+
+TERMINAL_SCHEMA_NAME = "exomem.consolidation-terminal/v1"
+
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_UUID4 = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z")
+_PLAN_KINDS = ("cutover", "rollback", "retirement")
+_STATUS_PLAN_CONTEXTS = frozenset(
+    {"render-begin", "render-page", "render-acknowledge", "render-complete"}
+)
+_PAIR = ("successor_context_ref", "successor_context_digest")
+_ROWS = {
+    "start": (("source_fingerprint", "destination_snapshot_fingerprint"), ("source_objects", "source_bytes", "destination_objects", "destination_bytes"), ("status", "reconcile")),
+    "status": (("run_state_digest", "journal_digest"), ("completed_effects", "pending_effects", "blocked_effects", "warnings"), ("status", "reconcile", "plan", "approve", "apply", "verify", "recover", "abort", "rollback", "retire-source")),
+    "reconcile": (("inventory_digest", "reconciliation_digest", "mapping_set_digest"), ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "unresolved", "mappings"), ("status", "reconcile", "plan")),
+    "plan:materialize": (("plan_digest", "control_basis_digest", "plan_successor_automaton_digest"), ("content_actions", "policy_documents", "impact_rows", "render_pages"), ("status", "plan")),
+    "plan:render-begin": (("plan_digest", "render_session_digest"), ("render_pages", "acknowledged_pages"), ("status", "plan")),
+    "plan:render-page": (("plan_digest", "render_page_digest"), ("page_ordinal", "page_rows", "render_pages"), ("status", "plan")),
+    "plan:render-acknowledge": (("plan_digest", "render_ack_digest"), ("acknowledged_pages", "render_pages"), ("status", "plan")),
+    "plan:render-complete": (("plan_digest", "rendering_completeness_digest"), ("acknowledged_pages", "render_pages"), ("status", "approve")),
+    "approve": (("plan_digest", "approval_token_digest"), ("acknowledged_pages", "render_pages"), ("status", "apply", "rollback", "retire-source")),
+    "apply": (("cutover_terminal_digest", "post_cutover_census_digest", "apply_predecessor_digest"), ("policy_documents", "content_batches", "content_actions", "rebuild_kinds", "in_process_probes", "transport_probes"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source")),
+    "verify": (("verification_basis_digest", "verification_terminal_digest"), ("positive_probes", "negative_probes", "passed_probes", "failed_probes"), ("status", "plan", "apply", "verify", "recover", "rollback", "retire-source")),
+    "recover": (("journal_digest", "recovery_terminal_digest"), ("classified_effects", "repaired_effects", "blocked_effects"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source")),
+    "abort": (("prior_census_digest", "abort_terminal_digest"), ("restored_entries", "removed_candidates", "evidence_events"), ("status",)),
+    "rollback:nonterminal-contingency": (("cutover_plan_digest", "original_apply_journal_digest", "rollback_contingency_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback")),
+    "rollback:terminal-plan": (("rollback_plan_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback")),
+    "retire-source:clearance": (("retirement_plan_digest", "clearance_digest", "retirement_lifecycle_digest", "surviving_copy_ledger_digest"), ("survivor_rows", "verified_survivor_rows"), ("status", "retire-source")),
+    "retire-source:finalize": (("retirement_plan_digest", "retirement_lifecycle_digest", "completion_digest", "finalization_digest", "surviving_copy_ledger_digest"), ("completion_records", "survivor_rows"), ("status", "plan")),
+}
+
+
+class ConsolidationTerminalUnavailable(RuntimeError):
+    """Content-free refusal for an invalid consolidation terminal."""
+
+    code = "CONSOLIDATION_TERMINAL_INVALID"
+
+    def __init__(self) -> None:
+        super().__init__("consolidation terminal is unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalProjectionState:
+    """Exact state projected by the process-trusted command coordinator."""
+
+    validated_request: Mapping[str, object]
+    terminal: Mapping[str, object]
+    trusted_run_mode: str | None = None
+    successor_reference: str | None = None
+    successor_context: consolidation_successor.CanonicalSuccessorContext | None = None
+    expected_successor: consolidation_successor.ExpectedSuccessorContext | None = None
+    eligible_plan_kinds: tuple[str, ...] | None = None
+    nonterminal_contingency_eligible: bool = False
+
+
+class _ValidatedTerminal(Mapping[str, object]):
+    __slots__ = ("_value",)
+
+    def __init__(self, value: Mapping[str, object], *, seal: object) -> None:
+        if seal is not _TERMINAL_SEAL:
+            _fail()
+        object.__setattr__(self, "_value", _freeze(value))
+
+    def __setattr__(self, _name: str, _value: object) -> NoReturn:
+        _fail()
+
+    def __getitem__(self, key: str) -> object:
+        return self._value[key]
+
+    def __iter__(self):
+        return iter(self._value)
+
+    def __len__(self) -> int:
+        return len(self._value)
+
+
+_TERMINAL_SEAL = object()
+
+
+def _freeze(value: object) -> object:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _thaw(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+def _fail() -> NoReturn:
+    raise ConsolidationTerminalUnavailable from None
+
+
+def _text(value: object, *, maximum: int = 512) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        _fail()
+    if unicodedata.normalize("NFC", value) != value:
+        _fail()
+    try:
+        if len(value.encode("utf-8")) > maximum:
+            _fail()
+    except UnicodeEncodeError:
+        _fail()
+    return value
+
+
+def _digest(value: object) -> str:
+    text = _text(value, maximum=64)
+    if _DIGEST.fullmatch(text) is None:
+        _fail()
+    return text
+
+
+def _uuid(value: object) -> str:
+    text = _text(value, maximum=36)
+    if _UUID4.fullmatch(text) is None:
+        _fail()
+    return text
+
+
+def _integer(value: object) -> int:
+    if type(value) is not int or not 0 <= value <= _MAX_SAFE_INTEGER:
+        _fail()
+    return value
+
+
+def _object(value: object, fields: Sequence[str]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or set(value) != set(fields):
+        _fail()
+    return value
+
+
+def _next_actions(value: object, allowed: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        _fail()
+    actions = tuple(_text(item, maximum=64) for item in value)
+    if len(actions) != len(set(actions)):
+        _fail()
+    positions = [allowed.index(item) if item in allowed else -1 for item in actions]
+    if -1 in positions or positions != sorted(positions):
+        _fail()
+    return actions
+
+
+def _output_forms(action: str) -> tuple[tuple[str, ...], ...]:
+    if action in {"start", "abort"}:
+        return ((),)
+    if action == "status":
+        return ((), ("next_cursor",), _PAIR, _PAIR + ("eligible_plan_kinds",), ("next_cursor",) + _PAIR, ("next_cursor",) + _PAIR + ("eligible_plan_kinds",))
+    if action == "reconcile":
+        return ((), _PAIR + ("eligible_plan_kinds",))
+    if action == "plan:materialize":
+        return (_PAIR,)
+    if action == "plan:render-begin":
+        return (_PAIR + ("render_session_ref",),)
+    if action == "plan:render-page":
+        return (_PAIR + ("render_session_ref", "render_delivery_ref"),)
+    if action == "plan:render-acknowledge":
+        return (_PAIR + ("render_session_ref",),)
+    if action == "plan:render-complete":
+        return (_PAIR + ("rendering_completeness_ref",),)
+    if action == "approve":
+        return (_PAIR + ("approval_token_ref",),)
+    if action == "retire-source:clearance":
+        return (("retirement_clearance_ref", "retirement_lifecycle_ref"),)
+    if action in {"apply", "verify", "recover"}:
+        return ((), _PAIR, _PAIR + ("eligible_plan_kinds",))
+    return ((), _PAIR + ("eligible_plan_kinds",))
+
+
+def _validate_outputs(action: str, value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        _fail()
+    try:
+        fields = frozenset(value)
+    except TypeError:
+        _fail()
+    if not all(isinstance(field, str) for field in fields) or fields not in {frozenset(form) for form in _output_forms(action)}:
+        _fail()
+    for name, item in value.items():
+        if name.endswith("_digest"):
+            _digest(item)
+        elif name.endswith("_ref") or name == "next_cursor":
+            _text(item)
+        elif name == "eligible_plan_kinds":
+            if isinstance(item, (str, bytes)) or not isinstance(item, Sequence):
+                _fail()
+            kinds = tuple(_text(kind, maximum=16) for kind in item)
+            if not kinds or kinds != tuple(kind for kind in _PLAN_KINDS if kind in kinds):
+                _fail()
+        else:
+            _fail()
+    return value
+
+
+def _output_schema(fields: tuple[str, ...]) -> dict[str, object]:
+    properties: dict[str, object] = {}
+    for field in fields:
+        if field.endswith("_digest"):
+            properties[field] = {"$ref": "#/$defs/digest"}
+        elif field.endswith("_ref") or field == "next_cursor":
+            properties[field] = {"$ref": "#/$defs/ref"}
+        else:
+            properties[field] = {"type": "array", "items": {"enum": list(_PLAN_KINDS)}, "uniqueItems": True}
+    return {"type": "object", "properties": properties, "required": list(fields), "additionalProperties": False}
+
+
+def _branch_schema(action: str) -> dict[str, object]:
+    digest_fields, count_fields, next_actions = _ROWS[action]
+    required = ["schema", "action", "outcome", "run_id", "run_revision", "phase", "artifact_digests", "counts", "next_actions", "trusted_outputs"]
+    properties: dict[str, object] = {
+        "schema": {"const": TERMINAL_SCHEMA_NAME}, "action": {"const": action},
+        "outcome": {"const": "observed" if action == "status" else "committed"},
+        "run_id": {"$ref": "#/$defs/uuid4"}, "run_revision": {"$ref": "#/$defs/integer"},
+        "phase": {"$ref": "#/$defs/text"},
+        "artifact_digests": {"type": "object", "properties": {name: {"$ref": "#/$defs/digest"} for name in digest_fields}, "required": list(digest_fields), "additionalProperties": False},
+        "counts": {"type": "object", "properties": {name: {"$ref": "#/$defs/integer"} for name in count_fields}, "required": list(count_fields), "additionalProperties": False},
+        "next_actions": {"type": "array", "items": {"enum": list(next_actions)}, "uniqueItems": True},
+        "trusted_outputs": {"oneOf": [_output_schema(form) for form in _output_forms(action)]},
+    }
+    if action != "status":
+        mutation = ("operation_id", "request_digest", "prior_state_digest", "final_state_digest")
+        required.extend(mutation)
+        properties.update({name: {"$ref": "#/$defs/uuid4" if name == "operation_id" else "#/$defs/digest"} for name in mutation})
+    return {"type": "object", "properties": properties, "required": required, "additionalProperties": False}
+
+
+TERMINAL_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": TERMINAL_SCHEMA_NAME,
+    "oneOf": [_branch_schema(action) for action in _ROWS],
+    "$defs": {
+        "uuid4": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?![\\s\\S])"},
+        "digest": {"type": "string", "pattern": "^[0-9a-f]{64}(?![\\s\\S])"},
+        "ref": {"type": "string", "minLength": 1, "maxLength": 512, "not": {"pattern": "\\u0000"}},
+        "integer": {"type": "integer", "minimum": 0, "maximum": _MAX_SAFE_INTEGER},
+        "text": {"type": "string", "minLength": 1, "maxLength": 512, "not": {"pattern": "\\u0000"}},
+    },
+}
+
+
+def terminal_schema() -> dict[str, object]:
+    """Return a fresh JSON Schema for the terminal tagged union."""
+
+    return copy.deepcopy(TERMINAL_SCHEMA)
+
+
+def _validate_structure(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        _fail()
+    action = value.get("action")
+    if not isinstance(action, str) or action not in _ROWS:
+        _fail()
+    digest_fields, count_fields, allowed_actions = _ROWS[action]
+    common = {"schema", "action", "outcome", "run_id", "run_revision", "phase", "artifact_digests", "counts", "next_actions", "trusted_outputs"}
+    mutation = {"operation_id", "request_digest", "prior_state_digest", "final_state_digest"}
+    if set(value) != (common if action == "status" else common | mutation):
+        _fail()
+    if value["schema"] != TERMINAL_SCHEMA_NAME or value["outcome"] != ("observed" if action == "status" else "committed"):
+        _fail()
+    _uuid(value["run_id"])
+    _integer(value["run_revision"])
+    _text(value["phase"])
+    for item in _object(value["artifact_digests"], digest_fields).values():
+        _digest(item)
+    for item in _object(value["counts"], count_fields).values():
+        _integer(item)
+    _next_actions(value["next_actions"], allowed_actions)
+    _validate_outputs(action, value["trusted_outputs"])
+    if action != "status":
+        _uuid(value["operation_id"])
+        for name in ("request_digest", "prior_state_digest", "final_state_digest"):
+            _digest(value[name])
+    return copy.deepcopy(dict(value))
+
+
+def _request_action(value: Mapping[str, object]) -> str:
+    action = value.get("action")
+    if action == "plan":
+        if value.get("operation") == "materialize":
+            return "plan:materialize"
+        step = value.get("render_step")
+        if value.get("operation") == "render" and step in {"begin", "page", "acknowledge", "complete"}:
+            return f"plan:render-{step}"
+    if action == "rollback" and value.get("rollback_mode") in {"nonterminal-contingency", "terminal-plan"}:
+        return f"rollback:{value['rollback_mode']}"
+    if action == "retire-source" and value.get("phase") in {"clearance", "finalize"}:
+        return f"retire-source:{value['phase']}"
+    if action in _ROWS:
+        return action
+    _fail()
+
+
+def _request_digest(value: Mapping[str, object]) -> str:
+    try:
+        return hashlib.sha256(consolidation_plan.canonical_closed_jcs(value)).hexdigest()
+    except (consolidation_plan.ConsolidationPlanUnavailable, RecursionError):
+        _fail()
+
+
+def _eligible_plan_kinds(value: object) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        _fail()
+    kinds = tuple(_text(kind, maximum=16) for kind in value)
+    if not kinds or kinds != tuple(kind for kind in _PLAN_KINDS if kind in kinds):
+        _fail()
+    return kinds
+
+
+def _require_facts(
+    context: consolidation_successor.CanonicalSuccessorContext,
+    kind: str,
+    expected: Mapping[str, object],
+) -> None:
+    if context.preimage["context_kind"] != kind:
+        _fail()
+    facts = context.preimage["facts"]
+    if not isinstance(facts, Mapping):
+        _fail()
+    for name, item in expected.items():
+        if facts.get(name) != item:
+            _fail()
+
+
+def _validate_plan_entry(
+    state: TerminalProjectionState,
+    request: Mapping[str, object],
+    terminal: Mapping[str, object],
+    context: consolidation_successor.CanonicalSuccessorContext,
+) -> None:
+    outputs = terminal["trusted_outputs"]
+    assert isinstance(outputs, Mapping)
+    facts = context.preimage["facts"]
+    if not isinstance(facts, Mapping):
+        _fail()
+    projected = _eligible_plan_kinds(state.eligible_plan_kinds)
+    terminal_kinds = _eligible_plan_kinds(outputs.get("eligible_plan_kinds"))
+    context_kinds = _eligible_plan_kinds(facts.get("eligible_plan_kinds"))
+    if projected is None or projected != terminal_kinds or projected != context_kinds:
+        _fail()
+    if "plan" not in terminal["next_actions"] or state.nonterminal_contingency_eligible:
+        _fail()
+
+    action = terminal["action"]
+    phase = terminal["phase"]
+    if action == "status":
+        allowed = (
+            projected == ("cutover",) and phase in {"reconcile", "repair-terminal"}
+        ) or (
+            projected == ("rollback",)
+            and phase
+            in {
+                "complete",
+                "rollback-complete",
+                "retirement-pending-forward-only",
+                "retirement-finalize",
+                "repair-terminal",
+            }
+        ) or (
+            projected == ("rollback", "retirement")
+            and phase in {"complete", "repair-terminal"}
+        )
+    elif action == "reconcile":
+        counts = terminal["counts"]
+        assert isinstance(counts, Mapping)
+        allowed = phase == "reconcile" and counts["unresolved"] == 0 and projected == ("cutover",)
+    elif action == "apply":
+        allowed = phase == "complete" and projected in {
+            ("rollback",),
+            ("rollback", "retirement"),
+        }
+    elif action == "verify":
+        allowed = (
+            phase == "complete"
+            and request.get("verification_kind") == "transport"
+            and projected in {("rollback",), ("rollback", "retirement")}
+        )
+    elif action == "recover":
+        allowed = phase == "repair-terminal" and projected in {
+            ("cutover",),
+            ("rollback",),
+            ("rollback", "retirement"),
+        }
+    elif action in {"rollback:nonterminal-contingency", "rollback:terminal-plan"}:
+        allowed = phase == "rollback-complete" and projected == ("rollback",)
+    elif action == "retire-source:finalize":
+        allowed = phase == "retirement-finalize" and projected == ("rollback",)
+    else:
+        allowed = False
+    if not allowed or ("retirement" in projected and state.trusted_run_mode != "real-cutover"):
+        _fail()
+
+
+def _validate_successor_branch(
+    state: TerminalProjectionState,
+    request: Mapping[str, object],
+    terminal: Mapping[str, object],
+    context: consolidation_successor.CanonicalSuccessorContext,
+) -> None:
+    if context.preimage["run_id"] != terminal["run_id"] or context.preimage["run_revision"] != terminal["run_revision"]:
+        _fail()
+    action = str(terminal["action"])
+    outputs = terminal["trusted_outputs"]
+    artifacts = terminal["artifact_digests"]
+    counts = terminal["counts"]
+    assert isinstance(outputs, Mapping)
+    assert isinstance(artifacts, Mapping)
+    assert isinstance(counts, Mapping)
+    kind = context.preimage["context_kind"]
+
+    if action.startswith("plan:render-") or action == "approve":
+        if request["plan_digest"] != artifacts["plan_digest"]:
+            _fail()
+    if state.nonterminal_contingency_eligible != (
+        kind == "rollback-nonterminal-contingency"
+    ):
+        _fail()
+
+    if kind == "plan-materialize":
+        _validate_plan_entry(state, request, terminal, context)
+        return
+    if state.eligible_plan_kinds is not None or "eligible_plan_kinds" in outputs:
+        _fail()
+
+    if action == "status":
+        if "plan" in terminal["next_actions"] and kind not in _STATUS_PLAN_CONTEXTS:
+            _fail()
+        return
+    if action == "plan:materialize":
+        if tuple(terminal["next_actions"]) != ("status", "plan"):
+            _fail()
+        _require_facts(context, "render-begin", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"]})
+    elif action == "plan:render-begin":
+        if tuple(terminal["next_actions"]) != ("status", "plan"):
+            _fail()
+        _require_facts(context, "render-page", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"], "render_session_digest": artifacts["render_session_digest"], "page_ordinal": 0})
+    elif action == "plan:render-page":
+        if tuple(terminal["next_actions"]) != ("status", "plan"):
+            _fail()
+        if outputs["render_session_ref"] != request["render_session_ref"] or counts["page_ordinal"] != request["page_ordinal"]:
+            _fail()
+        _require_facts(context, "render-acknowledge", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"], "page_ordinal": request["page_ordinal"], "page_digest": artifacts["render_page_digest"]})
+    elif action == "plan:render-acknowledge":
+        if tuple(terminal["next_actions"]) != ("status", "plan"):
+            _fail()
+        if outputs["render_session_ref"] != request["render_session_ref"] or counts["acknowledged_pages"] != request["page_ordinal"] + 1 or counts["acknowledged_pages"] > counts["render_pages"]:
+            _fail()
+        expected_kind = "render-complete" if counts["acknowledged_pages"] == counts["render_pages"] else "render-page"
+        expected_facts = {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"]}
+        if expected_kind == "render-page":
+            expected_facts["page_ordinal"] = counts["acknowledged_pages"]
+        _require_facts(context, expected_kind, expected_facts)
+    elif action == "plan:render-complete":
+        if tuple(terminal["next_actions"]) != ("status", "approve"):
+            _fail()
+        if counts["render_pages"] == 0 or counts["acknowledged_pages"] != counts["render_pages"]:
+            _fail()
+        _require_facts(context, "approve", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"], "rendering_completeness_digest": artifacts["rendering_completeness_digest"]})
+    elif action == "approve":
+        kinds = {
+            "cutover": ("apply", "cutover_plan_digest", "approval_token_digest", "apply"),
+            "rollback": ("rollback-terminal-plan", "rollback_plan_digest", "rollback_token_digest", "rollback"),
+            "retirement": ("retire-source-clearance", "retirement_plan_digest", "retirement_token_digest", "retire-source"),
+        }
+        expected_kind, plan_field, token_field, next_action = kinds[str(request["plan_kind"])]
+        _require_facts(context, expected_kind, {plan_field: request["plan_digest"], token_field: artifacts["approval_token_digest"]})
+        if tuple(terminal["next_actions"]) != ("status", next_action):
+            _fail()
+    elif action in {"apply", "verify", "recover"} and kind == "rollback-nonterminal-contingency":
+        if terminal["phase"] == "complete" or not state.nonterminal_contingency_eligible or "plan" in terminal["next_actions"]:
+            _fail()
+        if action == "apply":
+            _require_facts(context, kind, {"original_apply_operation_id": request["operation_id"], "cutover_plan_digest": request["cutover_plan_digest"]})
+    else:
+        _fail()
+
+
+def _validate_projection_binding(
+    state: TerminalProjectionState,
+    request: Mapping[str, object],
+    terminal: Mapping[str, object],
+) -> None:
+    if terminal["action"] == "status":
+        expected_revision = request.get("expected_run_revision")
+        if expected_revision is not None and expected_revision != terminal["run_revision"]:
+            _fail()
+    else:
+        if (
+            request["operation_id"] != terminal["operation_id"]
+            or request["expected_run_revision"] + 1 != terminal["run_revision"]
+            or _request_digest(request) != terminal["request_digest"]
+        ):
+            _fail()
+
+
+def _projection(value: object) -> dict[str, object]:
+    if not isinstance(value, TerminalProjectionState):
+        _fail()
+    if type(value.nonterminal_contingency_eligible) is not bool:
+        _fail()
+    try:
+        request = consolidation_request.validate_request(
+            dict(value.validated_request), trusted_run_mode=value.trusted_run_mode
+        )
+    except (consolidation_request.ConsolidationRequestUnavailable, TypeError, ValueError):
+        _fail()
+    terminal = _validate_structure(value.terminal)
+    if terminal["action"] != _request_action(request):
+        _fail()
+    if request.get("action") != "start" and request.get("run_id") != terminal["run_id"]:
+        _fail()
+    _validate_projection_binding(value, request, terminal)
+    pair = {"successor_context_ref", "successor_context_digest"}
+    has_pair = pair <= set(terminal["trusted_outputs"])
+    context_values = (value.successor_reference, value.successor_context, value.expected_successor)
+    if has_pair:
+        if any(item is None for item in context_values):
+            _fail()
+        try:
+            context = consolidation_successor.verify_context(
+                value.successor_context, expected=value.expected_successor
+            )
+        except consolidation_successor.SuccessorContextUnavailable:
+            _fail()
+        if (
+            terminal["trusted_outputs"]["successor_context_ref"] != _text(value.successor_reference)
+            or terminal["trusted_outputs"]["successor_context_digest"] != context.digest
+        ):
+            _fail()
+        if terminal["action"] == "status" and request.get("detail", "summary") != "owner-detail":
+            _fail()
+        if context.preimage["successor_action"] not in terminal["next_actions"]:
+            _fail()
+        _validate_successor_branch(value, request, terminal, context)
+    elif (
+        any(item is not None for item in context_values)
+        or value.eligible_plan_kinds is not None
+        or value.nonterminal_contingency_eligible
+    ):
+        _fail()
+    elif terminal["action"] in {
+        "status",
+        "reconcile",
+        "apply",
+        "verify",
+        "recover",
+        "rollback:nonterminal-contingency",
+        "rollback:terminal-plan",
+        "retire-source:finalize",
+    } and "plan" in terminal["next_actions"]:
+        _fail()
+    return terminal
+
+
+def validate_terminal(
+    value: object,
+    *,
+    request: TerminalProjectionState,
+    successor_context: object | None = None,
+    plan_entry: object | None = None,
+) -> dict[str, object]:
+    """Validate an exact terminal against the coordinator's current resolved state."""
+
+    if successor_context is not None or plan_entry is not None:
+        _fail()
+    terminal = _validate_structure(value)
+    if terminal != _projection(request):
+        _fail()
+    return _ValidatedTerminal(terminal, seal=_TERMINAL_SEAL)
+
+
+def success_envelope(terminal: Mapping[str, object], delivery: str = "initial") -> dict[str, object]:
+    """Return a detached JSON value around a sealed validated terminal."""
+
+    if type(terminal) is not _ValidatedTerminal:
+        _fail()
+    checked = terminal
+    if delivery not in {"initial", "replayed"}:
+        _fail()
+    if checked["action"] == "status" and delivery != "initial":
+        _fail()
+    thawed = _thaw(checked)
+    if not isinstance(thawed, dict):
+        _fail()
+    return {"success": True, "data": {"delivery": delivery, "terminal": thawed}}
+
+
+__all__ = [
+    "TERMINAL_SCHEMA", "TERMINAL_SCHEMA_NAME", "ConsolidationTerminalUnavailable", "TerminalProjectionState",
+    "success_envelope", "terminal_schema", "validate_terminal",
+]

--- a/src/exomem/governance/consolidation_terminal.py
+++ b/src/exomem/governance/consolidation_terminal.py
@@ -15,7 +15,7 @@ import unicodedata
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import NoReturn
+from typing import NoReturn, cast
 
 from . import consolidation_plan, consolidation_request, consolidation_successor
 
@@ -30,23 +30,140 @@ _STATUS_PLAN_CONTEXTS = frozenset(
 )
 _PAIR = ("successor_context_ref", "successor_context_digest")
 _ROWS = {
-    "start": (("source_fingerprint", "destination_snapshot_fingerprint"), ("source_objects", "source_bytes", "destination_objects", "destination_bytes"), ("status", "reconcile")),
-    "status": (("run_state_digest", "journal_digest"), ("completed_effects", "pending_effects", "blocked_effects", "warnings"), ("status", "reconcile", "plan", "approve", "apply", "verify", "recover", "abort", "rollback", "retire-source")),
-    "reconcile": (("inventory_digest", "reconciliation_digest", "mapping_set_digest"), ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "unresolved", "mappings"), ("status", "reconcile", "plan")),
-    "plan:materialize": (("plan_digest", "control_basis_digest", "plan_successor_automaton_digest"), ("content_actions", "policy_documents", "impact_rows", "render_pages"), ("status", "plan")),
-    "plan:render-begin": (("plan_digest", "render_session_digest"), ("render_pages", "acknowledged_pages"), ("status", "plan")),
-    "plan:render-page": (("plan_digest", "render_page_digest"), ("page_ordinal", "page_rows", "render_pages"), ("status", "plan")),
-    "plan:render-acknowledge": (("plan_digest", "render_ack_digest"), ("acknowledged_pages", "render_pages"), ("status", "plan")),
-    "plan:render-complete": (("plan_digest", "rendering_completeness_digest"), ("acknowledged_pages", "render_pages"), ("status", "approve")),
-    "approve": (("plan_digest", "approval_token_digest"), ("acknowledged_pages", "render_pages"), ("status", "apply", "rollback", "retire-source")),
-    "apply": (("cutover_terminal_digest", "post_cutover_census_digest", "apply_predecessor_digest"), ("policy_documents", "content_batches", "content_actions", "rebuild_kinds", "in_process_probes", "transport_probes"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source")),
-    "verify": (("verification_basis_digest", "verification_terminal_digest"), ("positive_probes", "negative_probes", "passed_probes", "failed_probes"), ("status", "plan", "apply", "verify", "recover", "rollback", "retire-source")),
-    "recover": (("journal_digest", "recovery_terminal_digest"), ("classified_effects", "repaired_effects", "blocked_effects"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source")),
-    "abort": (("prior_census_digest", "abort_terminal_digest"), ("restored_entries", "removed_candidates", "evidence_events"), ("status",)),
-    "rollback:nonterminal-contingency": (("cutover_plan_digest", "original_apply_journal_digest", "rollback_contingency_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback")),
-    "rollback:terminal-plan": (("rollback_plan_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback")),
-    "retire-source:clearance": (("retirement_plan_digest", "clearance_digest", "retirement_lifecycle_digest", "surviving_copy_ledger_digest"), ("survivor_rows", "verified_survivor_rows"), ("status", "retire-source")),
-    "retire-source:finalize": (("retirement_plan_digest", "retirement_lifecycle_digest", "completion_digest", "finalization_digest", "surviving_copy_ledger_digest"), ("completion_records", "survivor_rows"), ("status", "plan")),
+    "start": (
+        ("source_fingerprint", "destination_snapshot_fingerprint"),
+        ("source_objects", "source_bytes", "destination_objects", "destination_bytes"),
+        ("status", "reconcile"),
+    ),
+    "status": (
+        ("run_state_digest", "journal_digest"),
+        ("completed_effects", "pending_effects", "blocked_effects", "warnings"),
+        (
+            "status",
+            "reconcile",
+            "plan",
+            "approve",
+            "apply",
+            "verify",
+            "recover",
+            "abort",
+            "rollback",
+            "retire-source",
+        ),
+    ),
+    "reconcile": (
+        ("inventory_digest", "reconciliation_digest", "mapping_set_digest"),
+        ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "unresolved", "mappings"),
+        ("status", "reconcile", "plan"),
+    ),
+    "plan:materialize": (
+        ("plan_digest", "control_basis_digest", "plan_successor_automaton_digest"),
+        ("content_actions", "policy_documents", "impact_rows", "render_pages"),
+        ("status", "plan"),
+    ),
+    "plan:render-begin": (
+        ("plan_digest", "render_session_digest"),
+        ("render_pages", "acknowledged_pages"),
+        ("status", "plan"),
+    ),
+    "plan:render-page": (
+        ("plan_digest", "render_page_digest"),
+        ("page_ordinal", "page_rows", "render_pages"),
+        ("status", "plan"),
+    ),
+    "plan:render-acknowledge": (
+        ("plan_digest", "render_ack_digest"),
+        ("acknowledged_pages", "render_pages"),
+        ("status", "plan"),
+    ),
+    "plan:render-complete": (
+        ("plan_digest", "rendering_completeness_digest"),
+        ("acknowledged_pages", "render_pages"),
+        ("status", "approve"),
+    ),
+    "approve": (
+        ("plan_digest", "approval_token_digest"),
+        ("acknowledged_pages", "render_pages"),
+        ("status", "apply", "rollback", "retire-source"),
+    ),
+    "apply": (
+        ("cutover_terminal_digest", "post_cutover_census_digest", "apply_predecessor_digest"),
+        (
+            "policy_documents",
+            "content_batches",
+            "content_actions",
+            "rebuild_kinds",
+            "in_process_probes",
+            "transport_probes",
+        ),
+        ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"),
+    ),
+    "verify": (
+        ("verification_basis_digest", "verification_terminal_digest"),
+        ("positive_probes", "negative_probes", "passed_probes", "failed_probes"),
+        ("status", "plan", "apply", "verify", "recover", "rollback", "retire-source"),
+    ),
+    "recover": (
+        ("journal_digest", "recovery_terminal_digest"),
+        ("classified_effects", "repaired_effects", "blocked_effects"),
+        ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"),
+    ),
+    "abort": (
+        ("prior_census_digest", "abort_terminal_digest"),
+        ("restored_entries", "removed_candidates", "evidence_events"),
+        ("status",),
+    ),
+    "rollback:nonterminal-contingency": (
+        (
+            "cutover_plan_digest",
+            "original_apply_journal_digest",
+            "rollback_contingency_digest",
+            "target_census_digest",
+            "rollback_terminal_digest",
+        ),
+        (
+            "restored_entries",
+            "retained_entries",
+            "reapplied_entries",
+            "discarded_entries",
+            "rebuild_kinds",
+            "verification_probes",
+        ),
+        ("status", "plan", "recover", "verify", "rollback"),
+    ),
+    "rollback:terminal-plan": (
+        ("rollback_plan_digest", "target_census_digest", "rollback_terminal_digest"),
+        (
+            "restored_entries",
+            "retained_entries",
+            "reapplied_entries",
+            "discarded_entries",
+            "rebuild_kinds",
+            "verification_probes",
+        ),
+        ("status", "plan", "recover", "verify", "rollback"),
+    ),
+    "retire-source:clearance": (
+        (
+            "retirement_plan_digest",
+            "clearance_digest",
+            "retirement_lifecycle_digest",
+            "surviving_copy_ledger_digest",
+        ),
+        ("survivor_rows", "verified_survivor_rows"),
+        ("status", "retire-source"),
+    ),
+    "retire-source:finalize": (
+        (
+            "retirement_plan_digest",
+            "retirement_lifecycle_digest",
+            "completion_digest",
+            "finalization_digest",
+            "surviving_copy_ledger_digest",
+        ),
+        ("completion_records", "survivor_rows"),
+        ("status", "plan"),
+    ),
 }
 
 
@@ -75,6 +192,7 @@ class TerminalProjectionState:
 
 class _ValidatedTerminal(Mapping[str, object]):
     __slots__ = ("_value",)
+    _value: Mapping[str, object]
 
     def __init__(self, value: Mapping[str, object], *, seal: object) -> None:
         if seal is not _TERMINAL_SEAL:
@@ -172,7 +290,14 @@ def _output_forms(action: str) -> tuple[tuple[str, ...], ...]:
     if action in {"start", "abort"}:
         return ((),)
     if action == "status":
-        return ((), ("next_cursor",), _PAIR, _PAIR + ("eligible_plan_kinds",), ("next_cursor",) + _PAIR, ("next_cursor",) + _PAIR + ("eligible_plan_kinds",))
+        return (
+            (),
+            ("next_cursor",),
+            _PAIR,
+            _PAIR + ("eligible_plan_kinds",),
+            ("next_cursor",) + _PAIR,
+            ("next_cursor",) + _PAIR + ("eligible_plan_kinds",),
+        )
     if action == "reconcile":
         return ((), _PAIR + ("eligible_plan_kinds",))
     if action == "plan:materialize":
@@ -201,7 +326,9 @@ def _validate_outputs(action: str, value: object) -> Mapping[str, object]:
         fields = frozenset(value)
     except TypeError:
         _fail()
-    if not all(isinstance(field, str) for field in fields) or fields not in {frozenset(form) for form in _output_forms(action)}:
+    if not all(isinstance(field, str) for field in fields) or fields not in {
+        frozenset(form) for form in _output_forms(action)
+    }:
         _fail()
     for name, item in value.items():
         if name.endswith("_digest"):
@@ -227,36 +354,88 @@ def _output_schema(fields: tuple[str, ...]) -> dict[str, object]:
         elif field.endswith("_ref") or field == "next_cursor":
             properties[field] = {"$ref": "#/$defs/ref"}
         else:
-            properties[field] = {"type": "array", "items": {"enum": list(_PLAN_KINDS)}, "uniqueItems": True}
-    return {"type": "object", "properties": properties, "required": list(fields), "additionalProperties": False}
+            properties[field] = {
+                "type": "array",
+                "items": {"enum": list(_PLAN_KINDS)},
+                "uniqueItems": True,
+            }
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(fields),
+        "additionalProperties": False,
+    }
 
 
 def _branch_schema(action: str) -> dict[str, object]:
     digest_fields, count_fields, next_actions = _ROWS[action]
-    required = ["schema", "action", "outcome", "run_id", "run_revision", "phase", "artifact_digests", "counts", "next_actions", "trusted_outputs"]
+    required = [
+        "schema",
+        "action",
+        "outcome",
+        "run_id",
+        "run_revision",
+        "phase",
+        "artifact_digests",
+        "counts",
+        "next_actions",
+        "trusted_outputs",
+    ]
     properties: dict[str, object] = {
-        "schema": {"const": TERMINAL_SCHEMA_NAME}, "action": {"const": action},
+        "schema": {"const": TERMINAL_SCHEMA_NAME},
+        "action": {"const": action},
         "outcome": {"const": "observed" if action == "status" else "committed"},
-        "run_id": {"$ref": "#/$defs/uuid4"}, "run_revision": {"$ref": "#/$defs/integer"},
+        "run_id": {"$ref": "#/$defs/uuid4"},
+        "run_revision": {"$ref": "#/$defs/integer"},
         "phase": {"$ref": "#/$defs/text"},
-        "artifact_digests": {"type": "object", "properties": {name: {"$ref": "#/$defs/digest"} for name in digest_fields}, "required": list(digest_fields), "additionalProperties": False},
-        "counts": {"type": "object", "properties": {name: {"$ref": "#/$defs/integer"} for name in count_fields}, "required": list(count_fields), "additionalProperties": False},
-        "next_actions": {"type": "array", "items": {"enum": list(next_actions)}, "uniqueItems": True},
+        "artifact_digests": {
+            "type": "object",
+            "properties": {name: {"$ref": "#/$defs/digest"} for name in digest_fields},
+            "required": list(digest_fields),
+            "additionalProperties": False,
+        },
+        "counts": {
+            "type": "object",
+            "properties": {name: {"$ref": "#/$defs/integer"} for name in count_fields},
+            "required": list(count_fields),
+            "additionalProperties": False,
+        },
+        "next_actions": {
+            "type": "array",
+            "items": {"enum": list(next_actions)},
+            "uniqueItems": True,
+        },
         "trusted_outputs": {"oneOf": [_output_schema(form) for form in _output_forms(action)]},
     }
     if action != "status":
         mutation = ("operation_id", "request_digest", "prior_state_digest", "final_state_digest")
         required.extend(mutation)
-        properties.update({name: {"$ref": "#/$defs/uuid4" if name == "operation_id" else "#/$defs/digest"} for name in mutation})
-    return {"type": "object", "properties": properties, "required": required, "additionalProperties": False}
+        properties.update(
+            {
+                name: {"$ref": "#/$defs/uuid4" if name == "operation_id" else "#/$defs/digest"}
+                for name in mutation
+            }
+        )
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
 
 
-TERMINAL_SCHEMA = {
+TERMINAL_SCHEMA: dict[str, object] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": TERMINAL_SCHEMA_NAME,
     "oneOf": [_branch_schema(action) for action in _ROWS],
     "$defs": {
-        "uuid4": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?![\\s\\S])"},
+        "uuid4": {
+            "type": "string",
+            "pattern": (
+                "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-"
+                "[89ab][0-9a-f]{3}-[0-9a-f]{12}(?![\\s\\S])"
+            ),
+        },
         "digest": {"type": "string", "pattern": "^[0-9a-f]{64}(?![\\s\\S])"},
         "ref": {"type": "string", "minLength": 1, "maxLength": 512, "not": {"pattern": "\\u0000"}},
         "integer": {"type": "integer", "minimum": 0, "maximum": _MAX_SAFE_INTEGER},
@@ -278,11 +457,24 @@ def _validate_structure(value: object) -> dict[str, object]:
     if not isinstance(action, str) or action not in _ROWS:
         _fail()
     digest_fields, count_fields, allowed_actions = _ROWS[action]
-    common = {"schema", "action", "outcome", "run_id", "run_revision", "phase", "artifact_digests", "counts", "next_actions", "trusted_outputs"}
+    common = {
+        "schema",
+        "action",
+        "outcome",
+        "run_id",
+        "run_revision",
+        "phase",
+        "artifact_digests",
+        "counts",
+        "next_actions",
+        "trusted_outputs",
+    }
     mutation = {"operation_id", "request_digest", "prior_state_digest", "final_state_digest"}
     if set(value) != (common if action == "status" else common | mutation):
         _fail()
-    if value["schema"] != TERMINAL_SCHEMA_NAME or value["outcome"] != ("observed" if action == "status" else "committed"):
+    if value["schema"] != TERMINAL_SCHEMA_NAME or value["outcome"] != (
+        "observed" if action == "status" else "committed"
+    ):
         _fail()
     _uuid(value["run_id"])
     _integer(value["run_revision"])
@@ -306,9 +498,17 @@ def _request_action(value: Mapping[str, object]) -> str:
         if value.get("operation") == "materialize":
             return "plan:materialize"
         step = value.get("render_step")
-        if value.get("operation") == "render" and step in {"begin", "page", "acknowledge", "complete"}:
+        if value.get("operation") == "render" and step in {
+            "begin",
+            "page",
+            "acknowledge",
+            "complete",
+        }:
             return f"plan:render-{step}"
-    if action == "rollback" and value.get("rollback_mode") in {"nonterminal-contingency", "terminal-plan"}:
+    if action == "rollback" and value.get("rollback_mode") in {
+        "nonterminal-contingency",
+        "terminal-plan",
+    }:
         return f"rollback:{value['rollback_mode']}"
     if action == "retire-source" and value.get("phase") in {"clearance", "finalize"}:
         return f"retire-source:{value['phase']}"
@@ -366,27 +566,29 @@ def _validate_plan_entry(
     context_kinds = _eligible_plan_kinds(facts.get("eligible_plan_kinds"))
     if projected is None or projected != terminal_kinds or projected != context_kinds:
         _fail()
-    if "plan" not in terminal["next_actions"] or state.nonterminal_contingency_eligible:
+    next_actions = cast(Sequence[str], terminal["next_actions"])
+    if "plan" not in next_actions or state.nonterminal_contingency_eligible:
         _fail()
 
     action = terminal["action"]
     phase = terminal["phase"]
     if action == "status":
         allowed = (
-            projected == ("cutover",) and phase in {"reconcile", "repair-terminal"}
-        ) or (
-            projected == ("rollback",)
-            and phase
-            in {
-                "complete",
-                "rollback-complete",
-                "retirement-pending-forward-only",
-                "retirement-finalize",
-                "repair-terminal",
-            }
-        ) or (
-            projected == ("rollback", "retirement")
-            and phase in {"complete", "repair-terminal"}
+            (projected == ("cutover",) and phase in {"reconcile", "repair-terminal"})
+            or (
+                projected == ("rollback",)
+                and phase
+                in {
+                    "complete",
+                    "rollback-complete",
+                    "retirement-pending-forward-only",
+                    "retirement-finalize",
+                    "repair-terminal",
+                }
+            )
+            or (
+                projected == ("rollback", "retirement") and phase in {"complete", "repair-terminal"}
+            )
         )
     elif action == "reconcile":
         counts = terminal["counts"]
@@ -425,12 +627,16 @@ def _validate_successor_branch(
     terminal: Mapping[str, object],
     context: consolidation_successor.CanonicalSuccessorContext,
 ) -> None:
-    if context.preimage["run_id"] != terminal["run_id"] or context.preimage["run_revision"] != terminal["run_revision"]:
+    if (
+        context.preimage["run_id"] != terminal["run_id"]
+        or context.preimage["run_revision"] != terminal["run_revision"]
+    ):
         _fail()
     action = str(terminal["action"])
     outputs = terminal["trusted_outputs"]
     artifacts = terminal["artifact_digests"]
     counts = terminal["counts"]
+    next_actions = cast(Sequence[str], terminal["next_actions"])
     assert isinstance(outputs, Mapping)
     assert isinstance(artifacts, Mapping)
     assert isinstance(counts, Mapping)
@@ -439,9 +645,7 @@ def _validate_successor_branch(
     if action.startswith("plan:render-") or action == "approve":
         if request["plan_digest"] != artifacts["plan_digest"]:
             _fail()
-    if state.nonterminal_contingency_eligible != (
-        kind == "rollback-nonterminal-contingency"
-    ):
+    if state.nonterminal_contingency_eligible != (kind == "rollback-nonterminal-contingency"):
         _fail()
 
     if kind == "plan-materialize":
@@ -451,54 +655,123 @@ def _validate_successor_branch(
         _fail()
 
     if action == "status":
-        if "plan" in terminal["next_actions"] and kind not in _STATUS_PLAN_CONTEXTS:
+        if "plan" in next_actions and kind not in _STATUS_PLAN_CONTEXTS:
             _fail()
         return
     if action == "plan:materialize":
-        if tuple(terminal["next_actions"]) != ("status", "plan"):
+        if tuple(next_actions) != ("status", "plan"):
             _fail()
-        _require_facts(context, "render-begin", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"]})
+        _require_facts(
+            context,
+            "render-begin",
+            {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"]},
+        )
     elif action == "plan:render-begin":
-        if tuple(terminal["next_actions"]) != ("status", "plan"):
+        if tuple(next_actions) != ("status", "plan"):
             _fail()
-        _require_facts(context, "render-page", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"], "render_session_digest": artifacts["render_session_digest"], "page_ordinal": 0})
+        _require_facts(
+            context,
+            "render-page",
+            {
+                "plan_kind": request["plan_kind"],
+                "plan_digest": artifacts["plan_digest"],
+                "render_session_digest": artifacts["render_session_digest"],
+                "page_ordinal": 0,
+            },
+        )
     elif action == "plan:render-page":
-        if tuple(terminal["next_actions"]) != ("status", "plan"):
+        if tuple(next_actions) != ("status", "plan"):
             _fail()
-        if outputs["render_session_ref"] != request["render_session_ref"] or counts["page_ordinal"] != request["page_ordinal"]:
+        if (
+            outputs["render_session_ref"] != request["render_session_ref"]
+            or counts["page_ordinal"] != request["page_ordinal"]
+        ):
             _fail()
-        _require_facts(context, "render-acknowledge", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"], "page_ordinal": request["page_ordinal"], "page_digest": artifacts["render_page_digest"]})
+        _require_facts(
+            context,
+            "render-acknowledge",
+            {
+                "plan_kind": request["plan_kind"],
+                "plan_digest": artifacts["plan_digest"],
+                "page_ordinal": request["page_ordinal"],
+                "page_digest": artifacts["render_page_digest"],
+            },
+        )
     elif action == "plan:render-acknowledge":
-        if tuple(terminal["next_actions"]) != ("status", "plan"):
+        if tuple(next_actions) != ("status", "plan"):
             _fail()
-        if outputs["render_session_ref"] != request["render_session_ref"] or counts["acknowledged_pages"] != request["page_ordinal"] + 1 or counts["acknowledged_pages"] > counts["render_pages"]:
+        if (
+            outputs["render_session_ref"] != request["render_session_ref"]
+            or counts["acknowledged_pages"] != cast(int, request["page_ordinal"]) + 1
+            or counts["acknowledged_pages"] > counts["render_pages"]
+        ):
             _fail()
-        expected_kind = "render-complete" if counts["acknowledged_pages"] == counts["render_pages"] else "render-page"
-        expected_facts = {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"]}
+        expected_kind = (
+            "render-complete"
+            if counts["acknowledged_pages"] == counts["render_pages"]
+            else "render-page"
+        )
+        expected_facts = {
+            "plan_kind": request["plan_kind"],
+            "plan_digest": artifacts["plan_digest"],
+        }
         if expected_kind == "render-page":
             expected_facts["page_ordinal"] = counts["acknowledged_pages"]
         _require_facts(context, expected_kind, expected_facts)
     elif action == "plan:render-complete":
-        if tuple(terminal["next_actions"]) != ("status", "approve"):
+        if tuple(next_actions) != ("status", "approve"):
             _fail()
         if counts["render_pages"] == 0 or counts["acknowledged_pages"] != counts["render_pages"]:
             _fail()
-        _require_facts(context, "approve", {"plan_kind": request["plan_kind"], "plan_digest": artifacts["plan_digest"], "rendering_completeness_digest": artifacts["rendering_completeness_digest"]})
+        _require_facts(
+            context,
+            "approve",
+            {
+                "plan_kind": request["plan_kind"],
+                "plan_digest": artifacts["plan_digest"],
+                "rendering_completeness_digest": artifacts["rendering_completeness_digest"],
+            },
+        )
     elif action == "approve":
         kinds = {
             "cutover": ("apply", "cutover_plan_digest", "approval_token_digest", "apply"),
-            "rollback": ("rollback-terminal-plan", "rollback_plan_digest", "rollback_token_digest", "rollback"),
-            "retirement": ("retire-source-clearance", "retirement_plan_digest", "retirement_token_digest", "retire-source"),
+            "rollback": (
+                "rollback-terminal-plan",
+                "rollback_plan_digest",
+                "rollback_token_digest",
+                "rollback",
+            ),
+            "retirement": (
+                "retire-source-clearance",
+                "retirement_plan_digest",
+                "retirement_token_digest",
+                "retire-source",
+            ),
         }
         expected_kind, plan_field, token_field, next_action = kinds[str(request["plan_kind"])]
-        _require_facts(context, expected_kind, {plan_field: request["plan_digest"], token_field: artifacts["approval_token_digest"]})
-        if tuple(terminal["next_actions"]) != ("status", next_action):
+        _require_facts(
+            context,
+            expected_kind,
+            {plan_field: request["plan_digest"], token_field: artifacts["approval_token_digest"]},
+        )
+        if tuple(next_actions) != ("status", next_action):
             _fail()
     elif action in {"apply", "verify", "recover"} and kind == "rollback-nonterminal-contingency":
-        if terminal["phase"] == "complete" or not state.nonterminal_contingency_eligible or "plan" in terminal["next_actions"]:
+        if (
+            terminal["phase"] == "complete"
+            or not state.nonterminal_contingency_eligible
+            or "plan" in next_actions
+        ):
             _fail()
         if action == "apply":
-            _require_facts(context, kind, {"original_apply_operation_id": request["operation_id"], "cutover_plan_digest": request["cutover_plan_digest"]})
+            _require_facts(
+                context,
+                kind,
+                {
+                    "original_apply_operation_id": request["operation_id"],
+                    "cutover_plan_digest": request["cutover_plan_digest"],
+                },
+            )
     else:
         _fail()
 
@@ -515,7 +788,7 @@ def _validate_projection_binding(
     else:
         if (
             request["operation_id"] != terminal["operation_id"]
-            or request["expected_run_revision"] + 1 != terminal["run_revision"]
+            or cast(int, request["expected_run_revision"]) + 1 != terminal["run_revision"]
             or _request_digest(request) != terminal["request_digest"]
         ):
             _fail()
@@ -539,7 +812,9 @@ def _projection(value: object) -> dict[str, object]:
         _fail()
     _validate_projection_binding(value, request, terminal)
     pair = {"successor_context_ref", "successor_context_digest"}
-    has_pair = pair <= set(terminal["trusted_outputs"])
+    outputs = cast(Mapping[str, object], terminal["trusted_outputs"])
+    next_actions = cast(Sequence[str], terminal["next_actions"])
+    has_pair = pair <= set(outputs)
     context_values = (value.successor_reference, value.successor_context, value.expected_successor)
     if has_pair:
         if any(item is None for item in context_values):
@@ -551,13 +826,13 @@ def _projection(value: object) -> dict[str, object]:
         except consolidation_successor.SuccessorContextUnavailable:
             _fail()
         if (
-            terminal["trusted_outputs"]["successor_context_ref"] != _text(value.successor_reference)
-            or terminal["trusted_outputs"]["successor_context_digest"] != context.digest
+            outputs["successor_context_ref"] != _text(value.successor_reference)
+            or outputs["successor_context_digest"] != context.digest
         ):
             _fail()
         if terminal["action"] == "status" and request.get("detail", "summary") != "owner-detail":
             _fail()
-        if context.preimage["successor_action"] not in terminal["next_actions"]:
+        if context.preimage["successor_action"] not in next_actions:
             _fail()
         _validate_successor_branch(value, request, terminal, context)
     elif (
@@ -566,16 +841,20 @@ def _projection(value: object) -> dict[str, object]:
         or value.nonterminal_contingency_eligible
     ):
         _fail()
-    elif terminal["action"] in {
-        "status",
-        "reconcile",
-        "apply",
-        "verify",
-        "recover",
-        "rollback:nonterminal-contingency",
-        "rollback:terminal-plan",
-        "retire-source:finalize",
-    } and "plan" in terminal["next_actions"]:
+    elif (
+        terminal["action"]
+        in {
+            "status",
+            "reconcile",
+            "apply",
+            "verify",
+            "recover",
+            "rollback:nonterminal-contingency",
+            "rollback:terminal-plan",
+            "retire-source:finalize",
+        }
+        and "plan" in next_actions
+    ):
         _fail()
     return terminal
 
@@ -586,7 +865,7 @@ def validate_terminal(
     request: TerminalProjectionState,
     successor_context: object | None = None,
     plan_entry: object | None = None,
-) -> dict[str, object]:
+) -> Mapping[str, object]:
     """Validate an exact terminal against the coordinator's current resolved state."""
 
     if successor_context is not None or plan_entry is not None:
@@ -597,7 +876,9 @@ def validate_terminal(
     return _ValidatedTerminal(terminal, seal=_TERMINAL_SEAL)
 
 
-def success_envelope(terminal: Mapping[str, object], delivery: str = "initial") -> dict[str, object]:
+def success_envelope(
+    terminal: Mapping[str, object], delivery: str = "initial"
+) -> dict[str, object]:
     """Return a detached JSON value around a sealed validated terminal."""
 
     if type(terminal) is not _ValidatedTerminal:
@@ -614,6 +895,11 @@ def success_envelope(terminal: Mapping[str, object], delivery: str = "initial") 
 
 
 __all__ = [
-    "TERMINAL_SCHEMA", "TERMINAL_SCHEMA_NAME", "ConsolidationTerminalUnavailable", "TerminalProjectionState",
-    "success_envelope", "terminal_schema", "validate_terminal",
+    "TERMINAL_SCHEMA",
+    "TERMINAL_SCHEMA_NAME",
+    "ConsolidationTerminalUnavailable",
+    "TerminalProjectionState",
+    "success_envelope",
+    "terminal_schema",
+    "validate_terminal",
 ]

--- a/src/exomem/governance/principal.py
+++ b/src/exomem/governance/principal.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .authorization_session_lifecycle import AuthorizationSessionContext
+    from .consolidation_owner import ConsolidationOwnerContext
 
 # The vault's own operator: stdio MCP, the CLI, the shared REST key, and any
 # in-process/library call with no surface bound.
@@ -89,6 +90,7 @@ class RequestPrincipal:
     resolved: bool = True
     issuer_family: str | None = None
     verified_authorization_session: AuthorizationSessionContext | None = None
+    consolidation_owner_context: ConsolidationOwnerContext | None = None
 
     def with_purpose(self, purpose: str | None) -> RequestPrincipal:
         """Layer a per-call declared purpose on without mutating the binding."""
@@ -112,6 +114,7 @@ class RequestPrincipal:
             authorization_session_id=context.session_id if context is not None else None,
             issuer_family=issuer_family,
             verified_authorization_session=context,
+            consolidation_owner_context=None,
         )
 
 

--- a/src/exomem/product_invoke.py
+++ b/src/exomem/product_invoke.py
@@ -116,6 +116,19 @@ def invoke_prepared(
     from .governance import principal as principal_module
     from .writer_lease import invoke_command
 
+    if cmd.name == "consolidate_memory":
+        import time
+
+        from .governance import consolidation_owner
+
+        consolidation_owner.require_injected_owner(principal, now=int(time.time()))
+        selected = vault_root if vault_root is not None else os.environ.get("EXOMEM_VAULT_PATH")
+        if not selected:
+            raise consolidation_owner.ConsolidationOwnerUnavailable
+        consolidation_owner.require_bound_request(
+            Path(selected), principal=principal, arguments=kwargs, now=int(time.time()),
+        )
+
     # Domain-invalid mixed selectors must reach their stable public error
     # before the lease/egress coverage classifier. This is input validation,
     # not a branch registration.
@@ -180,7 +193,7 @@ def prepare_local_authorization(
         authorization_session_fd=authorization_session_fd,
         authorization_carrier=authorization_carrier,
     )
-    principal = enforce_local_authorization_route(cmd, raw, admission)
+    principal = enforce_local_authorization_route(cmd, raw, admission, vault_root=root)
     return root, principal
 
 
@@ -203,12 +216,6 @@ def verify_local_authorization_transport(
     )
     from .governance import principal as principal_module
 
-    root = resolve_vault_for(cmd.name, raw_for_vault, vault_root)
-    if surface == "cli":
-        try:
-            consolidation_enrollment.ensure_cli_runtime_presence(root)
-        except consolidation_enrollment.ConsolidationEnrollmentUnavailable:
-            raise cli_ops.OpError("VAULT_UNAVAILABLE", "vault is unavailable") from None
     carrier = authorization_carrier
     if carrier is None:
         carrier = (
@@ -218,6 +225,38 @@ def verify_local_authorization_transport(
                 authorization_session_fd
             )
         )
+    if cmd.name == "consolidate_memory":
+        from .governance import consolidation_owner
+
+        if surface != "cli" or carrier.is_absent or carrier.is_invalid:
+            carrier.discard()
+            raise consolidation_owner.ConsolidationOwnerUnavailable
+        # The destination comes from trusted host configuration, never action
+        # fields. Do not validate vault existence or register runtime presence
+        # before the protected session has established owner authority.
+        selected_root = vault_root if vault_root is not None else os.environ.get(
+            "EXOMEM_VAULT_PATH"
+        )
+        if not selected_root:
+            carrier.discard()
+            raise consolidation_owner.ConsolidationOwnerUnavailable
+        root = Path(selected_root)
+        now = int(time.time())
+        try:
+            admission = authorization_request.verify_authorization_context(
+                root, principal=principal_module.owner_principal(surface=surface),
+                credential=carrier.consume(), now=now,
+            )
+            consolidation_owner.require_local_owner_session(admission.principal, now=now)
+        except authorization_request.AuthorizationContextUnavailable:
+            raise consolidation_owner.ConsolidationOwnerUnavailable from None
+        return root, admission
+    root = resolve_vault_for(cmd.name, raw_for_vault, vault_root)
+    if surface == "cli":
+        try:
+            consolidation_enrollment.ensure_cli_runtime_presence(root)
+        except consolidation_enrollment.ConsolidationEnrollmentUnavailable:
+            raise cli_ops.OpError("VAULT_UNAVAILABLE", "vault is unavailable") from None
     admission = authorization_request.verify_authorization_context(
         root,
         principal=principal_module.owner_principal(surface=surface),
@@ -227,9 +266,22 @@ def verify_local_authorization_transport(
     return root, admission
 
 
-def enforce_local_authorization_route(cmd, raw: dict[str, Any], admission):
+def enforce_local_authorization_route(
+    cmd, raw: dict[str, Any], admission, *, vault_root: Path | None = None,
+):
     """Apply the closed route rule after argument parsing identifies the variant."""
     from .governance import authorization_request
+
+    if cmd.name == "consolidate_memory":
+        import time
+
+        from .governance import consolidation_owner
+
+        if vault_root is None or not admission.credential_present:
+            raise consolidation_owner.ConsolidationOwnerUnavailable
+        return consolidation_owner.bind_local_owner(
+            vault_root, principal=admission.principal, arguments=raw, now=int(time.time()),
+        )
 
     rule = authorization_request.credential_rule(cmd.name, raw)
     return authorization_request.enforce_credential_rule(admission, rule)

--- a/src/exomem/server_rest.py
+++ b/src/exomem/server_rest.py
@@ -22,7 +22,12 @@ from starlette.responses import JSONResponse
 from . import capabilities, cf_access, cli_ops, edit_operations, runtime_resources, upload_tokens
 from . import commands as commands_module
 from .command_surface import canonical_request_id
-from .governance import authorization_request, authorization_transport
+from .governance import (
+    authorization_request,
+    authorization_transport,
+    consolidation_owner,
+    consolidation_request,
+)
 from .server_transfer import TransferConfig
 
 _log = logging.getLogger(__name__)
@@ -310,7 +315,7 @@ def register_rest_facade(
             )
         return None, principal_scope
 
-    async def _rest_body(request: Request) -> dict | None:
+    async def _rest_body(request: Request, *, consolidation: bool = False) -> dict | None:
         try:
             raw = await request.body()
         except Exception:  # noqa: BLE001
@@ -318,7 +323,7 @@ def register_rest_facade(
         if not raw or not raw.strip():
             return {}
         try:
-            data = json.loads(raw)
+            data = consolidation_request.decode_request_json(raw) if consolidation else json.loads(raw)
         except Exception:  # noqa: BLE001
             return None
         return data if isinstance(data, dict) else None
@@ -364,7 +369,11 @@ def register_rest_facade(
                     credential=request_carrier.consume(),
                     now=int(time.time()),
                 )
-                body = await _rest_body(request)
+                if _cmd.name == "consolidate_memory":
+                    consolidation_owner.require_local_owner_session(
+                        admission.principal, now=int(time.time()),
+                    )
+                body = await _rest_body(request, consolidation=_cmd.name == "consolidate_memory")
                 if body is None:
                     raise cli_ops.OpError("INVALID_BODY", "request body must be a JSON object")
                 forbidden_identity_fields = {
@@ -378,11 +387,18 @@ def register_rest_facade(
                 }
                 if forbidden_identity_fields.intersection(body):
                     raise authorization_request.AuthorizationContextUnavailable
-                rule = authorization_request.credential_rule(_cmd.name, body)
-                bound_principal = authorization_request.enforce_credential_rule(
-                    admission,
-                    rule,
-                )
+                if _cmd.name == "consolidate_memory":
+                    bound_principal = await run_in_threadpool(
+                        consolidation_owner.bind_local_owner,
+                        vault_root, principal=admission.principal,
+                        arguments=body, now=int(time.time()),
+                    )
+                else:
+                    rule = authorization_request.credential_rule(_cmd.name, body)
+                    bound_principal = authorization_request.enforce_credential_rule(
+                        admission,
+                        rule,
+                    )
                 if _cmd.name == "edit_memory":
                     body = edit_operations.normalize_edit_surface_arguments(body)
                 kwargs = cli_ops.coerce(
@@ -426,6 +442,8 @@ def register_rest_facade(
                     status_code=cli_ops.http_status_for(err["code"]),
                 )
             except (
+                consolidation_owner.ConsolidationOwnerUnavailable,
+                consolidation_request.ConsolidationRequestUnavailable,
                 authorization_request.AuthorizationContextUnavailable,
                 authorization_request.AuthorizationRouteUnclassified,
                 cli_ops.OpError,

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -4733,6 +4733,19 @@ def _consolidation_command_admission(
         mutation_request_id: str | None = None,
         **kwargs: Any,
     ) -> Any:
+        if command.name == "consolidate_memory":
+            from .governance import consolidation_owner
+            from .governance.principal import current_principal
+
+            principal = current_principal()
+            now = int(time.time())
+            consolidation_owner.require_injected_owner(principal, now=now)
+            if not injected or not isinstance(injected[0], (Path, str)):
+                raise consolidation_owner.ConsolidationOwnerUnavailable
+            consolidation_owner.require_bound_request(
+                Path(injected[0]), principal=principal, arguments=kwargs, now=now,
+            )
+
         def invoke() -> Any:
             return function(
                 command,

--- a/tests/test_consolidation_owner.py
+++ b/tests/test_consolidation_owner.py
@@ -766,3 +766,32 @@ def test_mcp_raw_decoder_refuses_non_utf8_json():
     raw = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"consolidate_memory","arguments":{}}}'
     with pytest.raises(authorization_transport.AuthorizationEnvelopeUnavailable):
         authorization_transport.sanitize_mcp_http_body(raw.encode("utf-16"))
+
+
+def test_stdio_decoder_refuses_invalid_utf8_without_normalizing_it(monkeypatch):
+    import asyncio
+    import io
+    from types import SimpleNamespace
+
+    import anyio
+    from mcp.shared.message import SessionMessage
+
+    from exomem.governance import authorization_transport
+
+    invalid = (b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+               b'"params":{"name":"consolidate_memory","arguments":{"cursor":"\xff"}}}\n')
+    valid = b'{"jsonrpc":"2.0","id":2,"method":"ping"}\n'
+    monkeypatch.setattr(authorization_transport.sys, "stdin", SimpleNamespace(buffer=io.BytesIO(invalid + valid)))
+
+    async def receive():
+        output = anyio.wrap_file(io.StringIO())
+        async with authorization_transport.sanitized_stdio_server(stdout=output) as (reader, writer):
+            first = await reader.receive()
+            second = await reader.receive()
+            await writer.aclose()
+        return first, second
+
+    first, second = asyncio.run(receive())
+    assert isinstance(first, authorization_transport.AuthorizationEnvelopeUnavailable)
+    assert isinstance(second, SessionMessage)
+    assert second.message.root.id == 2

--- a/tests/test_consolidation_owner.py
+++ b/tests/test_consolidation_owner.py
@@ -16,8 +16,17 @@ from exomem.governance.principal import RequestPrincipal, owner_principal
 
 NOW = 1_800_000_000
 ACTIONS = (
-    "start", "status", "reconcile", "plan", "approve", "apply", "verify",
-    "recover", "abort", "rollback", "retire-source",
+    "start",
+    "status",
+    "reconcile",
+    "plan",
+    "approve",
+    "apply",
+    "verify",
+    "recover",
+    "abort",
+    "rollback",
+    "retire-source",
 )
 
 
@@ -41,22 +50,29 @@ def _principal(surface="mcp"):
         expires_at=NOW + 600,
     )
     return who.with_verified_authorization_session(
-        session, issuer_family=who.issuer_family,
+        session,
+        issuer_family=who.issuer_family,
     )
 
 
 def _identity():
     return consolidation_identity.ConsolidationCellIdentity(
         schema=consolidation_identity.IDENTITY_SCHEMA,
-        cell_id="cell-a", vault_id="vault-a",
+        cell_id="cell-a",
+        vault_id="vault-a",
         installation_id="installation-v1-" + "a" * 64,
-        installation_generation=1, active_fence_digest="b" * 64,
+        installation_generation=1,
+        active_fence_digest="b" * 64,
         root_binding_id="attachment-v1-" + "c" * 64,
-        root_binding_digest="d" * 64, machine_key_id="host-key-v1-" + "e" * 64,
+        root_binding_digest="d" * 64,
+        machine_key_id="host-key-v1-" + "e" * 64,
         adoption_census_digest="f" * 64,
-        clone_of_vault_id=None, clone_of_installation_id=None,
-        clone_of_snapshot_digest=None, created_at=NOW - 60,
-        authentication_algorithm="HMAC-SHA256", record_digest="1" * 64,
+        clone_of_vault_id=None,
+        clone_of_installation_id=None,
+        clone_of_snapshot_digest=None,
+        created_at=NOW - 60,
+        authentication_algorithm="HMAC-SHA256",
+        record_digest="1" * 64,
         identity_path=Path("private-identity.json"),
     )
 
@@ -77,32 +93,51 @@ def verified_session_stub(monkeypatch):
     """Only facts/adapter unit tests stub durable verification; real tests don't."""
     module = _module()
     monkeypatch.setattr(
-        module, "_durable_session",
+        module,
+        "_durable_session",
         lambda root, *, principal, now: module._session(principal, now=now),
     )
 
 
 @pytest.mark.parametrize("action", ACTIONS)
-@pytest.mark.parametrize("who", [None, owner_principal(), _principal("library"),
-    RequestPrincipal("ordinary", surface="mcp", issuer_family="mcp-local-stdio"),
-    replace(_principal(), resolved=False)])
+@pytest.mark.parametrize(
+    "who",
+    [
+        None,
+        owner_principal(),
+        _principal("library"),
+        RequestPrincipal("ordinary", surface="mcp", issuer_family="mcp-local-stdio"),
+        replace(_principal(), resolved=False),
+    ],
+)
 def test_nonowner_and_unbound_calls_refuse_before_identity_or_body(
-    tmp_path, monkeypatch, action, who,
+    tmp_path,
+    monkeypatch,
+    action,
+    who,
 ):
     module = _module()
-    monkeypatch.setattr(consolidation_identity, "load_local_identity",
-                        lambda *a, **k: pytest.fail("unauthorized identity lookup"))
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *a, **k: pytest.fail("unauthorized identity lookup"),
+    )
     before = tuple(tmp_path.rglob("*"))
     with pytest.raises(module.ConsolidationOwnerUnavailable) as error:
         module.admit_local_owner(
-            tmp_path, principal=who,
-            arguments={"schema": "exomem.consolidate-memory-request/v1",
-                       "action": action, "source_artifact_ref": _Secret()},
+            tmp_path,
+            principal=who,
+            arguments={
+                "schema": "exomem.consolidate-memory-request/v1",
+                "action": action,
+                "source_artifact_ref": _Secret(),
+            },
             now=NOW,
         )
     assert error.value.as_public_dict() == {
         "code": "CONSOLIDATION_OWNER_UNAVAILABLE",
-        "message": "consolidation owner is unavailable", "remediation": None,
+        "message": "consolidation owner is unavailable",
+        "remediation": None,
     }
     assert tuple(tmp_path.rglob("*")) == before
 
@@ -110,21 +145,32 @@ def test_nonowner_and_unbound_calls_refuse_before_identity_or_body(
 @pytest.mark.parametrize("action", ACTIONS)
 @pytest.mark.parametrize("surface", ["cli", "mcp", "rest"])
 def test_explicit_session_owner_is_bound_to_exact_action_and_installation(
-    tmp_path, monkeypatch, action, surface, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    action,
+    surface,
+    verified_session_stub,
 ):
     module = _module()
     who = _principal(surface)
     identity = _identity()
-    monkeypatch.setattr(consolidation_identity, "load_local_identity",
-                        lambda *a, **k: identity)
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
     context = module.admit_local_owner(
-        tmp_path, principal=who,
-        arguments={"schema": "exomem.consolidate-memory-request/v1",
-                   "action": action, "source_artifact_ref": _Secret()},
+        tmp_path,
+        principal=who,
+        arguments={
+            "schema": "exomem.consolidate-memory-request/v1",
+            "action": action,
+            "source_artifact_ref": _Secret(),
+        },
         now=NOW,
     )
     facts = module.require_owner_context(
-        context, principal=who, identity=identity, action=action, now=NOW,
+        context,
+        principal=who,
+        identity=identity,
+        action=action,
+        now=NOW,
     )
     assert facts.schema == "ConsolidationOwnerContext/v1"
     assert facts.purpose == "vault-consolidation"
@@ -143,18 +189,40 @@ def test_explicit_session_owner_is_bound_to_exact_action_and_installation(
             operation(context)
 
 
-@pytest.mark.parametrize("change", ["action", "vault", "installation", "generation",
-    "fence", "session", "issuer", "surface", "expired", "future", "forged"])
+@pytest.mark.parametrize(
+    "change",
+    [
+        "action",
+        "vault",
+        "installation",
+        "generation",
+        "fence",
+        "session",
+        "issuer",
+        "surface",
+        "expired",
+        "future",
+        "forged",
+    ],
+)
 def test_owner_capability_cannot_cross_or_outlive_its_binding(
-    tmp_path, monkeypatch, change, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    change,
+    verified_session_stub,
 ):
     module = _module()
     who = _principal()
     identity = _identity()
     monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
     context = module.admit_local_owner(
-        tmp_path, principal=who,
-        arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        tmp_path,
+        principal=who,
+        arguments={
+            "schema": "exomem.consolidate-memory-request/v1",
+            "action": "status",
+            "run_id": "123e4567-e89b-42d3-a456-426614174000",
+        },
         now=NOW,
     )
     action, now = "status", NOW
@@ -182,13 +250,20 @@ def test_owner_capability_cannot_cross_or_outlive_its_binding(
         context = {"owner": True}
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         module.require_owner_context(
-            context, principal=who, identity=identity, action=action, now=now,
+            context,
+            principal=who,
+            identity=identity,
+            action=action,
+            now=now,
         )
 
 
 @pytest.mark.parametrize("change", ["vault", "cell", "alias", "session", "expired"])
 def test_cross_bound_identity_never_mints_context(
-    tmp_path, monkeypatch, change, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    change,
+    verified_session_stub,
 ):
     module = _module()
     who, identity = _principal(), _identity()
@@ -201,20 +276,31 @@ def test_cross_bound_identity_never_mints_context(
     elif change == "session":
         who = replace(who, authorization_session_id="different-session")
     else:
-        who = replace(who, verified_authorization_session=replace(
-            who.verified_authorization_session, expires_at=NOW,
-        ))
+        who = replace(
+            who,
+            verified_authorization_session=replace(
+                who.verified_authorization_session,
+                expires_at=NOW,
+            ),
+        )
     monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         module.admit_local_owner(
-            tmp_path, principal=who,
-            arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+            tmp_path,
+            principal=who,
+            arguments={
+                "schema": "exomem.consolidate-memory-request/v1",
+                "action": "status",
+                "run_id": "123e4567-e89b-42d3-a456-426614174000",
+            },
             now=NOW,
         )
 
 
 def test_adapter_binds_context_but_session_reverification_clears_it(
-    tmp_path, monkeypatch, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    verified_session_stub,
 ):
     module = _module()
     who, identity = _principal(), _identity()
@@ -222,16 +308,25 @@ def test_adapter_binds_context_but_session_reverification_clears_it(
     bind = getattr(module, "bind_local_owner", None)
     assert callable(bind), "the trusted adapter must carry owner authority to dispatch"
     bound = bind(
-        tmp_path, principal=who,
-        arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        tmp_path,
+        principal=who,
+        arguments={
+            "schema": "exomem.consolidate-memory-request/v1",
+            "action": "status",
+            "run_id": "123e4567-e89b-42d3-a456-426614174000",
+        },
         now=NOW,
     )
     module.require_owner_context(
-        bound.consolidation_owner_context, principal=bound,
-        identity=identity, action="status", now=NOW,
+        bound.consolidation_owner_context,
+        principal=bound,
+        identity=identity,
+        action="status",
+        now=NOW,
     )
     rebound = bound.with_verified_authorization_session(
-        who.verified_authorization_session, issuer_family=who.issuer_family,
+        who.verified_authorization_session,
+        issuer_family=who.issuer_family,
     )
     assert rebound.consolidation_owner_context is None
 
@@ -242,13 +337,19 @@ def test_unbound_prepared_consolidation_refuses_before_vault_resolution(monkeypa
     from exomem import product_invoke
 
     module = _module()
-    monkeypatch.setattr(product_invoke, "resolve_vault_for",
-                        lambda *a, **k: pytest.fail("unbound request resolved vault"))
+    monkeypatch.setattr(
+        product_invoke,
+        "resolve_vault_for",
+        lambda *a, **k: pytest.fail("unbound request resolved vault"),
+    )
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         product_invoke.invoke_prepared(
             SimpleNamespace(name="consolidate_memory"),
-            {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
-             "run_id": _Secret()},
+            {
+                "schema": "exomem.consolidate-memory-request/v1",
+                "action": "status",
+                "run_id": _Secret(),
+            },
             principal=_principal("library"),
         )
 
@@ -260,14 +361,22 @@ def test_local_transport_denies_absent_session_before_presence_and_resolution(mo
     from exomem.governance import consolidation_enrollment
 
     module = _module()
-    monkeypatch.setattr(product_invoke, "resolve_vault_for",
-                        lambda *a, **k: pytest.fail("unauthorized vault resolution"))
-    monkeypatch.setattr(consolidation_enrollment, "ensure_cli_runtime_presence",
-                        lambda *a, **k: pytest.fail("unauthorized presence registration"))
+    monkeypatch.setattr(
+        product_invoke,
+        "resolve_vault_for",
+        lambda *a, **k: pytest.fail("unauthorized vault resolution"),
+    )
+    monkeypatch.setattr(
+        consolidation_enrollment,
+        "ensure_cli_runtime_presence",
+        lambda *a, **k: pytest.fail("unauthorized presence registration"),
+    )
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         product_invoke.verify_local_authorization_transport(
-            SimpleNamespace(name="consolidate_memory"), raw_for_vault={"run_id": _Secret()},
-            surface="cli", vault_root=Path("does-not-exist"),
+            SimpleNamespace(name="consolidate_memory"),
+            raw_for_vault={"run_id": _Secret()},
+            surface="cli",
+            vault_root=Path("does-not-exist"),
         )
 
 
@@ -282,10 +391,16 @@ def test_unknown_protected_session_denies_before_presence_and_vault_validation(m
     )
 
     module = _module()
-    monkeypatch.setattr(product_invoke, "resolve_vault_for",
-                        lambda *a, **k: pytest.fail("pre-auth vault validation"))
-    monkeypatch.setattr(consolidation_enrollment, "ensure_cli_runtime_presence",
-                        lambda *a, **k: pytest.fail("pre-auth presence registration"))
+    monkeypatch.setattr(
+        product_invoke,
+        "resolve_vault_for",
+        lambda *a, **k: pytest.fail("pre-auth vault validation"),
+    )
+    monkeypatch.setattr(
+        consolidation_enrollment,
+        "ensure_cli_runtime_presence",
+        lambda *a, **k: pytest.fail("pre-auth presence registration"),
+    )
 
     def deny(*a, **k):
         raise authorization_request.AuthorizationContextUnavailable
@@ -297,13 +412,18 @@ def test_unknown_protected_session_denies_before_presence_and_vault_validation(m
     assert not carrier.is_invalid
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         product_invoke.verify_local_authorization_transport(
-            SimpleNamespace(name="consolidate_memory"), raw_for_vault={"run_id": _Secret()},
-            surface="cli", vault_root=Path("selected-vault"), authorization_carrier=carrier,
+            SimpleNamespace(name="consolidate_memory"),
+            raw_for_vault={"run_id": _Secret()},
+            surface="cli",
+            vault_root=Path("selected-vault"),
+            authorization_carrier=carrier,
         )
 
 
 def test_local_route_binds_owner_before_reading_action_fields(
-    tmp_path, monkeypatch, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    verified_session_stub,
 ):
     from types import SimpleNamespace
 
@@ -316,19 +436,31 @@ def test_local_route_binds_owner_before_reading_action_fields(
     monkeypatch.setattr("time.time", lambda: NOW)
     bound = product_invoke.enforce_local_authorization_route(
         SimpleNamespace(name="consolidate_memory"),
-        {"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
-        authorization_request.AuthorizationAdmission(who, True), vault_root=tmp_path,
+        {
+            "schema": "exomem.consolidate-memory-request/v1",
+            "action": "status",
+            "run_id": "123e4567-e89b-42d3-a456-426614174000",
+        },
+        authorization_request.AuthorizationAdmission(who, True),
+        vault_root=tmp_path,
     )
     module.require_owner_context(
-        bound.consolidation_owner_context, principal=bound, identity=identity,
-        action="status", now=NOW,
+        bound.consolidation_owner_context,
+        principal=bound,
+        identity=identity,
+        action="status",
+        now=NOW,
     )
 
 
 @pytest.mark.parametrize("invalid", [False, True])
 @pytest.mark.parametrize("authorized", [False, True])
 def test_mcp_middleware_enforces_owner_before_next_handler(
-    tmp_path, monkeypatch, authorized, invalid, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    authorized,
+    invalid,
+    verified_session_stub,
 ):
     import asyncio
     from types import SimpleNamespace
@@ -342,12 +474,20 @@ def test_mcp_middleware_enforces_owner_before_next_handler(
     module = _module()
     who = _principal() if authorized else owner_principal(surface="mcp")
     monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: _identity())
-    monkeypatch.setattr(authorization_transport.principal_module, "resolve_mcp_principal", lambda: who)
-    monkeypatch.setattr(authorization_transport, "verify_authorization_context",
-                        lambda *a, **k: authorization_request.AuthorizationAdmission(who, authorized))
+    monkeypatch.setattr(
+        authorization_transport.principal_module, "resolve_mcp_principal", lambda: who
+    )
+    monkeypatch.setattr(
+        authorization_transport,
+        "verify_authorization_context",
+        lambda *a, **k: authorization_request.AuthorizationAdmission(who, authorized),
+    )
     monkeypatch.setattr("time.time", lambda: NOW)
-    arguments = {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
-                 "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+    arguments = {
+        "schema": "exomem.consolidate-memory-request/v1",
+        "action": "status",
+        "run_id": "123e4567-e89b-42d3-a456-426614174000",
+    }
     if invalid:
         arguments["expected_run_revision"] = "0"
     message = mcp.types.CallToolRequestParams(name="consolidate_memory", arguments=arguments)
@@ -365,25 +505,35 @@ def test_mcp_middleware_enforces_owner_before_next_handler(
         assert not invalid, "invalid request reached downstream coercion"
         bound = principal_module.current_principal()
         module.require_owner_context(
-            bound.consolidation_owner_context, principal=bound, identity=_identity(),
-            action="status", now=NOW,
+            bound.consolidation_owner_context,
+            principal=bound,
+            identity=_identity(),
+            action="status",
+            now=NOW,
         )
         assert context.message.arguments == arguments
         return "bound-owner"
 
     call = authorization_transport.AuthorizationSessionMiddleware(tmp_path).on_call_tool(
-        Context(message), next_handler,
+        Context(message),
+        next_handler,
     )
     if authorized and not invalid:
         assert asyncio.run(call) == "bound-owner"
     else:
-        message = "consolidation request is unavailable" if authorized else "consolidation owner is unavailable"
+        message = (
+            "consolidation request is unavailable"
+            if authorized
+            else "consolidation owner is unavailable"
+        )
         with pytest.raises(McpError, match=message):
             asyncio.run(call)
 
 
 def test_prepared_context_rechecks_exact_selected_destination(
-    tmp_path, monkeypatch, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    verified_session_stub,
 ):
     from types import SimpleNamespace
 
@@ -394,19 +544,35 @@ def test_prepared_context_rechecks_exact_selected_destination(
     monkeypatch.setattr("time.time", lambda: NOW)
     monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
     bound = module.bind_local_owner(
-        tmp_path, principal=_principal("cli"),
-        arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        tmp_path,
+        principal=_principal("cli"),
+        arguments={
+            "schema": "exomem.consolidate-memory-request/v1",
+            "action": "status",
+            "run_id": "123e4567-e89b-42d3-a456-426614174000",
+        },
         now=NOW,
     )
-    monkeypatch.setattr(consolidation_identity, "load_local_identity",
-                        lambda *a, **k: replace(identity, installation_generation=2))
-    monkeypatch.setattr(product_invoke, "resolve_vault_for",
-                        lambda *a, **k: pytest.fail("stale context reached vault validation"))
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *a, **k: replace(identity, installation_generation=2),
+    )
+    monkeypatch.setattr(
+        product_invoke,
+        "resolve_vault_for",
+        lambda *a, **k: pytest.fail("stale context reached vault validation"),
+    )
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         product_invoke.invoke_prepared(
             SimpleNamespace(name="consolidate_memory"),
-            {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
-            "run_id": _Secret()}, principal=bound, vault_root=tmp_path,
+            {
+                "schema": "exomem.consolidate-memory-request/v1",
+                "action": "status",
+                "run_id": _Secret(),
+            },
+            principal=bound,
+            vault_root=tmp_path,
         )
 
 
@@ -417,20 +583,30 @@ def test_shared_dispatch_rejects_unbound_owner_before_reserved_preflight(tmp_pat
     from exomem.governance import principal as principal_module
 
     module = _module()
-    monkeypatch.setattr(reserved_paths, "reserved_preflight",
-                        lambda *a, **k: pytest.fail("preflight inspected untrusted request"))
+    monkeypatch.setattr(
+        reserved_paths,
+        "reserved_preflight",
+        lambda *a, **k: pytest.fail("preflight inspected untrusted request"),
+    )
     with principal_module.request_scope(owner_principal(surface="mcp")):
         with pytest.raises(module.ConsolidationOwnerUnavailable):
             writer_lease.invoke_command(
-                SimpleNamespace(name="consolidate_memory"), tmp_path,
-                schema="exomem.consolidate-memory-request/v1", action="status", run_id=_Secret(),
+                SimpleNamespace(name="consolidate_memory"),
+                tmp_path,
+                schema="exomem.consolidate-memory-request/v1",
+                action="status",
+                run_id=_Secret(),
             )
 
 
 @pytest.mark.parametrize("body_kind", ["valid", "duplicate", "string-revision"])
 @pytest.mark.parametrize("authorized", [False, True])
 def test_rest_route_checks_owner_before_parsing_and_binds_before_coercion(
-    tmp_path, monkeypatch, authorized, body_kind, verified_session_stub,
+    tmp_path,
+    monkeypatch,
+    authorized,
+    body_kind,
+    verified_session_stub,
 ):
     import json
 
@@ -448,8 +624,11 @@ def test_rest_route_checks_owner_before_parsing_and_binds_before_coercion(
     cmd = Command("consolidate_memory", lambda: None, (), frozenset({"rest"}))
     monkeypatch.setattr(commands, "product_commands_for", lambda *a, **k: (cmd,))
     monkeypatch.setenv("EXOMEM_REST_API_KEY", "test-service-key")
-    monkeypatch.setattr(authorization_request, "verify_authorization_context",
-                        lambda *a, **k: authorization_request.AuthorizationAdmission(who, authorized))
+    monkeypatch.setattr(
+        authorization_request,
+        "verify_authorization_context",
+        lambda *a, **k: authorization_request.AuthorizationAdmission(who, authorized),
+    )
     monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: _identity())
     monkeypatch.setattr("time.time", lambda: NOW)
 
@@ -461,8 +640,11 @@ def test_rest_route_checks_owner_before_parsing_and_binds_before_coercion(
     def invoke(*args, **kwargs):
         bound = principal_module.current_principal()
         module.require_owner_context(
-            bound.consolidation_owner_context, principal=bound, identity=_identity(),
-            action="status", now=NOW,
+            bound.consolidation_owner_context,
+            principal=bound,
+            identity=_identity(),
+            action="status",
+            now=NOW,
         )
         return {"owner_bound": True}
 
@@ -470,14 +652,19 @@ def test_rest_route_checks_owner_before_parsing_and_binds_before_coercion(
     monkeypatch.setattr(writer_lease, "invoke_command", invoke)
     app = FastMCP("owner-boundary-test")
     server_rest.register_rest_facade(
-        app, vault_root=tmp_path, source_schema=None,
+        app,
+        vault_root=tmp_path,
+        source_schema=None,
         transfer_config=TransferConfig(None, 1024, None, None, None, None),
     )
     client = TestClient(authorization_transport.AuthorizationCarrierMiddleware(app.http_app()))
     headers = {"Authorization": "Bearer test-service-key"}
     if authorized:
-        body = {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
-                "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+        body = {
+            "schema": "exomem.consolidate-memory-request/v1",
+            "action": "status",
+            "run_id": "123e4567-e89b-42d3-a456-426614174000",
+        }
         if body_kind == "string-revision":
             body["expected_run_revision"] = "0"
         raw = json.dumps(body)
@@ -515,8 +702,12 @@ def issued_local_session(tmp_path, monkeypatch):
     who = owner_principal(surface="cli")
     consolidation_identity.adopt_local_identity(root, principal=who, now=NOW)
     registered = authorization_custody.load_authorization_custody(root, now=NOW + 1)
-    documents = (("scopes/owner.yaml", b"governance_version: 1\n"
-                  b"id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n"),)
+    documents = (
+        (
+            "scopes/owner.yaml",
+            b"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n",
+        ),
+    )
     compiled = policy.compile_documents(dict(documents))
     assert not compiled.empty and not compiled.blocked
     seed = schema_v4.MigrationSeed(
@@ -525,26 +716,36 @@ def issued_local_session(tmp_path, monkeypatch):
         activation_epoch=1,
         policy=schema_v4.PolicyGenerationSeed(
             generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
-            source_documents=documents, source_fingerprint=compiled.fingerprint,
+            source_documents=documents,
+            source_fingerprint=compiled.fingerprint,
             conflict_digest="2" * 64,
             compiled_policy=policy.canonical_compiled_bytes(compiled),
             policy_fingerprint=compiled.fingerprint,
-            compiler_schema_version=1, projector_schema_version=1,
-            predecessor_generation_id=None, authoring_event_id="event-owner-test",
-            receipt_event_id="receipt-owner-test", created_at=NOW,
+            compiler_schema_version=1,
+            projector_schema_version=1,
+            predecessor_generation_id=None,
+            authoring_event_id="event-owner-test",
+            receipt_event_id="receipt-owner-test",
+            created_at=NOW,
         ),
         catalog=schema_v4.CatalogGenerationSeed(
-            catalog_generation=1, descriptor=b'{"artifacts":[]}',
-            artifact_count=0, created_at=NOW,
+            catalog_generation=1,
+            descriptor=b'{"artifacts":[]}',
+            artifact_count=0,
+            created_at=NOW,
         ),
         namespace=schema_v4.ProjectionNamespaceSeed(
-            namespace_id="projection-owner-test", evidence=b'{"ready":true}', ready_at=NOW,
+            namespace_id="projection-owner-test",
+            evidence=b'{"ready":true}',
+            ready_at=NOW,
         ),
         migrated_at=NOW,
     )
     authorization_custody.enroll_initial_activation_tuple(
-        root, expected_control=registered.control,
-        target=schema_v4.migration_target(seed), now=NOW + 1,
+        root,
+        expected_control=registered.control,
+        target=schema_v4.migration_target(seed),
+        now=NOW + 1,
     )
     connection = store.open_connection(root)
     try:
@@ -558,8 +759,12 @@ def issued_local_session(tmp_path, monkeypatch):
     connection = store.open_authorization_session_connection(root)
     try:
         issued = authorization_session_lifecycle.open_session(
-            connection, custody=custody, principal_id=who.audience_id,
-            issuer_family=who.issuer_family, now=NOW + 3, ttl_seconds=120,
+            connection,
+            custody=custody,
+            principal_id=who.audience_id,
+            issuer_family=who.issuer_family,
+            now=NOW + 3,
+            ttl_seconds=120,
         )
     finally:
         connection.close()
@@ -570,7 +775,9 @@ def _verified_local_principal(root, issued):
     from exomem.governance import authorization_request
 
     return authorization_request.verify_authorization_context(
-        root, principal=owner_principal(surface="cli"), credential=issued.bearer,
+        root,
+        principal=owner_principal(surface="cli"),
+        credential=issued.bearer,
         now=NOW + 4,
     ).principal
 
@@ -596,12 +803,22 @@ def test_real_descriptor_session_can_bind_and_recheck_owner(issued_local_session
             os.close(write_fd)
     cmd = SimpleNamespace(name="consolidate_memory")
     selected, admission = product_invoke.verify_local_authorization_transport(
-        cmd, raw_for_vault={}, surface="cli", vault_root=root,
+        cmd,
+        raw_for_vault={},
+        surface="cli",
+        vault_root=root,
         authorization_carrier=carrier,
     )
-    request = {"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+    request = {
+        "schema": "exomem.consolidate-memory-request/v1",
+        "action": "status",
+        "run_id": "123e4567-e89b-42d3-a456-426614174000",
+    }
     bound = product_invoke.enforce_local_authorization_route(
-        cmd, request, admission, vault_root=selected,
+        cmd,
+        request,
+        admission,
+        vault_root=selected,
     )
     _module().require_bound_request(root, principal=bound, arguments=request, now=NOW + 4)
     assert bound.consolidation_owner_context is not None
@@ -610,14 +827,21 @@ def test_real_descriptor_session_can_bind_and_recheck_owner(issued_local_session
 @pytest.mark.parametrize("stage", ["admit", "recheck"])
 @pytest.mark.parametrize("change", ["fabricated", "revoked", "rotated", "keyring"])
 def test_durable_session_is_rechecked_before_private_identity(
-    issued_local_session, monkeypatch, stage, change,
+    issued_local_session,
+    monkeypatch,
+    stage,
+    change,
 ):
     from exomem.governance import store
 
     root, custody, issued = issued_local_session
     module = _module()
     who = _verified_local_principal(root, issued)
-    request = {"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+    request = {
+        "schema": "exomem.consolidate-memory-request/v1",
+        "action": "status",
+        "run_id": "123e4567-e89b-42d3-a456-426614174000",
+    }
     if stage == "recheck":
         who = module.bind_local_owner(root, principal=who, arguments=request, now=NOW + 4)
     session = who.verified_authorization_session
@@ -629,21 +853,30 @@ def test_durable_session_is_rechecked_before_private_identity(
         connection = store.open_authorization_session_connection(root)
         try:
             operation = (
-                authorization_session_lifecycle.close_session if change == "revoked"
+                authorization_session_lifecycle.close_session
+                if change == "revoked"
                 else authorization_session_lifecycle.rotate_session
             )
             kwargs = {"ttl_seconds": 60} if change == "rotated" else {}
             operation(
-                connection, custody=custody, bearer=issued.bearer,
-                principal_id=session.principal_id, issuer_family=session.issuer_family,
-                now=NOW + 5, **kwargs,
+                connection,
+                custody=custody,
+                bearer=issued.bearer,
+                principal_id=session.principal_id,
+                issuer_family=session.issuer_family,
+                now=NOW + 5,
+                **kwargs,
             )
         finally:
             connection.close()
-    who = replace(who, verified_authorization_session=session,
-                  authorization_session_id=session.session_id)
-    monkeypatch.setattr(consolidation_identity, "load_local_identity",
-                        lambda *a, **k: pytest.fail("unverified session read private identity"))
+    who = replace(
+        who, verified_authorization_session=session, authorization_session_id=session.session_id
+    )
+    monkeypatch.setattr(
+        consolidation_identity,
+        "load_local_identity",
+        lambda *a, **k: pytest.fail("unverified session read private identity"),
+    )
     operation = module.bind_local_owner if stage == "admit" else module.require_bound_request
     with pytest.raises(module.ConsolidationOwnerUnavailable):
         operation(root, principal=who, arguments=request, now=NOW + 6)
@@ -657,8 +890,9 @@ def test_cli_without_owner_carrier_refuses_before_any_argument_parsing(monkeypat
 
     cmd = Command("consolidate_memory", lambda: None, (), frozenset({"cli"}))
     monkeypatch.setattr(commands, "product_commands_for", lambda *a, **k: (cmd,))
-    monkeypatch.setattr(cli_main, "_CLIParser",
-                        lambda *a, **k: pytest.fail("absent session reached CLI parsing"))
+    monkeypatch.setattr(
+        cli_main, "_CLIParser", lambda *a, **k: pytest.fail("absent session reached CLI parsing")
+    )
     assert cli_main._core_op_main(["consolidate_memory", *extra]) == 1
     captured = capsys.readouterr()
     assert "CONSOLIDATION_OWNER_UNAVAILABLE" in captured.err
@@ -667,7 +901,10 @@ def test_cli_without_owner_carrier_refuses_before_any_argument_parsing(monkeypat
 
 @pytest.mark.parametrize("invalid", ["0", 0.0, True, -1])
 def test_local_adapter_refuses_semantically_invalid_request_before_coercion(
-    tmp_path, monkeypatch, verified_session_stub, invalid,
+    tmp_path,
+    monkeypatch,
+    verified_session_stub,
+    invalid,
 ):
     from types import SimpleNamespace
 
@@ -680,28 +917,45 @@ def test_local_adapter_refuses_semantically_invalid_request_before_coercion(
     with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
         product_invoke.enforce_local_authorization_route(
             SimpleNamespace(name="consolidate_memory"),
-            {"schema": consolidation_request.REQUEST_SCHEMA_NAME, "action": "status",
-             "run_id": "123e4567-e89b-42d3-a456-426614174000", "expected_run_revision": invalid},
-            authorization_request.AuthorizationAdmission(who, True), vault_root=tmp_path,
+            {
+                "schema": consolidation_request.REQUEST_SCHEMA_NAME,
+                "action": "status",
+                "run_id": "123e4567-e89b-42d3-a456-426614174000",
+                "expected_run_revision": invalid,
+            },
+            authorization_request.AuthorizationAdmission(who, True),
+            vault_root=tmp_path,
         )
 
 
 def test_mcp_raw_duplicates_cannot_become_an_admissible_request():
     from exomem.governance import authorization_transport
 
-    raw = (b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
-           b'"params":{"name":"consolidate_memory","arguments":{'
-           b'"action":"status","action":"apply"}}}')
+    raw = (
+        b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+        b'"params":{"name":"consolidate_memory","arguments":{'
+        b'"action":"status","action":"apply"}}}'
+    )
     result = authorization_transport.sanitize_mcp_http_body(raw)
     assert result.carrier.is_invalid
 
 
-@pytest.mark.parametrize("mode,proof,valid", [
-    ("real-cutover", False, False), ("real-cutover", True, True),
-    ("cloned-rehearsal", False, True), ("cloned-rehearsal", True, False),
-])
+@pytest.mark.parametrize(
+    "mode,proof,valid",
+    [
+        ("real-cutover", False, False),
+        ("real-cutover", True, True),
+        ("cloned-rehearsal", False, True),
+        ("cloned-rehearsal", True, False),
+    ],
+)
 def test_adapter_uses_stored_run_mode_for_cutover_proof(
-    tmp_path, monkeypatch, verified_session_stub, mode, proof, valid,
+    tmp_path,
+    monkeypatch,
+    verified_session_stub,
+    mode,
+    proof,
+    valid,
 ):
     from types import SimpleNamespace
 
@@ -717,33 +971,55 @@ def test_adapter_uses_stored_run_mode_for_cutover_proof(
     monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
     monkeypatch.setattr("time.time", lambda: NOW)
     loads = []
+
     def load(store, run_id):
         loads.append(run_id)
-        return SimpleNamespace(identity=SimpleNamespace(
-            run_mode=mode, destination_vault_id=identity.vault_id,
-            destination_installation_id=identity.installation_id,
-            destination_generation=identity.installation_generation,
-            destination_fence_digest=identity.active_fence_digest,
-        ))
+        return SimpleNamespace(
+            identity=SimpleNamespace(
+                run_mode=mode,
+                destination_vault_id=identity.vault_id,
+                destination_installation_id=identity.installation_id,
+                destination_generation=identity.installation_generation,
+                destination_fence_digest=identity.active_fence_digest,
+            )
+        )
+
     monkeypatch.setattr(consolidation_run_state.ConsolidationRunStore, "load", load)
-    options = {name: "a" * 64 for name in (
-        "expected_reconciliation_digest", "expected_policy_bundle_digest",
-        "expected_principal_attestation_set_digest", "expected_verification_plan_digest",
-        "expected_rollback_contingency_digest", "expected_source_retention_digest",
-        "expected_control_basis_digest",
-    )}
+    options = {
+        name: "a" * 64
+        for name in (
+            "expected_reconciliation_digest",
+            "expected_policy_bundle_digest",
+            "expected_principal_attestation_set_digest",
+            "expected_verification_plan_digest",
+            "expected_rollback_contingency_digest",
+            "expected_source_retention_digest",
+            "expected_control_basis_digest",
+        )
+    }
     if proof:
         options["expected_rehearsal_proof_digest"] = "a" * 64
-    request = {"schema": consolidation_request.REQUEST_SCHEMA_NAME, "action": "plan",
+    request = {
+        "schema": consolidation_request.REQUEST_SCHEMA_NAME,
+        "action": "plan",
         "operation_id": "123e4567-e89b-42d3-a456-426614174001",
-        "run_id": "123e4567-e89b-42d3-a456-426614174000", "expected_run_revision": 0,
-        "plan_kind": "cutover", "operation": "materialize", "successor_context_ref": "context",
-        "successor_context_digest": "a" * 64, "cutover_options": options}
+        "run_id": "123e4567-e89b-42d3-a456-426614174000",
+        "expected_run_revision": 0,
+        "plan_kind": "cutover",
+        "operation": "materialize",
+        "successor_context_ref": "context",
+        "successor_context_digest": "a" * 64,
+        "cutover_options": options,
+    }
+
     def invoke():
         return product_invoke.enforce_local_authorization_route(
-            SimpleNamespace(name="consolidate_memory"), request,
-            authorization_request.AuthorizationAdmission(who, True), vault_root=tmp_path,
+            SimpleNamespace(name="consolidate_memory"),
+            request,
+            authorization_request.AuthorizationAdmission(who, True),
+            vault_root=tmp_path,
         )
+
     if valid:
         invoke()
     else:
@@ -754,8 +1030,11 @@ def test_adapter_uses_stored_run_mode_for_cutover_proof(
 
 def test_mcp_sanitizer_preserves_surrogates_for_post_owner_semantic_refusal():
     from exomem.governance import authorization_transport
-    raw = (b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
-           b'"params":{"name":"consolidate_memory","arguments":{"cursor":"\\ud800"}}}')
+
+    raw = (
+        b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+        b'"params":{"name":"consolidate_memory","arguments":{"cursor":"\\ud800"}}}'
+    )
     result = authorization_transport.sanitize_mcp_http_body(raw)
     assert result.arguments["cursor"] == "\ud800"
     result.body.decode("utf-8")
@@ -763,7 +1042,11 @@ def test_mcp_sanitizer_preserves_surrogates_for_post_owner_semantic_refusal():
 
 def test_mcp_raw_decoder_refuses_non_utf8_json():
     from exomem.governance import authorization_transport
-    raw = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"consolidate_memory","arguments":{}}}'
+
+    raw = (
+        '{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+        '"params":{"name":"consolidate_memory","arguments":{}}}'
+    )
     with pytest.raises(authorization_transport.AuthorizationEnvelopeUnavailable):
         authorization_transport.sanitize_mcp_http_body(raw.encode("utf-16"))
 
@@ -778,14 +1061,21 @@ def test_stdio_decoder_refuses_invalid_utf8_without_normalizing_it(monkeypatch):
 
     from exomem.governance import authorization_transport
 
-    invalid = (b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
-               b'"params":{"name":"consolidate_memory","arguments":{"cursor":"\xff"}}}\n')
+    invalid = (
+        b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+        b'"params":{"name":"consolidate_memory","arguments":{"cursor":"\xff"}}}\n'
+    )
     valid = b'{"jsonrpc":"2.0","id":2,"method":"ping"}\n'
-    monkeypatch.setattr(authorization_transport.sys, "stdin", SimpleNamespace(buffer=io.BytesIO(invalid + valid)))
+    monkeypatch.setattr(
+        authorization_transport.sys, "stdin", SimpleNamespace(buffer=io.BytesIO(invalid + valid))
+    )
 
     async def receive():
         output = anyio.wrap_file(io.StringIO())
-        async with authorization_transport.sanitized_stdio_server(stdout=output) as (reader, writer):
+        async with authorization_transport.sanitized_stdio_server(stdout=output) as (
+            reader,
+            writer,
+        ):
             first = await reader.receive()
             second = await reader.receive()
             await writer.aclose()

--- a/tests/test_consolidation_owner.py
+++ b/tests/test_consolidation_owner.py
@@ -1,0 +1,768 @@
+"""Owner admission precedes every consolidation request field and effect."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import importlib.util
+import pickle
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from exomem.governance import authorization_session_lifecycle, consolidation_identity
+from exomem.governance.principal import RequestPrincipal, owner_principal
+
+NOW = 1_800_000_000
+ACTIONS = (
+    "start", "status", "reconcile", "plan", "approve", "apply", "verify",
+    "recover", "abort", "rollback", "retire-source",
+)
+
+
+def _module():
+    assert importlib.util.find_spec("exomem.governance.consolidation_owner"), (
+        "consolidation needs explicit owner admission, not a library owner default"
+    )
+    return importlib.import_module("exomem.governance.consolidation_owner")
+
+
+def _principal(surface="mcp"):
+    who = owner_principal(surface=surface)
+    session = authorization_session_lifecycle.AuthorizationSessionContext(
+        session_id="authorization-session:0123456789abcdef0123456789abcdef",
+        principal_id=who.audience_id,
+        issuer_family=who.issuer_family,
+        cell_id="cell-a",
+        logical_vault_id="vault-a",
+        keyring_id="keyring-a",
+        credential_generation=1,
+        expires_at=NOW + 600,
+    )
+    return who.with_verified_authorization_session(
+        session, issuer_family=who.issuer_family,
+    )
+
+
+def _identity():
+    return consolidation_identity.ConsolidationCellIdentity(
+        schema=consolidation_identity.IDENTITY_SCHEMA,
+        cell_id="cell-a", vault_id="vault-a",
+        installation_id="installation-v1-" + "a" * 64,
+        installation_generation=1, active_fence_digest="b" * 64,
+        root_binding_id="attachment-v1-" + "c" * 64,
+        root_binding_digest="d" * 64, machine_key_id="host-key-v1-" + "e" * 64,
+        adoption_census_digest="f" * 64,
+        clone_of_vault_id=None, clone_of_installation_id=None,
+        clone_of_snapshot_digest=None, created_at=NOW - 60,
+        authentication_algorithm="HMAC-SHA256", record_digest="1" * 64,
+        identity_path=Path("private-identity.json"),
+    )
+
+
+class _Secret:
+    def __repr__(self):
+        pytest.fail("private request value was rendered before owner admission")
+
+    def __str__(self):
+        pytest.fail("private request value was coerced before owner admission")
+
+    def __hash__(self):
+        pytest.fail("private request value was hashed before owner admission")
+
+
+@pytest.fixture
+def verified_session_stub(monkeypatch):
+    """Only facts/adapter unit tests stub durable verification; real tests don't."""
+    module = _module()
+    monkeypatch.setattr(
+        module, "_durable_session",
+        lambda root, *, principal, now: module._session(principal, now=now),
+    )
+
+
+@pytest.mark.parametrize("action", ACTIONS)
+@pytest.mark.parametrize("who", [None, owner_principal(), _principal("library"),
+    RequestPrincipal("ordinary", surface="mcp", issuer_family="mcp-local-stdio"),
+    replace(_principal(), resolved=False)])
+def test_nonowner_and_unbound_calls_refuse_before_identity_or_body(
+    tmp_path, monkeypatch, action, who,
+):
+    module = _module()
+    monkeypatch.setattr(consolidation_identity, "load_local_identity",
+                        lambda *a, **k: pytest.fail("unauthorized identity lookup"))
+    before = tuple(tmp_path.rglob("*"))
+    with pytest.raises(module.ConsolidationOwnerUnavailable) as error:
+        module.admit_local_owner(
+            tmp_path, principal=who,
+            arguments={"schema": "exomem.consolidate-memory-request/v1",
+                       "action": action, "source_artifact_ref": _Secret()},
+            now=NOW,
+        )
+    assert error.value.as_public_dict() == {
+        "code": "CONSOLIDATION_OWNER_UNAVAILABLE",
+        "message": "consolidation owner is unavailable", "remediation": None,
+    }
+    assert tuple(tmp_path.rglob("*")) == before
+
+
+@pytest.mark.parametrize("action", ACTIONS)
+@pytest.mark.parametrize("surface", ["cli", "mcp", "rest"])
+def test_explicit_session_owner_is_bound_to_exact_action_and_installation(
+    tmp_path, monkeypatch, action, surface, verified_session_stub,
+):
+    module = _module()
+    who = _principal(surface)
+    identity = _identity()
+    monkeypatch.setattr(consolidation_identity, "load_local_identity",
+                        lambda *a, **k: identity)
+    context = module.admit_local_owner(
+        tmp_path, principal=who,
+        arguments={"schema": "exomem.consolidate-memory-request/v1",
+                   "action": action, "source_artifact_ref": _Secret()},
+        now=NOW,
+    )
+    facts = module.require_owner_context(
+        context, principal=who, identity=identity, action=action, now=NOW,
+    )
+    assert facts.schema == "ConsolidationOwnerContext/v1"
+    assert facts.purpose == "vault-consolidation"
+    assert facts.vault_id == identity.vault_id
+    assert facts.installation_generation == identity.installation_generation
+    assert facts.active_fence_digest == identity.active_fence_digest
+    assert facts.authorization_session_id == who.authorization_session_id
+    assert facts.action == action
+    assert facts.surface == surface
+    assert NOW < facts.expires_at <= who.verified_authorization_session.expires_at
+    assert facts.nonce and facts.verifier_fingerprint
+    assert facts.human_confirmation is False
+    assert "vault-a" not in repr(context)
+    for operation in (copy.copy, copy.deepcopy, pickle.dumps):
+        with pytest.raises(TypeError):
+            operation(context)
+
+
+@pytest.mark.parametrize("change", ["action", "vault", "installation", "generation",
+    "fence", "session", "issuer", "surface", "expired", "future", "forged"])
+def test_owner_capability_cannot_cross_or_outlive_its_binding(
+    tmp_path, monkeypatch, change, verified_session_stub,
+):
+    module = _module()
+    who = _principal()
+    identity = _identity()
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
+    context = module.admit_local_owner(
+        tmp_path, principal=who,
+        arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        now=NOW,
+    )
+    action, now = "status", NOW
+    if change == "action":
+        action = "apply"
+    elif change == "vault":
+        identity = replace(identity, vault_id="vault-b")
+    elif change == "installation":
+        identity = replace(identity, installation_id="installation-v1-" + "2" * 64)
+    elif change == "generation":
+        identity = replace(identity, installation_generation=2)
+    elif change == "fence":
+        identity = replace(identity, active_fence_digest="3" * 64)
+    elif change == "session":
+        who = replace(who, authorization_session_id="foreign-session")
+    elif change == "issuer":
+        who = replace(who, issuer_family="foreign-issuer")
+    elif change == "surface":
+        who = replace(who, surface="rest")
+    elif change == "expired":
+        now += 600
+    elif change == "future":
+        now -= 1
+    else:
+        context = {"owner": True}
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        module.require_owner_context(
+            context, principal=who, identity=identity, action=action, now=now,
+        )
+
+
+@pytest.mark.parametrize("change", ["vault", "cell", "alias", "session", "expired"])
+def test_cross_bound_identity_never_mints_context(
+    tmp_path, monkeypatch, change, verified_session_stub,
+):
+    module = _module()
+    who, identity = _principal(), _identity()
+    if change == "vault":
+        identity = replace(identity, vault_id="vault-b")
+    elif change == "cell":
+        identity = replace(identity, cell_id="cell-b")
+    elif change == "alias":
+        identity = replace(identity, cell_id=identity.vault_id)
+    elif change == "session":
+        who = replace(who, authorization_session_id="different-session")
+    else:
+        who = replace(who, verified_authorization_session=replace(
+            who.verified_authorization_session, expires_at=NOW,
+        ))
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        module.admit_local_owner(
+            tmp_path, principal=who,
+            arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+            now=NOW,
+        )
+
+
+def test_adapter_binds_context_but_session_reverification_clears_it(
+    tmp_path, monkeypatch, verified_session_stub,
+):
+    module = _module()
+    who, identity = _principal(), _identity()
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
+    bind = getattr(module, "bind_local_owner", None)
+    assert callable(bind), "the trusted adapter must carry owner authority to dispatch"
+    bound = bind(
+        tmp_path, principal=who,
+        arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        now=NOW,
+    )
+    module.require_owner_context(
+        bound.consolidation_owner_context, principal=bound,
+        identity=identity, action="status", now=NOW,
+    )
+    rebound = bound.with_verified_authorization_session(
+        who.verified_authorization_session, issuer_family=who.issuer_family,
+    )
+    assert rebound.consolidation_owner_context is None
+
+
+def test_unbound_prepared_consolidation_refuses_before_vault_resolution(monkeypatch):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+
+    module = _module()
+    monkeypatch.setattr(product_invoke, "resolve_vault_for",
+                        lambda *a, **k: pytest.fail("unbound request resolved vault"))
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        product_invoke.invoke_prepared(
+            SimpleNamespace(name="consolidate_memory"),
+            {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
+             "run_id": _Secret()},
+            principal=_principal("library"),
+        )
+
+
+def test_local_transport_denies_absent_session_before_presence_and_resolution(monkeypatch):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+    from exomem.governance import consolidation_enrollment
+
+    module = _module()
+    monkeypatch.setattr(product_invoke, "resolve_vault_for",
+                        lambda *a, **k: pytest.fail("unauthorized vault resolution"))
+    monkeypatch.setattr(consolidation_enrollment, "ensure_cli_runtime_presence",
+                        lambda *a, **k: pytest.fail("unauthorized presence registration"))
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        product_invoke.verify_local_authorization_transport(
+            SimpleNamespace(name="consolidate_memory"), raw_for_vault={"run_id": _Secret()},
+            surface="cli", vault_root=Path("does-not-exist"),
+        )
+
+
+def test_unknown_protected_session_denies_before_presence_and_vault_validation(monkeypatch):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+    from exomem.governance import (
+        authorization_request,
+        authorization_transport,
+        consolidation_enrollment,
+    )
+
+    module = _module()
+    monkeypatch.setattr(product_invoke, "resolve_vault_for",
+                        lambda *a, **k: pytest.fail("pre-auth vault validation"))
+    monkeypatch.setattr(consolidation_enrollment, "ensure_cli_runtime_presence",
+                        lambda *a, **k: pytest.fail("pre-auth presence registration"))
+
+    def deny(*a, **k):
+        raise authorization_request.AuthorizationContextUnavailable
+
+    monkeypatch.setattr(authorization_request, "verify_authorization_context", deny)
+    carrier = authorization_transport.CredentialCarrier.from_value(
+        "as1.AQEBAQEBAQEBAQEBAQEBAQ.AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI"
+    )
+    assert not carrier.is_invalid
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        product_invoke.verify_local_authorization_transport(
+            SimpleNamespace(name="consolidate_memory"), raw_for_vault={"run_id": _Secret()},
+            surface="cli", vault_root=Path("selected-vault"), authorization_carrier=carrier,
+        )
+
+
+def test_local_route_binds_owner_before_reading_action_fields(
+    tmp_path, monkeypatch, verified_session_stub,
+):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+    from exomem.governance import authorization_request
+
+    module = _module()
+    who, identity = _principal("cli"), _identity()
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
+    monkeypatch.setattr("time.time", lambda: NOW)
+    bound = product_invoke.enforce_local_authorization_route(
+        SimpleNamespace(name="consolidate_memory"),
+        {"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        authorization_request.AuthorizationAdmission(who, True), vault_root=tmp_path,
+    )
+    module.require_owner_context(
+        bound.consolidation_owner_context, principal=bound, identity=identity,
+        action="status", now=NOW,
+    )
+
+
+@pytest.mark.parametrize("invalid", [False, True])
+@pytest.mark.parametrize("authorized", [False, True])
+def test_mcp_middleware_enforces_owner_before_next_handler(
+    tmp_path, monkeypatch, authorized, invalid, verified_session_stub,
+):
+    import asyncio
+    from types import SimpleNamespace
+
+    import mcp.types
+    from mcp.shared.exceptions import McpError
+
+    from exomem.governance import authorization_request, authorization_transport
+    from exomem.governance import principal as principal_module
+
+    module = _module()
+    who = _principal() if authorized else owner_principal(surface="mcp")
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: _identity())
+    monkeypatch.setattr(authorization_transport.principal_module, "resolve_mcp_principal", lambda: who)
+    monkeypatch.setattr(authorization_transport, "verify_authorization_context",
+                        lambda *a, **k: authorization_request.AuthorizationAdmission(who, authorized))
+    monkeypatch.setattr("time.time", lambda: NOW)
+    arguments = {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
+                 "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+    if invalid:
+        arguments["expected_run_revision"] = "0"
+    message = mcp.types.CallToolRequestParams(name="consolidate_memory", arguments=arguments)
+
+    class Context:
+        def __init__(self, msg):
+            self.message = msg
+            self.fastmcp_context = SimpleNamespace(request_context=None)
+
+        def copy(self, *, message):
+            return Context(message)
+
+    async def next_handler(context):
+        assert authorized, "unauthorized request reached argument validation"
+        assert not invalid, "invalid request reached downstream coercion"
+        bound = principal_module.current_principal()
+        module.require_owner_context(
+            bound.consolidation_owner_context, principal=bound, identity=_identity(),
+            action="status", now=NOW,
+        )
+        assert context.message.arguments == arguments
+        return "bound-owner"
+
+    call = authorization_transport.AuthorizationSessionMiddleware(tmp_path).on_call_tool(
+        Context(message), next_handler,
+    )
+    if authorized and not invalid:
+        assert asyncio.run(call) == "bound-owner"
+    else:
+        message = "consolidation request is unavailable" if authorized else "consolidation owner is unavailable"
+        with pytest.raises(McpError, match=message):
+            asyncio.run(call)
+
+
+def test_prepared_context_rechecks_exact_selected_destination(
+    tmp_path, monkeypatch, verified_session_stub,
+):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+
+    module = _module()
+    identity = _identity()
+    monkeypatch.setattr("time.time", lambda: NOW)
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
+    bound = module.bind_local_owner(
+        tmp_path, principal=_principal("cli"),
+        arguments={"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"},
+        now=NOW,
+    )
+    monkeypatch.setattr(consolidation_identity, "load_local_identity",
+                        lambda *a, **k: replace(identity, installation_generation=2))
+    monkeypatch.setattr(product_invoke, "resolve_vault_for",
+                        lambda *a, **k: pytest.fail("stale context reached vault validation"))
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        product_invoke.invoke_prepared(
+            SimpleNamespace(name="consolidate_memory"),
+            {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
+            "run_id": _Secret()}, principal=bound, vault_root=tmp_path,
+        )
+
+
+def test_shared_dispatch_rejects_unbound_owner_before_reserved_preflight(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from exomem import reserved_paths, writer_lease
+    from exomem.governance import principal as principal_module
+
+    module = _module()
+    monkeypatch.setattr(reserved_paths, "reserved_preflight",
+                        lambda *a, **k: pytest.fail("preflight inspected untrusted request"))
+    with principal_module.request_scope(owner_principal(surface="mcp")):
+        with pytest.raises(module.ConsolidationOwnerUnavailable):
+            writer_lease.invoke_command(
+                SimpleNamespace(name="consolidate_memory"), tmp_path,
+                schema="exomem.consolidate-memory-request/v1", action="status", run_id=_Secret(),
+            )
+
+
+@pytest.mark.parametrize("body_kind", ["valid", "duplicate", "string-revision"])
+@pytest.mark.parametrize("authorized", [False, True])
+def test_rest_route_checks_owner_before_parsing_and_binds_before_coercion(
+    tmp_path, monkeypatch, authorized, body_kind, verified_session_stub,
+):
+    import json
+
+    from fastmcp import FastMCP
+    from starlette.testclient import TestClient
+
+    from exomem import commands, server_rest, writer_lease
+    from exomem.command_surface import Command
+    from exomem.governance import authorization_request, authorization_transport
+    from exomem.governance import principal as principal_module
+    from exomem.server_transfer import TransferConfig
+
+    module = _module()
+    who = _principal("rest") if authorized else owner_principal(surface="rest")
+    cmd = Command("consolidate_memory", lambda: None, (), frozenset({"rest"}))
+    monkeypatch.setattr(commands, "product_commands_for", lambda *a, **k: (cmd,))
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "test-service-key")
+    monkeypatch.setattr(authorization_request, "verify_authorization_context",
+                        lambda *a, **k: authorization_request.AuthorizationAdmission(who, authorized))
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: _identity())
+    monkeypatch.setattr("time.time", lambda: NOW)
+
+    def coerce(*args, **kwargs):
+        assert authorized, "unbound REST request reached body coercion"
+        assert body_kind == "valid", "invalid request reached body coercion"
+        return args[1]
+
+    def invoke(*args, **kwargs):
+        bound = principal_module.current_principal()
+        module.require_owner_context(
+            bound.consolidation_owner_context, principal=bound, identity=_identity(),
+            action="status", now=NOW,
+        )
+        return {"owner_bound": True}
+
+    monkeypatch.setattr(server_rest.cli_ops, "coerce", coerce)
+    monkeypatch.setattr(writer_lease, "invoke_command", invoke)
+    app = FastMCP("owner-boundary-test")
+    server_rest.register_rest_facade(
+        app, vault_root=tmp_path, source_schema=None,
+        transfer_config=TransferConfig(None, 1024, None, None, None, None),
+    )
+    client = TestClient(authorization_transport.AuthorizationCarrierMiddleware(app.http_app()))
+    headers = {"Authorization": "Bearer test-service-key"}
+    if authorized:
+        body = {"schema": "exomem.consolidate-memory-request/v1", "action": "status",
+                "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+        if body_kind == "string-revision":
+            body["expected_run_revision"] = "0"
+        raw = json.dumps(body)
+        if body_kind == "duplicate":
+            raw = raw[:-1] + ', "action":"status"}'
+        response = client.post("/api/consolidate_memory", headers=headers, content=raw)
+        if body_kind == "valid":
+            assert response.status_code == 200
+            assert response.json()["data"] == {"owner_bound": True}
+        else:
+            assert response.status_code == 400
+            assert response.json()["success"] is False
+    else:
+        response = client.post("/api/consolidate_memory", headers=headers, content=b"not-json")
+        assert response.json()["error"] == module.ConsolidationOwnerUnavailable().as_public_dict()
+
+
+@pytest.fixture
+def issued_local_session(tmp_path, monkeypatch):
+    """Real signed custody, v4 store and bearer, all under isolated test roots."""
+    from exomem import sidecar_store
+    from exomem.governance import authorization_custody, policy, schema_v4, store
+
+    external = tmp_path / "external"
+    external.mkdir(mode=0o700)
+    for variable, name in (
+        (authorization_custody.KEYRING_FILE_ENV, "keyring.json"),
+        (authorization_custody.CONTROL_FILE_ENV, "control.json"),
+        (authorization_custody.MEMBERSHIP_FILE_ENV, "membership.json"),
+    ):
+        monkeypatch.setenv(variable, str(external / name))
+    monkeypatch.setenv(authorization_custody.REPLICA_ID_ENV, "standalone")
+    root = tmp_path / "vault"
+    (root / "Knowledge Base/Notes").mkdir(parents=True)
+    who = owner_principal(surface="cli")
+    consolidation_identity.adopt_local_identity(root, principal=who, now=NOW)
+    registered = authorization_custody.load_authorization_custody(root, now=NOW + 1)
+    documents = (("scopes/owner.yaml", b"governance_version: 1\n"
+                  b"id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths:\n  - Notes/**\n"),)
+    compiled = policy.compile_documents(dict(documents))
+    assert not compiled.empty and not compiled.blocked
+    seed = schema_v4.MigrationSeed(
+        activation_store_id="activation-store-owner-test",
+        logical_vault_id=registered.control.logical_vault_id,
+        activation_epoch=1,
+        policy=schema_v4.PolicyGenerationSeed(
+            generation_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            source_documents=documents, source_fingerprint=compiled.fingerprint,
+            conflict_digest="2" * 64,
+            compiled_policy=policy.canonical_compiled_bytes(compiled),
+            policy_fingerprint=compiled.fingerprint,
+            compiler_schema_version=1, projector_schema_version=1,
+            predecessor_generation_id=None, authoring_event_id="event-owner-test",
+            receipt_event_id="receipt-owner-test", created_at=NOW,
+        ),
+        catalog=schema_v4.CatalogGenerationSeed(
+            catalog_generation=1, descriptor=b'{"artifacts":[]}',
+            artifact_count=0, created_at=NOW,
+        ),
+        namespace=schema_v4.ProjectionNamespaceSeed(
+            namespace_id="projection-owner-test", evidence=b'{"ready":true}', ready_at=NOW,
+        ),
+        migrated_at=NOW,
+    )
+    authorization_custody.enroll_initial_activation_tuple(
+        root, expected_control=registered.control,
+        target=schema_v4.migration_target(seed), now=NOW + 1,
+    )
+    connection = store.open_connection(root)
+    try:
+        store._migrate(connection)
+        sidecar_store.ensure_meta_table(connection, store.DATA_TABLE, "owner-test")
+        connection.commit()
+        schema_v4.migrate_v3_connection(connection, seed)
+    finally:
+        connection.close()
+    custody = authorization_custody.load_authorization_custody(root, now=NOW + 2)
+    connection = store.open_authorization_session_connection(root)
+    try:
+        issued = authorization_session_lifecycle.open_session(
+            connection, custody=custody, principal_id=who.audience_id,
+            issuer_family=who.issuer_family, now=NOW + 3, ttl_seconds=120,
+        )
+    finally:
+        connection.close()
+    return root, custody, issued
+
+
+def _verified_local_principal(root, issued):
+    from exomem.governance import authorization_request
+
+    return authorization_request.verify_authorization_context(
+        root, principal=owner_principal(surface="cli"), credential=issued.bearer,
+        now=NOW + 4,
+    ).principal
+
+
+def test_real_descriptor_session_can_bind_and_recheck_owner(issued_local_session, monkeypatch):
+    import os
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+    from exomem.governance import authorization_transport
+
+    root, _custody, issued = issued_local_session
+    monkeypatch.setattr("time.time", lambda: NOW + 4)
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, issued.bearer.encode())
+        os.close(write_fd)
+        write_fd = -1
+        carrier = authorization_transport.read_cli_authorization_fd(str(read_fd))
+    finally:
+        os.close(read_fd)
+        if write_fd >= 0:
+            os.close(write_fd)
+    cmd = SimpleNamespace(name="consolidate_memory")
+    selected, admission = product_invoke.verify_local_authorization_transport(
+        cmd, raw_for_vault={}, surface="cli", vault_root=root,
+        authorization_carrier=carrier,
+    )
+    request = {"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+    bound = product_invoke.enforce_local_authorization_route(
+        cmd, request, admission, vault_root=selected,
+    )
+    _module().require_bound_request(root, principal=bound, arguments=request, now=NOW + 4)
+    assert bound.consolidation_owner_context is not None
+
+
+@pytest.mark.parametrize("stage", ["admit", "recheck"])
+@pytest.mark.parametrize("change", ["fabricated", "revoked", "rotated", "keyring"])
+def test_durable_session_is_rechecked_before_private_identity(
+    issued_local_session, monkeypatch, stage, change,
+):
+    from exomem.governance import store
+
+    root, custody, issued = issued_local_session
+    module = _module()
+    who = _verified_local_principal(root, issued)
+    request = {"schema": "exomem.consolidate-memory-request/v1", "action": "status", "run_id": "123e4567-e89b-42d3-a456-426614174000"}
+    if stage == "recheck":
+        who = module.bind_local_owner(root, principal=who, arguments=request, now=NOW + 4)
+    session = who.verified_authorization_session
+    if change == "fabricated":
+        session = replace(session, session_id="authorization-session:" + "0" * 32)
+    elif change == "keyring":
+        session = replace(session, keyring_id="never-issued-keyring")
+    else:
+        connection = store.open_authorization_session_connection(root)
+        try:
+            operation = (
+                authorization_session_lifecycle.close_session if change == "revoked"
+                else authorization_session_lifecycle.rotate_session
+            )
+            kwargs = {"ttl_seconds": 60} if change == "rotated" else {}
+            operation(
+                connection, custody=custody, bearer=issued.bearer,
+                principal_id=session.principal_id, issuer_family=session.issuer_family,
+                now=NOW + 5, **kwargs,
+            )
+        finally:
+            connection.close()
+    who = replace(who, verified_authorization_session=session,
+                  authorization_session_id=session.session_id)
+    monkeypatch.setattr(consolidation_identity, "load_local_identity",
+                        lambda *a, **k: pytest.fail("unverified session read private identity"))
+    operation = module.bind_local_owner if stage == "admit" else module.require_bound_request
+    with pytest.raises(module.ConsolidationOwnerUnavailable):
+        operation(root, principal=who, arguments=request, now=NOW + 6)
+
+
+@pytest.mark.parametrize("extra", [[], ["--unknown", "private-action-value"]])
+def test_cli_without_owner_carrier_refuses_before_any_argument_parsing(monkeypatch, capsys, extra):
+    from exomem import __main__ as cli_main
+    from exomem import commands
+    from exomem.command_surface import Command
+
+    cmd = Command("consolidate_memory", lambda: None, (), frozenset({"cli"}))
+    monkeypatch.setattr(commands, "product_commands_for", lambda *a, **k: (cmd,))
+    monkeypatch.setattr(cli_main, "_CLIParser",
+                        lambda *a, **k: pytest.fail("absent session reached CLI parsing"))
+    assert cli_main._core_op_main(["consolidate_memory", *extra]) == 1
+    captured = capsys.readouterr()
+    assert "CONSOLIDATION_OWNER_UNAVAILABLE" in captured.err
+    assert "private-action-value" not in captured.err
+
+
+@pytest.mark.parametrize("invalid", ["0", 0.0, True, -1])
+def test_local_adapter_refuses_semantically_invalid_request_before_coercion(
+    tmp_path, monkeypatch, verified_session_stub, invalid,
+):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+    from exomem.governance import authorization_request, consolidation_request
+
+    who = _principal("cli")
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: _identity())
+    monkeypatch.setattr("time.time", lambda: NOW)
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        product_invoke.enforce_local_authorization_route(
+            SimpleNamespace(name="consolidate_memory"),
+            {"schema": consolidation_request.REQUEST_SCHEMA_NAME, "action": "status",
+             "run_id": "123e4567-e89b-42d3-a456-426614174000", "expected_run_revision": invalid},
+            authorization_request.AuthorizationAdmission(who, True), vault_root=tmp_path,
+        )
+
+
+def test_mcp_raw_duplicates_cannot_become_an_admissible_request():
+    from exomem.governance import authorization_transport
+
+    raw = (b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+           b'"params":{"name":"consolidate_memory","arguments":{'
+           b'"action":"status","action":"apply"}}}')
+    result = authorization_transport.sanitize_mcp_http_body(raw)
+    assert result.carrier.is_invalid
+
+
+@pytest.mark.parametrize("mode,proof,valid", [
+    ("real-cutover", False, False), ("real-cutover", True, True),
+    ("cloned-rehearsal", False, True), ("cloned-rehearsal", True, False),
+])
+def test_adapter_uses_stored_run_mode_for_cutover_proof(
+    tmp_path, monkeypatch, verified_session_stub, mode, proof, valid,
+):
+    from types import SimpleNamespace
+
+    from exomem import product_invoke
+    from exomem.governance import (
+        authorization_request,
+        consolidation_request,
+        consolidation_run_state,
+    )
+
+    identity = _identity()
+    who = _principal("cli")
+    monkeypatch.setattr(consolidation_identity, "load_local_identity", lambda *a, **k: identity)
+    monkeypatch.setattr("time.time", lambda: NOW)
+    loads = []
+    def load(store, run_id):
+        loads.append(run_id)
+        return SimpleNamespace(identity=SimpleNamespace(
+            run_mode=mode, destination_vault_id=identity.vault_id,
+            destination_installation_id=identity.installation_id,
+            destination_generation=identity.installation_generation,
+            destination_fence_digest=identity.active_fence_digest,
+        ))
+    monkeypatch.setattr(consolidation_run_state.ConsolidationRunStore, "load", load)
+    options = {name: "a" * 64 for name in (
+        "expected_reconciliation_digest", "expected_policy_bundle_digest",
+        "expected_principal_attestation_set_digest", "expected_verification_plan_digest",
+        "expected_rollback_contingency_digest", "expected_source_retention_digest",
+        "expected_control_basis_digest",
+    )}
+    if proof:
+        options["expected_rehearsal_proof_digest"] = "a" * 64
+    request = {"schema": consolidation_request.REQUEST_SCHEMA_NAME, "action": "plan",
+        "operation_id": "123e4567-e89b-42d3-a456-426614174001",
+        "run_id": "123e4567-e89b-42d3-a456-426614174000", "expected_run_revision": 0,
+        "plan_kind": "cutover", "operation": "materialize", "successor_context_ref": "context",
+        "successor_context_digest": "a" * 64, "cutover_options": options}
+    def invoke():
+        return product_invoke.enforce_local_authorization_route(
+            SimpleNamespace(name="consolidate_memory"), request,
+            authorization_request.AuthorizationAdmission(who, True), vault_root=tmp_path,
+        )
+    if valid:
+        invoke()
+    else:
+        with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+            invoke()
+    assert loads == [request["run_id"]]
+
+
+def test_mcp_sanitizer_preserves_surrogates_for_post_owner_semantic_refusal():
+    from exomem.governance import authorization_transport
+    raw = (b'{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+           b'"params":{"name":"consolidate_memory","arguments":{"cursor":"\\ud800"}}}')
+    result = authorization_transport.sanitize_mcp_http_body(raw)
+    assert result.arguments["cursor"] == "\ud800"
+    result.body.decode("utf-8")
+
+
+def test_mcp_raw_decoder_refuses_non_utf8_json():
+    from exomem.governance import authorization_transport
+    raw = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"consolidate_memory","arguments":{}}}'
+    with pytest.raises(authorization_transport.AuthorizationEnvelopeUnavailable):
+        authorization_transport.sanitize_mcp_http_body(raw.encode("utf-16"))

--- a/tests/test_consolidation_request.py
+++ b/tests/test_consolidation_request.py
@@ -34,15 +34,22 @@ def _request(action: str) -> dict[str, object]:
         return base | {"run_id": UUID, "detail": "owner-detail", "cursor": "next", "limit": 1}
     if action == "reconcile":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "expected_inventory_digest": DIGEST, "decision_set_ref": "decisions",
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "expected_inventory_digest": DIGEST,
+            "decision_set_ref": "decisions",
             "decision_set_digest": DIGEST,
         }
     if action == "plan":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "plan_kind": "cutover", "operation": "materialize",
-            "successor_context_ref": "context", "successor_context_digest": DIGEST,
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "plan_kind": "cutover",
+            "operation": "materialize",
+            "successor_context_ref": "context",
+            "successor_context_digest": DIGEST,
             "cutover_options": {
                 "expected_reconciliation_digest": DIGEST,
                 "expected_policy_bundle_digest": DIGEST,
@@ -55,48 +62,76 @@ def _request(action: str) -> dict[str, object]:
         }
     if action == "approve":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "plan_kind": "cutover", "plan_digest": DIGEST,
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "plan_kind": "cutover",
+            "plan_digest": DIGEST,
             "rendering_completeness_ref": "completeness",
             "rendering_completeness_digest": DIGEST,
-            "successor_context_ref": "context", "successor_context_digest": DIGEST,
+            "successor_context_ref": "context",
+            "successor_context_digest": DIGEST,
         }
     if action == "apply":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "cutover_plan_digest": DIGEST, "approval_token_ref": "token",
-            "approval_token_digest": DIGEST, "successor_context_ref": "context",
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "cutover_plan_digest": DIGEST,
+            "approval_token_ref": "token",
+            "approval_token_digest": DIGEST,
+            "successor_context_ref": "context",
             "successor_context_digest": DIGEST,
         }
     if action == "verify":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "verification_kind": "in-process", "expected_plan_digest": DIGEST,
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "verification_kind": "in-process",
+            "expected_plan_digest": DIGEST,
             "expected_verification_basis_digest": DIGEST,
         }
     if action == "recover":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "expected_journal_digest": DIGEST, "expected_intent_event_id": DIGEST,
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "expected_journal_digest": DIGEST,
+            "expected_intent_event_id": DIGEST,
         }
     if action == "abort":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "expected_journal_digest": DIGEST, "reason_code": "owner-cancelled", "reason": "stop",
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "expected_journal_digest": DIGEST,
+            "reason_code": "owner-cancelled",
+            "reason": "stop",
         }
     if action == "rollback":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "rollback_mode": "terminal-plan", "successor_context_ref": "context",
-            "successor_context_digest": DIGEST, "rollback_plan_digest": DIGEST,
-            "rollback_token_ref": "token", "rollback_token_digest": DIGEST,
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "rollback_mode": "terminal-plan",
+            "successor_context_ref": "context",
+            "successor_context_digest": DIGEST,
+            "rollback_plan_digest": DIGEST,
+            "rollback_token_ref": "token",
+            "rollback_token_digest": DIGEST,
         }
     if action == "retire-source":
         return base | {
-            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
-            "phase": "clearance", "retirement_plan_digest": DIGEST,
-            "retirement_token_ref": "token", "retirement_token_digest": DIGEST,
-            "successor_context_ref": "context", "successor_context_digest": DIGEST,
+            "operation_id": UUID,
+            "run_id": UUID,
+            "expected_run_revision": 0,
+            "phase": "clearance",
+            "retirement_plan_digest": DIGEST,
+            "retirement_token_ref": "token",
+            "retirement_token_digest": DIGEST,
+            "successor_context_ref": "context",
+            "successor_context_digest": DIGEST,
         }
     raise AssertionError(action)
 
@@ -109,9 +144,7 @@ def _validate(request: dict[str, object]) -> dict[str, object]:
         and request.get("plan_kind") == "cutover"
         else None
     )
-    return consolidation_request.validate_request(
-        request, trusted_run_mode=trusted_run_mode
-    )
+    return consolidation_request.validate_request(request, trusted_run_mode=trusted_run_mode)
 
 
 @pytest.mark.parametrize("action", consolidation_request.ACTIONS)
@@ -168,7 +201,10 @@ def test_refuses_invalid_common_field_mutations(mutate) -> None:
         ("verify", lambda request: request.__setitem__("verification_kind", "other")),
         ("recover", lambda request: request.__setitem__("expected_intent_event_id", DIGEST + "0")),
         ("abort", lambda request: request.__setitem__("reason", "x" * 501)),
-        ("rollback", lambda request: request.__setitem__("rollback_mode", "nonterminal-contingency")),
+        (
+            "rollback",
+            lambda request: request.__setitem__("rollback_mode", "nonterminal-contingency"),
+        ),
         ("retire-source", lambda request: request.__setitem__("phase", "finalize")),
     ],
 )
@@ -182,11 +218,16 @@ def test_refuses_cross_action_and_conditional_mutations(action: str, mutate) -> 
 
 def test_plan_render_steps_and_materialize_options_are_closed() -> None:
     request = _request("plan")
-    request.update({
-        "operation": "render", "render_step": "acknowledge", "plan_digest": DIGEST,
-        "render_session_ref": "session", "page_ordinal": 0,
-        "acknowledged_page_digest": DIGEST,
-    })
+    request.update(
+        {
+            "operation": "render",
+            "render_step": "acknowledge",
+            "plan_digest": DIGEST,
+            "render_session_ref": "session",
+            "page_ordinal": 0,
+            "acknowledged_page_digest": DIGEST,
+        }
+    )
     request.pop("cutover_options")
 
     assert _validate(request) == request
@@ -200,8 +241,7 @@ def test_plan_render_steps_and_materialize_options_are_closed() -> None:
     ("payload", "trusted_run_mode"),
     [
         (
-            _request("start")
-            | {"run_mode": "real-cutover"},
+            _request("start") | {"run_mode": "real-cutover"},
             None,
         ),
         (
@@ -252,8 +292,7 @@ def test_plan_render_steps_and_materialize_options_are_closed() -> None:
             None,
         ),
         (
-            _request("rollback")
-            | {"rollback_mode": "nonterminal-contingency"},
+            _request("rollback") | {"rollback_mode": "nonterminal-contingency"},
             None,
         ),
         (
@@ -285,9 +324,10 @@ def test_accepts_every_non_nested_conditional_branch(
     schema = Draft202012Validator(consolidation_request.request_schema())
 
     assert schema.is_valid(request)
-    assert consolidation_request.validate_request(
-        request, trusted_run_mode=trusted_run_mode
-    ) == request
+    assert (
+        consolidation_request.validate_request(request, trusted_run_mode=trusted_run_mode)
+        == request
+    )
 
 
 @pytest.mark.parametrize(
@@ -337,7 +377,9 @@ def test_materialize_options_enforce_trusted_real_cutover_rehearsal_proof() -> N
 
     request["cutover_options"] = copy.deepcopy(request["cutover_options"])
     request["cutover_options"]["expected_rehearsal_proof_digest"] = DIGEST  # type: ignore[index]
-    assert consolidation_request.validate_request(request, trusted_run_mode="real-cutover") == request
+    assert (
+        consolidation_request.validate_request(request, trusted_run_mode="real-cutover") == request
+    )
     with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
         consolidation_request.validate_request(request, trusted_run_mode="cloned-rehearsal")
 
@@ -401,7 +443,8 @@ def test_generated_schema_has_stable_serialized_order_across_hash_seeds() -> Non
     script = (
         "import hashlib, json; "
         "from exomem.governance.consolidation_request import REQUEST_SCHEMA; "
-        "print(hashlib.sha256(json.dumps(REQUEST_SCHEMA, separators=(',', ':')).encode()).hexdigest())"
+        "print(hashlib.sha256("
+        "json.dumps(REQUEST_SCHEMA, separators=(',', ':')).encode()).hexdigest())"
     )
     environment = os.environ.copy()
     hashes = set()

--- a/tests/test_consolidation_request.py
+++ b/tests/test_consolidation_request.py
@@ -1,0 +1,440 @@
+"""Closed request contract for governed vault consolidation."""
+
+from __future__ import annotations
+
+import copy
+import os
+import subprocess
+import sys
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from exomem.governance import consolidation_request
+
+UUID = "123e4567-e89b-42d3-a456-426614174000"
+DIGEST = "a" * 64
+
+
+def _request(action: str) -> dict[str, object]:
+    base: dict[str, object] = {
+        "schema": "exomem.consolidate-memory-request/v1",
+        "action": action,
+    }
+    if action == "start":
+        return base | {
+            "operation_id": UUID,
+            "expected_run_revision": 0,
+            "run_mode": "cloned-rehearsal",
+            "source_artifact_ref": "source-artifact",
+            "source_attestation_ref": "source-attestation",
+            "clone_binding_ref": "clone-binding",
+        }
+    if action == "status":
+        return base | {"run_id": UUID, "detail": "owner-detail", "cursor": "next", "limit": 1}
+    if action == "reconcile":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "expected_inventory_digest": DIGEST, "decision_set_ref": "decisions",
+            "decision_set_digest": DIGEST,
+        }
+    if action == "plan":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "plan_kind": "cutover", "operation": "materialize",
+            "successor_context_ref": "context", "successor_context_digest": DIGEST,
+            "cutover_options": {
+                "expected_reconciliation_digest": DIGEST,
+                "expected_policy_bundle_digest": DIGEST,
+                "expected_principal_attestation_set_digest": DIGEST,
+                "expected_verification_plan_digest": DIGEST,
+                "expected_rollback_contingency_digest": DIGEST,
+                "expected_source_retention_digest": DIGEST,
+                "expected_control_basis_digest": DIGEST,
+            },
+        }
+    if action == "approve":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "plan_kind": "cutover", "plan_digest": DIGEST,
+            "rendering_completeness_ref": "completeness",
+            "rendering_completeness_digest": DIGEST,
+            "successor_context_ref": "context", "successor_context_digest": DIGEST,
+        }
+    if action == "apply":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "cutover_plan_digest": DIGEST, "approval_token_ref": "token",
+            "approval_token_digest": DIGEST, "successor_context_ref": "context",
+            "successor_context_digest": DIGEST,
+        }
+    if action == "verify":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "verification_kind": "in-process", "expected_plan_digest": DIGEST,
+            "expected_verification_basis_digest": DIGEST,
+        }
+    if action == "recover":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "expected_journal_digest": DIGEST, "expected_intent_event_id": DIGEST,
+        }
+    if action == "abort":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "expected_journal_digest": DIGEST, "reason_code": "owner-cancelled", "reason": "stop",
+        }
+    if action == "rollback":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "rollback_mode": "terminal-plan", "successor_context_ref": "context",
+            "successor_context_digest": DIGEST, "rollback_plan_digest": DIGEST,
+            "rollback_token_ref": "token", "rollback_token_digest": DIGEST,
+        }
+    if action == "retire-source":
+        return base | {
+            "operation_id": UUID, "run_id": UUID, "expected_run_revision": 0,
+            "phase": "clearance", "retirement_plan_digest": DIGEST,
+            "retirement_token_ref": "token", "retirement_token_digest": DIGEST,
+            "successor_context_ref": "context", "successor_context_digest": DIGEST,
+        }
+    raise AssertionError(action)
+
+
+def _validate(request: dict[str, object]) -> dict[str, object]:
+    trusted_run_mode = (
+        "cloned-rehearsal"
+        if request.get("action") == "plan"
+        and request.get("operation") == "materialize"
+        and request.get("plan_kind") == "cutover"
+        else None
+    )
+    return consolidation_request.validate_request(
+        request, trusted_run_mode=trusted_run_mode
+    )
+
+
+@pytest.mark.parametrize("action", consolidation_request.ACTIONS)
+def test_accepts_each_closed_request_variant(action: str) -> None:
+    request = _request(action)
+
+    validated = _validate(request)
+
+    assert validated == request
+    assert validated is not request
+
+
+def test_schema_and_runtime_accept_the_same_canonical_examples() -> None:
+    schema = consolidation_request.request_schema()
+    validator = Draft202012Validator(schema)
+
+    for action in consolidation_request.ACTIONS:
+        request = _request(action)
+        assert validator.is_valid(request)
+        assert _validate(request) == request
+
+
+@pytest.mark.parametrize(
+    ("mutate"),
+    [
+        lambda request: request.__setitem__("unknown", "no"),
+        lambda request: request.__setitem__("operation_id", UUID.upper()),
+        lambda request: request.__setitem__("expected_run_revision", True),
+        lambda request: request.__setitem__("source_artifact_ref", "\x00"),
+        lambda request: request.__setitem__("source_attestation_ref", "x" * 513),
+        lambda request: request.__setitem__("schema", None),
+    ],
+)
+def test_refuses_invalid_common_field_mutations(mutate) -> None:
+    request = _request("start")
+    mutate(request)
+
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable) as raised:
+        _validate(request)
+
+    assert raised.value.code == "CONSOLIDATION_REQUEST_INVALID"
+    assert str(raised.value) == "consolidation request is unavailable"
+
+
+@pytest.mark.parametrize(
+    ("action", "mutate"),
+    [
+        ("start", lambda request: request.__setitem__("run_mode", "real-cutover")),
+        ("status", lambda request: request.__setitem__("operation_id", UUID)),
+        ("reconcile", lambda request: request.__setitem__("decision_set_digest", None)),
+        ("plan", lambda request: request.__setitem__("render_step", "begin")),
+        ("approve", lambda request: request.__setitem__("approval", True)),
+        ("apply", lambda request: request.__setitem__("resume", True)),
+        ("verify", lambda request: request.__setitem__("verification_kind", "other")),
+        ("recover", lambda request: request.__setitem__("expected_intent_event_id", DIGEST + "0")),
+        ("abort", lambda request: request.__setitem__("reason", "x" * 501)),
+        ("rollback", lambda request: request.__setitem__("rollback_mode", "nonterminal-contingency")),
+        ("retire-source", lambda request: request.__setitem__("phase", "finalize")),
+    ],
+)
+def test_refuses_cross_action_and_conditional_mutations(action: str, mutate) -> None:
+    request = _request(action)
+    mutate(request)
+
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        _validate(request)
+
+
+def test_plan_render_steps_and_materialize_options_are_closed() -> None:
+    request = _request("plan")
+    request.update({
+        "operation": "render", "render_step": "acknowledge", "plan_digest": DIGEST,
+        "render_session_ref": "session", "page_ordinal": 0,
+        "acknowledged_page_digest": DIGEST,
+    })
+    request.pop("cutover_options")
+
+    assert _validate(request) == request
+
+    request["rollback_options"] = {}
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        _validate(request)
+
+
+@pytest.mark.parametrize(
+    ("payload", "trusted_run_mode"),
+    [
+        (
+            _request("start")
+            | {"run_mode": "real-cutover"},
+            None,
+        ),
+        (
+            _request("plan")
+            | {
+                "plan_kind": "rollback",
+                "rollback_options": {
+                    "target_kind": "pre-cutover",
+                    "target_snapshot_ref": "snapshot",
+                    "target_snapshot_digest": DIGEST,
+                    "expected_current_census_digest": DIGEST,
+                    "treatment_set_ref": "treatment-set",
+                    "treatment_set_digest": DIGEST,
+                    "surviving_copy_ledger_digest": DIGEST,
+                    "expected_retirement_state_digest": DIGEST,
+                },
+            },
+            None,
+        ),
+        (
+            _request("plan")
+            | {
+                "operation": "render",
+                "render_step": "begin",
+                "plan_digest": DIGEST,
+            },
+            None,
+        ),
+        (
+            _request("plan")
+            | {
+                "operation": "render",
+                "render_step": "page",
+                "plan_digest": DIGEST,
+                "render_session_ref": "session",
+                "page_ordinal": 0,
+            },
+            None,
+        ),
+        (
+            _request("plan")
+            | {
+                "operation": "render",
+                "render_step": "complete",
+                "plan_digest": DIGEST,
+                "render_session_ref": "session",
+            },
+            None,
+        ),
+        (
+            _request("rollback")
+            | {"rollback_mode": "nonterminal-contingency"},
+            None,
+        ),
+        (
+            _request("retire-source")
+            | {
+                "phase": "finalize",
+                "retirement_lifecycle_ref": "lifecycle",
+                "completion_attestation_ref": "attestation",
+                "completion_attestation_digest": DIGEST,
+            },
+            None,
+        ),
+    ],
+)
+def test_accepts_every_non_nested_conditional_branch(
+    payload: dict[str, object], trusted_run_mode: str | None
+) -> None:
+    request = copy.deepcopy(payload)
+    request.pop("clone_binding_ref", None)
+    request.pop("cutover_options", None)
+    request.pop("rollback_plan_digest", None)
+    request.pop("rollback_token_ref", None)
+    request.pop("rollback_token_digest", None)
+    request.pop("retirement_token_ref", None)
+    request.pop("retirement_token_digest", None)
+    if request["action"] == "retire-source" and request["phase"] == "finalize":
+        request.pop("successor_context_ref")
+        request.pop("successor_context_digest")
+    schema = Draft202012Validator(consolidation_request.request_schema())
+
+    assert schema.is_valid(request)
+    assert consolidation_request.validate_request(
+        request, trusted_run_mode=trusted_run_mode
+    ) == request
+
+
+@pytest.mark.parametrize(
+    ("disposition", "rollback_mode"),
+    [
+        ("retain", "pre-cutover-reversible"),
+        ("retain", "forward-only"),
+        ("transfer", "pre-cutover-reversible"),
+        ("transfer", "forward-only"),
+        ("external-destruction", "pre-cutover-reversible"),
+        ("external-destruction", "forward-only"),
+    ],
+)
+def test_retirement_options_accept_each_exact_conditional_branch(
+    disposition: str, rollback_mode: str
+) -> None:
+    request = _request("plan")
+    request["plan_kind"] = "retirement"
+    request.pop("cutover_options")
+    options = {
+        "archive_disposition": disposition,
+        "archive_artifact_ref": "archive",
+        "archive_artifact_digest": DIGEST,
+        "archive_terms_digest": DIGEST,
+        "post_retirement_rollback_mode": rollback_mode,
+        "source_retention_proof_ref": "retention-proof",
+        "source_retention_proof_digest": DIGEST,
+        "surviving_copy_ledger_digest": DIGEST,
+        "retained_irrecoverable_statement_digest": DIGEST,
+    }
+    if disposition == "transfer":
+        options |= {"custodian_receipt_ref": "custody", "custodian_receipt_digest": DIGEST}
+    if rollback_mode == "forward-only":
+        options |= {"forward_snapshot_ref": "forward", "forward_snapshot_digest": DIGEST}
+    request["retirement_options"] = options
+
+    assert _validate(request) == request
+
+
+def test_materialize_options_enforce_trusted_real_cutover_rehearsal_proof() -> None:
+    request = _request("plan")
+
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        consolidation_request.validate_request(request)
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        consolidation_request.validate_request(request, trusted_run_mode="real-cutover")
+
+    request["cutover_options"] = copy.deepcopy(request["cutover_options"])
+    request["cutover_options"]["expected_rehearsal_proof_digest"] = DIGEST  # type: ignore[index]
+    assert consolidation_request.validate_request(request, trusted_run_mode="real-cutover") == request
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        consolidation_request.validate_request(request, trusted_run_mode="cloned-rehearsal")
+
+
+def test_refuses_non_nfc_and_non_dict_decoded_values() -> None:
+    request = _request("start")
+    request["source_artifact_ref"] = "cafe\u0301"
+
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        _validate(request)
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        consolidation_request.validate_request(tuple(request.items()), trusted_run_mode=None)
+
+
+@pytest.mark.parametrize(
+    ("action", "field", "invalid"),
+    [
+        ("start", "operation_id", UUID + "\n"),
+        ("plan", "successor_context_digest", DIGEST + "\n"),
+    ],
+)
+def test_schema_and_runtime_refuse_exact_type_and_end_boundary_mutations(
+    action: str, field: str, invalid: object
+) -> None:
+    request = _request(action)
+    request[field] = invalid
+    validator = Draft202012Validator(consolidation_request.request_schema())
+
+    assert not validator.is_valid(request)
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        _validate(request)
+
+
+def test_runtime_refuses_float_for_exact_integer_field() -> None:
+    request = _request("start")
+    request["expected_run_revision"] = 0.0
+
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        _validate(request)
+
+
+def test_stock_json_schema_cannot_distinguish_a_decoded_integral_float() -> None:
+    request = _request("start")
+    request["expected_run_revision"] = 0.0
+    validator = Draft202012Validator(consolidation_request.request_schema())
+
+    assert validator.is_valid(request)
+
+
+def test_stock_json_schema_cannot_express_the_unicode_ref_contract() -> None:
+    request = _request("start")
+    request["source_artifact_ref"] = "é" * 512
+    validator = Draft202012Validator(consolidation_request.request_schema())
+
+    assert validator.is_valid(request)
+    with pytest.raises(consolidation_request.ConsolidationRequestUnavailable):
+        _validate(request)
+
+
+def test_generated_schema_has_stable_serialized_order_across_hash_seeds() -> None:
+    script = (
+        "import hashlib, json; "
+        "from exomem.governance.consolidation_request import REQUEST_SCHEMA; "
+        "print(hashlib.sha256(json.dumps(REQUEST_SCHEMA, separators=(',', ':')).encode()).hexdigest())"
+    )
+    environment = os.environ.copy()
+    hashes = set()
+    for seed in ("1", "2", "3"):
+        environment["PYTHONHASHSEED"] = seed
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+            capture_output=True,
+            env=environment,
+            text=True,
+        )
+        hashes.add(completed.stdout.strip())
+
+    assert len(hashes) == 1
+
+
+def test_schema_is_fresh_and_closed() -> None:
+    first = consolidation_request.request_schema()
+    second = consolidation_request.request_schema()
+
+    assert first == consolidation_request.REQUEST_SCHEMA
+    assert first is not second
+    first["$defs"]["digest"]["pattern"] = "broken"
+    assert second["$defs"]["digest"]["pattern"] == "^[0-9a-f]{64}(?![\\s\\S])"
+
+
+@pytest.mark.parametrize("action", ["start", "abort"])
+def test_optional_rehearsal_binding_and_empty_abort_reason_are_valid(action):
+    request = _request(action)
+    if action == "start":
+        request.pop("clone_binding_ref")
+    else:
+        request["reason"] = ""
+    assert _validate(request) == request
+    assert Draft202012Validator(consolidation_request.request_schema()).is_valid(request)

--- a/tests/test_consolidation_terminal.py
+++ b/tests/test_consolidation_terminal.py
@@ -25,23 +25,146 @@ def _digest(label: str) -> str:
 
 
 ROWS = {
-    "start": (("source_fingerprint", "destination_snapshot_fingerprint"), ("source_objects", "source_bytes", "destination_objects", "destination_bytes"), ("status", "reconcile"), "start"),
-    "status": (("run_state_digest", "journal_digest"), ("completed_effects", "pending_effects", "blocked_effects", "warnings"), ("status",), "active"),
-    "reconcile": (("inventory_digest", "reconciliation_digest", "mapping_set_digest"), ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "unresolved", "mappings"), ("status", "reconcile", "plan"), "reconcile"),
-    "plan:materialize": (("plan_digest", "control_basis_digest", "plan_successor_automaton_digest"), ("content_actions", "policy_documents", "impact_rows", "render_pages"), ("status", "plan"), "materialize"),
-    "plan:render-begin": (("plan_digest", "render_session_digest"), ("render_pages", "acknowledged_pages"), ("status", "plan"), "render-begin"),
-    "plan:render-page": (("plan_digest", "render_page_digest"), ("page_ordinal", "page_rows", "render_pages"), ("status", "plan"), "render-page"),
-    "plan:render-acknowledge": (("plan_digest", "render_ack_digest"), ("acknowledged_pages", "render_pages"), ("status", "plan"), "render-acknowledge"),
-    "plan:render-complete": (("plan_digest", "rendering_completeness_digest"), ("acknowledged_pages", "render_pages"), ("status", "approve"), "render-complete"),
-    "approve": (("plan_digest", "approval_token_digest"), ("acknowledged_pages", "render_pages"), ("status", "apply"), "approved"),
-    "apply": (("cutover_terminal_digest", "post_cutover_census_digest", "apply_predecessor_digest"), ("policy_documents", "content_batches", "content_actions", "rebuild_kinds", "in_process_probes", "transport_probes"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"), "complete"),
-    "verify": (("verification_basis_digest", "verification_terminal_digest"), ("positive_probes", "negative_probes", "passed_probes", "failed_probes"), ("status", "plan", "apply", "verify", "recover", "rollback", "retire-source"), "complete"),
-    "recover": (("journal_digest", "recovery_terminal_digest"), ("classified_effects", "repaired_effects", "blocked_effects"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"), "repair-terminal"),
-    "abort": (("prior_census_digest", "abort_terminal_digest"), ("restored_entries", "removed_candidates", "evidence_events"), ("status",), "aborted"),
-    "rollback:nonterminal-contingency": (("cutover_plan_digest", "original_apply_journal_digest", "rollback_contingency_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback"), "rollback-complete"),
-    "rollback:terminal-plan": (("rollback_plan_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback"), "rollback-complete"),
-    "retire-source:clearance": (("retirement_plan_digest", "clearance_digest", "retirement_lifecycle_digest", "surviving_copy_ledger_digest"), ("survivor_rows", "verified_survivor_rows"), ("status", "retire-source"), "retirement-pending"),
-    "retire-source:finalize": (("retirement_plan_digest", "retirement_lifecycle_digest", "completion_digest", "finalization_digest", "surviving_copy_ledger_digest"), ("completion_records", "survivor_rows"), ("status", "plan"), "retirement-finalize"),
+    "start": (
+        ("source_fingerprint", "destination_snapshot_fingerprint"),
+        ("source_objects", "source_bytes", "destination_objects", "destination_bytes"),
+        ("status", "reconcile"),
+        "start",
+    ),
+    "status": (
+        ("run_state_digest", "journal_digest"),
+        ("completed_effects", "pending_effects", "blocked_effects", "warnings"),
+        ("status",),
+        "active",
+    ),
+    "reconcile": (
+        ("inventory_digest", "reconciliation_digest", "mapping_set_digest"),
+        ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "unresolved", "mappings"),
+        ("status", "reconcile", "plan"),
+        "reconcile",
+    ),
+    "plan:materialize": (
+        ("plan_digest", "control_basis_digest", "plan_successor_automaton_digest"),
+        ("content_actions", "policy_documents", "impact_rows", "render_pages"),
+        ("status", "plan"),
+        "materialize",
+    ),
+    "plan:render-begin": (
+        ("plan_digest", "render_session_digest"),
+        ("render_pages", "acknowledged_pages"),
+        ("status", "plan"),
+        "render-begin",
+    ),
+    "plan:render-page": (
+        ("plan_digest", "render_page_digest"),
+        ("page_ordinal", "page_rows", "render_pages"),
+        ("status", "plan"),
+        "render-page",
+    ),
+    "plan:render-acknowledge": (
+        ("plan_digest", "render_ack_digest"),
+        ("acknowledged_pages", "render_pages"),
+        ("status", "plan"),
+        "render-acknowledge",
+    ),
+    "plan:render-complete": (
+        ("plan_digest", "rendering_completeness_digest"),
+        ("acknowledged_pages", "render_pages"),
+        ("status", "approve"),
+        "render-complete",
+    ),
+    "approve": (
+        ("plan_digest", "approval_token_digest"),
+        ("acknowledged_pages", "render_pages"),
+        ("status", "apply"),
+        "approved",
+    ),
+    "apply": (
+        ("cutover_terminal_digest", "post_cutover_census_digest", "apply_predecessor_digest"),
+        (
+            "policy_documents",
+            "content_batches",
+            "content_actions",
+            "rebuild_kinds",
+            "in_process_probes",
+            "transport_probes",
+        ),
+        ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"),
+        "complete",
+    ),
+    "verify": (
+        ("verification_basis_digest", "verification_terminal_digest"),
+        ("positive_probes", "negative_probes", "passed_probes", "failed_probes"),
+        ("status", "plan", "apply", "verify", "recover", "rollback", "retire-source"),
+        "complete",
+    ),
+    "recover": (
+        ("journal_digest", "recovery_terminal_digest"),
+        ("classified_effects", "repaired_effects", "blocked_effects"),
+        ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"),
+        "repair-terminal",
+    ),
+    "abort": (
+        ("prior_census_digest", "abort_terminal_digest"),
+        ("restored_entries", "removed_candidates", "evidence_events"),
+        ("status",),
+        "aborted",
+    ),
+    "rollback:nonterminal-contingency": (
+        (
+            "cutover_plan_digest",
+            "original_apply_journal_digest",
+            "rollback_contingency_digest",
+            "target_census_digest",
+            "rollback_terminal_digest",
+        ),
+        (
+            "restored_entries",
+            "retained_entries",
+            "reapplied_entries",
+            "discarded_entries",
+            "rebuild_kinds",
+            "verification_probes",
+        ),
+        ("status", "plan", "recover", "verify", "rollback"),
+        "rollback-complete",
+    ),
+    "rollback:terminal-plan": (
+        ("rollback_plan_digest", "target_census_digest", "rollback_terminal_digest"),
+        (
+            "restored_entries",
+            "retained_entries",
+            "reapplied_entries",
+            "discarded_entries",
+            "rebuild_kinds",
+            "verification_probes",
+        ),
+        ("status", "plan", "recover", "verify", "rollback"),
+        "rollback-complete",
+    ),
+    "retire-source:clearance": (
+        (
+            "retirement_plan_digest",
+            "clearance_digest",
+            "retirement_lifecycle_digest",
+            "surviving_copy_ledger_digest",
+        ),
+        ("survivor_rows", "verified_survivor_rows"),
+        ("status", "retire-source"),
+        "retirement-pending",
+    ),
+    "retire-source:finalize": (
+        (
+            "retirement_plan_digest",
+            "retirement_lifecycle_digest",
+            "completion_digest",
+            "finalization_digest",
+            "surviving_copy_ledger_digest",
+        ),
+        ("completion_records", "survivor_rows"),
+        ("status", "plan"),
+        "retirement-finalize",
+    ),
 }
 
 PLAN_ENTRY_BRANCHES = {
@@ -74,20 +197,40 @@ def _request(action: str) -> tuple[dict[str, object], str | None]:
         "action": action.split(":", 1)[0],
     }
     if action == "start":
-        return base | {"operation_id": OPERATION_ID, "expected_run_revision": 0, "run_mode": "real-cutover", "source_artifact_ref": "source", "source_attestation_ref": "attestation"}, "real-cutover"
+        return base | {
+            "operation_id": OPERATION_ID,
+            "expected_run_revision": 0,
+            "run_mode": "real-cutover",
+            "source_artifact_ref": "source",
+            "source_attestation_ref": "attestation",
+        }, "real-cutover"
     if action == "status":
         return base | {"run_id": RUN_ID, "expected_run_revision": 1, "detail": "summary"}, None
     mutation = {"operation_id": OPERATION_ID, "run_id": RUN_ID, "expected_run_revision": 0}
-    context = {"successor_context_ref": "input-context", "successor_context_digest": _digest("input-context")}
+    context = {
+        "successor_context_ref": "input-context",
+        "successor_context_digest": _digest("input-context"),
+    }
     if action == "reconcile":
-        return base | mutation | {"expected_inventory_digest": _digest("inventory"), "decision_set_ref": "decisions", "decision_set_digest": _digest("decisions")}, None
+        return base | mutation | {
+            "expected_inventory_digest": _digest("inventory"),
+            "decision_set_ref": "decisions",
+            "decision_set_digest": _digest("decisions"),
+        }, None
     if action.startswith("plan:"):
         request = base | mutation | context | {"plan_kind": "cutover"}
         variant = action.removeprefix("plan:")
         if variant == "materialize":
-            return request | {"operation": "materialize", "cutover_options": _cutover_options()}, "real-cutover"
+            return request | {
+                "operation": "materialize",
+                "cutover_options": _cutover_options(),
+            }, "real-cutover"
         step = variant.removeprefix("render-")
-        request |= {"operation": "render", "render_step": step, "plan_digest": _digest("plan_digest")}
+        request |= {
+            "operation": "render",
+            "render_step": step,
+            "plan_digest": _digest("plan_digest"),
+        }
         if step in {"page", "acknowledge", "complete"}:
             request["render_session_ref"] = "render-session"
         if step in {"page", "acknowledge"}:
@@ -96,25 +239,56 @@ def _request(action: str) -> tuple[dict[str, object], str | None]:
             request["acknowledged_page_digest"] = _digest("render_page_digest")
         return request, None
     if action == "approve":
-        return base | mutation | context | {"plan_kind": "cutover", "plan_digest": _digest("plan_digest"), "rendering_completeness_ref": "completeness", "rendering_completeness_digest": _digest("rendering_completeness_digest")}, None
+        return base | mutation | context | {
+            "plan_kind": "cutover",
+            "plan_digest": _digest("plan_digest"),
+            "rendering_completeness_ref": "completeness",
+            "rendering_completeness_digest": _digest("rendering_completeness_digest"),
+        }, None
     if action == "apply":
-        return base | mutation | context | {"cutover_plan_digest": _digest("plan_digest"), "approval_token_ref": "token", "approval_token_digest": _digest("approval_token_digest")}, "real-cutover"
+        return base | mutation | context | {
+            "cutover_plan_digest": _digest("plan_digest"),
+            "approval_token_ref": "token",
+            "approval_token_digest": _digest("approval_token_digest"),
+        }, "real-cutover"
     if action == "verify":
-        return base | mutation | {"verification_kind": "transport", "expected_plan_digest": _digest("plan_digest"), "expected_verification_basis_digest": _digest("verification-basis")}, "real-cutover"
+        return base | mutation | {
+            "verification_kind": "transport",
+            "expected_plan_digest": _digest("plan_digest"),
+            "expected_verification_basis_digest": _digest("verification-basis"),
+        }, "real-cutover"
     if action == "recover":
         return base | mutation | {"expected_journal_digest": _digest("journal")}, None
     if action == "abort":
-        return base | mutation | {"expected_journal_digest": _digest("journal"), "reason_code": "owner-cancelled"}, None
+        return base | mutation | {
+            "expected_journal_digest": _digest("journal"),
+            "reason_code": "owner-cancelled",
+        }, None
     if action.startswith("rollback:"):
         mode = action.removeprefix("rollback:")
         request = base | mutation | context | {"rollback_mode": mode}
         if mode == "terminal-plan":
-            request |= {"rollback_plan_digest": _digest("rollback_plan_digest"), "rollback_token_ref": "rollback-token", "rollback_token_digest": _digest("rollback-token")}
+            request |= {
+                "rollback_plan_digest": _digest("rollback_plan_digest"),
+                "rollback_token_ref": "rollback-token",
+                "rollback_token_digest": _digest("rollback-token"),
+            }
         return request, None
     if action == "retire-source:clearance":
-        return base | mutation | context | {"phase": "clearance", "retirement_plan_digest": _digest("retirement_plan_digest"), "retirement_token_ref": "retirement-token", "retirement_token_digest": _digest("retirement-token")}, None
+        return base | mutation | context | {
+            "phase": "clearance",
+            "retirement_plan_digest": _digest("retirement_plan_digest"),
+            "retirement_token_ref": "retirement-token",
+            "retirement_token_digest": _digest("retirement-token"),
+        }, None
     if action == "retire-source:finalize":
-        return base | mutation | {"phase": "finalize", "retirement_plan_digest": _digest("retirement_plan_digest"), "retirement_lifecycle_ref": "lifecycle", "completion_attestation_ref": "completion", "completion_attestation_digest": _digest("completion")}, None
+        return base | mutation | {
+            "phase": "finalize",
+            "retirement_plan_digest": _digest("retirement_plan_digest"),
+            "retirement_lifecycle_ref": "lifecycle",
+            "completion_attestation_ref": "completion",
+            "completion_attestation_digest": _digest("completion"),
+        }, None
     raise AssertionError(action)
 
 
@@ -143,13 +317,51 @@ def _successor(
     action, variant = expected_successors[kind]
     if kind == "approve":
         variant = str(facts["plan_kind"])
-    basis = str(facts.get("plan_input_basis_digest", facts.get("original_apply_journal_digest", _digest("basis"))))
+    basis = str(
+        facts.get(
+            "plan_input_basis_digest", facts.get("original_apply_journal_digest", _digest("basis"))
+        )
+    )
     expiry = PLAN_ENTRY_EXPIRES_AT if kind == "plan-materialize" else EXPIRES_AT
-    owner = successor.SuccessorOwnerIdentity("vault", "installation", 1, _digest("fence"), _digest("principal"))
+    owner = successor.SuccessorOwnerIdentity(
+        "vault", "installation", 1, _digest("fence"), _digest("principal")
+    )
     owner_digest = successor.build_owner_binding(owner).digest
-    seed = successor.build_seed(successor.SuccessorSeedInput(kind, RUN_ID, run_revision, _digest("destination"), owner_digest, basis, action, variant, ISSUED_AT, expiry, "nonce", facts))
-    context = successor.derive_context(seed, predecessor_event_id=f"{_digest('event')}:committed", predecessor_payload_digest=_digest("payload"))
-    expected = successor.ExpectedSuccessorContext(kind, RUN_ID, run_revision, _digest("destination"), owner_digest, basis, context.preimage["predecessor_event_id"], _digest("payload"), action, variant, facts, ISSUED_AT)
+    seed = successor.build_seed(
+        successor.SuccessorSeedInput(
+            kind,
+            RUN_ID,
+            run_revision,
+            _digest("destination"),
+            owner_digest,
+            basis,
+            action,
+            variant,
+            ISSUED_AT,
+            expiry,
+            "nonce",
+            facts,
+        )
+    )
+    context = successor.derive_context(
+        seed,
+        predecessor_event_id=f"{_digest('event')}:committed",
+        predecessor_payload_digest=_digest("payload"),
+    )
+    expected = successor.ExpectedSuccessorContext(
+        kind,
+        RUN_ID,
+        run_revision,
+        _digest("destination"),
+        owner_digest,
+        basis,
+        context.preimage["predecessor_event_id"],
+        _digest("payload"),
+        action,
+        variant,
+        facts,
+        ISSUED_AT,
+    )
     return context, expected
 
 
@@ -169,47 +381,113 @@ def _terminal(action: str) -> tuple[dict[str, object], terminal.TerminalProjecti
         "trusted_outputs": {},
     }
     if action != "status":
-        value.update({"operation_id": OPERATION_ID, "request_digest": _request_digest(request), "prior_state_digest": _digest("prior"), "final_state_digest": _digest("final")})
+        value.update(
+            {
+                "operation_id": OPERATION_ID,
+                "request_digest": _request_digest(request),
+                "prior_state_digest": _digest("prior"),
+                "final_state_digest": _digest("final"),
+            }
+        )
 
     context = None
     expected = None
     eligible = PLAN_ENTRY_BRANCHES.get(action)
     facts: dict[str, object] | None = None
     if eligible is not None:
-        facts = {"eligible_plan_kinds": list(eligible), "plan_input_basis_digest": _digest(f"{action}-basis")}
+        facts = {
+            "eligible_plan_kinds": list(eligible),
+            "plan_input_basis_digest": _digest(f"{action}-basis"),
+        }
         context, expected = _successor("plan-materialize", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "eligible_plan_kinds": list(eligible)}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+            "eligible_plan_kinds": list(eligible),
+        }
     elif action == "plan:materialize":
         facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"]}
         context, expected = _successor("render-begin", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+        }
     elif action == "plan:render-begin":
         value["counts"].update({"render_pages": 2, "acknowledged_pages": 0})
-        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": value["artifact_digests"]["render_session_digest"], "page_ordinal": 0}
+        facts = {
+            "plan_kind": "cutover",
+            "plan_digest": value["artifact_digests"]["plan_digest"],
+            "render_session_digest": value["artifact_digests"]["render_session_digest"],
+            "page_ordinal": 0,
+        }
         context, expected = _successor("render-page", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "render_session_ref": "render-session"}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+            "render_session_ref": "render-session",
+        }
     elif action == "plan:render-page":
         value["counts"].update({"page_ordinal": 0, "render_pages": 2})
-        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": _digest("render-session"), "page_ordinal": 0, "page_digest": value["artifact_digests"]["render_page_digest"]}
+        facts = {
+            "plan_kind": "cutover",
+            "plan_digest": value["artifact_digests"]["plan_digest"],
+            "render_session_digest": _digest("render-session"),
+            "page_ordinal": 0,
+            "page_digest": value["artifact_digests"]["render_page_digest"],
+        }
         context, expected = _successor("render-acknowledge", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "render_session_ref": "render-session", "render_delivery_ref": "render-delivery"}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+            "render_session_ref": "render-session",
+            "render_delivery_ref": "render-delivery",
+        }
     elif action == "plan:render-acknowledge":
         value["counts"].update({"acknowledged_pages": 1, "render_pages": 2})
-        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": _digest("render-session"), "page_ordinal": 1}
+        facts = {
+            "plan_kind": "cutover",
+            "plan_digest": value["artifact_digests"]["plan_digest"],
+            "render_session_digest": _digest("render-session"),
+            "page_ordinal": 1,
+        }
         context, expected = _successor("render-page", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "render_session_ref": "render-session"}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+            "render_session_ref": "render-session",
+        }
     elif action == "plan:render-complete":
         value["counts"].update({"acknowledged_pages": 2, "render_pages": 2})
-        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "rendering_completeness_digest": value["artifact_digests"]["rendering_completeness_digest"]}
+        facts = {
+            "plan_kind": "cutover",
+            "plan_digest": value["artifact_digests"]["plan_digest"],
+            "rendering_completeness_digest": value["artifact_digests"][
+                "rendering_completeness_digest"
+            ],
+        }
         context, expected = _successor("approve", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "rendering_completeness_ref": "completeness"}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+            "rendering_completeness_ref": "completeness",
+        }
     elif action == "approve":
         value["counts"].update({"acknowledged_pages": 2, "render_pages": 2})
-        facts = {"cutover_plan_digest": value["artifact_digests"]["plan_digest"], "approval_token_digest": value["artifact_digests"]["approval_token_digest"]}
+        facts = {
+            "cutover_plan_digest": value["artifact_digests"]["plan_digest"],
+            "approval_token_digest": value["artifact_digests"]["approval_token_digest"],
+        }
         context, expected = _successor("apply", facts)
-        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "approval_token_ref": "approval-token"}
+        value["trusted_outputs"] = {
+            "successor_context_ref": "output-context",
+            "successor_context_digest": context.digest,
+            "approval_token_ref": "approval-token",
+        }
     elif action == "retire-source:clearance":
-        value["trusted_outputs"] = {"retirement_clearance_ref": "clearance", "retirement_lifecycle_ref": "lifecycle"}
+        value["trusted_outputs"] = {
+            "retirement_clearance_ref": "clearance",
+            "retirement_lifecycle_ref": "lifecycle",
+        }
 
     eligibility = {}
     if "eligible_plan_kinds" in terminal.TerminalProjectionState.__dataclass_fields__:
@@ -238,10 +516,26 @@ def test_all_closed_rows_bind_the_exact_coordinator_projection(action: str) -> N
 
 @pytest.mark.parametrize("action", tuple(action for action in ROWS if action != "status"))
 @pytest.mark.parametrize("field", ("operation_id", "request_digest", "run_revision"))
-def test_every_mutation_binds_identity_request_and_resulting_revision(action: str, field: str) -> None:
+def test_every_mutation_binds_identity_request_and_resulting_revision(
+    action: str, field: str
+) -> None:
     value, state = _terminal(action)
-    value[field] = OTHER_OPERATION_ID if field == "operation_id" else _digest("foreign-request") if field == "request_digest" else 2
-    state = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+    value[field] = (
+        OTHER_OPERATION_ID
+        if field == "operation_id"
+        else _digest("foreign-request")
+        if field == "request_digest"
+        else 2
+    )
+    state = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        state.trusted_run_mode,
+        state.successor_reference,
+        state.successor_context,
+        state.expected_successor,
+        eligible_plan_kinds=state.eligible_plan_kinds,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=state)
@@ -258,12 +552,30 @@ def test_status_binds_an_optional_expected_revision() -> None:
 
 @pytest.mark.parametrize(
     ("action", "bad_phase"),
-    (("reconcile", "complete"), ("apply", "seal-intent"), ("verify", "probe"), ("recover", "classify"), ("rollback:nonterminal-contingency", "rolling-back"), ("rollback:terminal-plan", "rolling-back"), ("retire-source:finalize", "finalizing")),
+    (
+        ("reconcile", "complete"),
+        ("apply", "seal-intent"),
+        ("verify", "probe"),
+        ("recover", "classify"),
+        ("rollback:nonterminal-contingency", "rolling-back"),
+        ("rollback:terminal-plan", "rolling-back"),
+        ("retire-source:finalize", "finalizing"),
+    ),
 )
-def test_plan_entry_contexts_only_appear_at_exact_product_terminal_phases(action: str, bad_phase: str) -> None:
+def test_plan_entry_contexts_only_appear_at_exact_product_terminal_phases(
+    action: str, bad_phase: str
+) -> None:
     value, state = _terminal(action)
     value["phase"] = bad_phase
-    state = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+    state = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        state.trusted_run_mode,
+        state.successor_reference,
+        state.successor_context,
+        state.expected_successor,
+        eligible_plan_kinds=state.eligible_plan_kinds,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=state)
@@ -271,15 +583,24 @@ def test_plan_entry_contexts_only_appear_at_exact_product_terminal_phases(action
 
 def test_apply_complete_rejects_a_valid_but_wrong_render_successor() -> None:
     value, state = _terminal("apply")
-    context, expected = _successor("render-begin", {"plan_kind": "cutover", "plan_digest": _digest("plan_digest")})
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
-    state = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected)
+    context, expected = _successor(
+        "render-begin", {"plan_kind": "cutover", "plan_digest": _digest("plan_digest")}
+    )
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+    }
+    state = terminal.TerminalProjectionState(
+        state.validated_request, value, "real-cutover", "output-context", context, expected
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=state)
 
 
-def _contingency() -> tuple[successor.CanonicalSuccessorContext, successor.ExpectedSuccessorContext]:
+def _contingency() -> tuple[
+    successor.CanonicalSuccessorContext, successor.ExpectedSuccessorContext
+]:
     facts = {
         "original_apply_operation_id": OPERATION_ID,
         "original_apply_journal_digest": _digest("apply-journal"),
@@ -297,14 +618,27 @@ def test_apply_before_complete_only_accepts_an_explicitly_eligible_contingency()
     value, state = _terminal("apply")
     value["phase"] = "seal-intent"
     context, expected = _contingency()
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+    }
     value["next_actions"] = [action for action in value["next_actions"] if action != "plan"]
 
-    ineligible = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected)
+    ineligible = terminal.TerminalProjectionState(
+        state.validated_request, value, "real-cutover", "output-context", context, expected
+    )
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=ineligible)
 
-    eligible = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected, nonterminal_contingency_eligible=True)
+    eligible = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        "real-cutover",
+        "output-context",
+        context,
+        expected,
+        nonterminal_contingency_eligible=True,
+    )
     assert terminal.validate_terminal(value, request=eligible)["phase"] == "seal-intent"
 
 
@@ -312,8 +646,19 @@ def test_contingency_context_never_advertises_plan() -> None:
     value, state = _terminal("apply")
     value["phase"] = "seal-intent"
     context, expected = _contingency()
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
-    state = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected, nonterminal_contingency_eligible=True)
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+    }
+    state = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        "real-cutover",
+        "output-context",
+        context,
+        expected,
+        nonterminal_contingency_eligible=True,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=state)
@@ -321,17 +666,40 @@ def test_contingency_context_never_advertises_plan() -> None:
 
 def test_status_context_requires_owner_detail_and_plan_requires_plan_entry_context() -> None:
     value, state = _terminal("status")
-    facts = {"eligible_plan_kinds": ["rollback"], "plan_input_basis_digest": _digest("status-basis")}
+    facts = {
+        "eligible_plan_kinds": ["rollback"],
+        "plan_input_basis_digest": _digest("status-basis"),
+    }
     context, expected = _successor("plan-materialize", facts)
     value["phase"] = "complete"
     value["next_actions"] = ["status", "plan"]
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "eligible_plan_kinds": ["rollback"]}
-    summary = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected, eligible_plan_kinds=("rollback",))
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+        "eligible_plan_kinds": ["rollback"],
+    }
+    summary = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        "real-cutover",
+        "output-context",
+        context,
+        expected,
+        eligible_plan_kinds=("rollback",),
+    )
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=summary)
 
     owner_request = dict(state.validated_request) | {"detail": "owner-detail"}
-    owner_state = terminal.TerminalProjectionState(owner_request, value, "real-cutover", "output-context", context, expected, eligible_plan_kinds=("rollback",))
+    owner_state = terminal.TerminalProjectionState(
+        owner_request,
+        value,
+        "real-cutover",
+        "output-context",
+        context,
+        expected,
+        eligible_plan_kinds=("rollback",),
+    )
     assert terminal.validate_terminal(value, request=owner_state)["phase"] == "complete"
 
     value["trusted_outputs"] = {}
@@ -342,12 +710,25 @@ def test_status_context_requires_owner_detail_and_plan_requires_plan_entry_conte
 
 def test_owner_detail_status_may_return_another_current_context_with_a_cursor() -> None:
     value, state = _terminal("status")
-    facts = {"cutover_plan_digest": _digest("plan_digest"), "approval_token_digest": _digest("approval")}
+    facts = {
+        "cutover_plan_digest": _digest("plan_digest"),
+        "approval_token_digest": _digest("approval"),
+    }
     context, expected = _successor("apply", facts)
     request = dict(state.validated_request) | {"detail": "owner-detail"}
     value["next_actions"] = ["status", "apply"]
-    value["trusted_outputs"] = {"next_cursor": "cursor", "successor_context_ref": "output-context", "successor_context_digest": context.digest}
-    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+    value["trusted_outputs"] = {
+        "next_cursor": "cursor",
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+    }
+    state = terminal.TerminalProjectionState(
+        request,
+        value,
+        successor_reference="output-context",
+        successor_context=context,
+        expected_successor=expected,
+    )
 
     checked = terminal.validate_terminal(value, request=state)
 
@@ -358,25 +739,116 @@ def test_owner_detail_status_may_return_another_current_context_with_a_cursor() 
     ("kind", "facts", "next_action", "contingency"),
     (
         ("render-begin", {"plan_kind": "cutover", "plan_digest": _digest("plan")}, "plan", False),
-        ("render-page", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "render_session_digest": _digest("session"), "page_ordinal": 0}, "plan", False),
-        ("render-acknowledge", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "render_session_digest": _digest("session"), "page_ordinal": 0, "page_digest": _digest("page")}, "plan", False),
-        ("render-complete", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "render_session_digest": _digest("session")}, "plan", False),
-        ("approve", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "rendering_completeness_digest": _digest("completeness")}, "approve", False),
-        ("apply", {"cutover_plan_digest": _digest("plan"), "approval_token_digest": _digest("approval")}, "apply", False),
-        ("rollback-terminal-plan", {"rollback_plan_digest": _digest("plan"), "rollback_token_digest": _digest("rollback-token")}, "rollback", False),
-        ("rollback-nonterminal-contingency", {"original_apply_operation_id": OPERATION_ID, "original_apply_journal_digest": _digest("journal"), "cutover_plan_digest": _digest("plan"), "rollback_contingency_digest": _digest("contingency"), "publication_state_digest": _digest("publication"), "contingency_authority_ref": "authority", "contingency_authority_digest": _digest("authority"), "recovery_window_deadline": "2026-08-28T12:30:00.000Z"}, "rollback", True),
-        ("retire-source-clearance", {"retirement_plan_digest": _digest("plan"), "retirement_token_digest": _digest("retirement-token")}, "retire-source", False),
+        (
+            "render-page",
+            {
+                "plan_kind": "cutover",
+                "plan_digest": _digest("plan"),
+                "render_session_digest": _digest("session"),
+                "page_ordinal": 0,
+            },
+            "plan",
+            False,
+        ),
+        (
+            "render-acknowledge",
+            {
+                "plan_kind": "cutover",
+                "plan_digest": _digest("plan"),
+                "render_session_digest": _digest("session"),
+                "page_ordinal": 0,
+                "page_digest": _digest("page"),
+            },
+            "plan",
+            False,
+        ),
+        (
+            "render-complete",
+            {
+                "plan_kind": "cutover",
+                "plan_digest": _digest("plan"),
+                "render_session_digest": _digest("session"),
+            },
+            "plan",
+            False,
+        ),
+        (
+            "approve",
+            {
+                "plan_kind": "cutover",
+                "plan_digest": _digest("plan"),
+                "rendering_completeness_digest": _digest("completeness"),
+            },
+            "approve",
+            False,
+        ),
+        (
+            "apply",
+            {"cutover_plan_digest": _digest("plan"), "approval_token_digest": _digest("approval")},
+            "apply",
+            False,
+        ),
+        (
+            "rollback-terminal-plan",
+            {
+                "rollback_plan_digest": _digest("plan"),
+                "rollback_token_digest": _digest("rollback-token"),
+            },
+            "rollback",
+            False,
+        ),
+        (
+            "rollback-nonterminal-contingency",
+            {
+                "original_apply_operation_id": OPERATION_ID,
+                "original_apply_journal_digest": _digest("journal"),
+                "cutover_plan_digest": _digest("plan"),
+                "rollback_contingency_digest": _digest("contingency"),
+                "publication_state_digest": _digest("publication"),
+                "contingency_authority_ref": "authority",
+                "contingency_authority_digest": _digest("authority"),
+                "recovery_window_deadline": "2026-08-28T12:30:00.000Z",
+            },
+            "rollback",
+            True,
+        ),
+        (
+            "retire-source-clearance",
+            {
+                "retirement_plan_digest": _digest("plan"),
+                "retirement_token_digest": _digest("retirement-token"),
+            },
+            "retire-source",
+            False,
+        ),
     ),
 )
-def test_owner_detail_status_reexposes_each_current_successor_context(kind: str, facts: dict[str, object], next_action: str, contingency: bool) -> None:
+def test_owner_detail_status_reexposes_each_current_successor_context(
+    kind: str, facts: dict[str, object], next_action: str, contingency: bool
+) -> None:
     value, state = _terminal("status")
     context, expected = _successor(kind, facts)
     request = dict(state.validated_request) | {"detail": "owner-detail"}
     value["next_actions"] = ["status", next_action]
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
-    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected, nonterminal_contingency_eligible=contingency)
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+    }
+    state = terminal.TerminalProjectionState(
+        request,
+        value,
+        successor_reference="output-context",
+        successor_context=context,
+        expected_successor=expected,
+        nonterminal_contingency_eligible=contingency,
+    )
 
-    assert terminal.validate_terminal(value, request=state)["trusted_outputs"]["successor_context_digest"] == context.digest
+    assert (
+        terminal.validate_terminal(value, request=state)["trusted_outputs"][
+            "successor_context_digest"
+        ]
+        == context.digest
+    )
 
 
 def test_owner_detail_status_rejects_plan_for_an_unrelated_current_context() -> None:
@@ -385,8 +857,17 @@ def test_owner_detail_status_rejects_plan_for_an_unrelated_current_context() -> 
     context, expected = _successor("apply", facts)
     request = dict(state.validated_request) | {"detail": "owner-detail"}
     value["next_actions"] = ["status", "plan", "apply"]
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
-    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+    }
+    state = terminal.TerminalProjectionState(
+        request,
+        value,
+        successor_reference="output-context",
+        successor_context=context,
+        expected_successor=expected,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=state)
@@ -395,7 +876,15 @@ def test_owner_detail_status_rejects_plan_for_an_unrelated_current_context() -> 
 def test_terminal_eligible_kinds_match_canonical_context_and_process_state() -> None:
     value, state = _terminal("apply")
     value["trusted_outputs"]["eligible_plan_kinds"] = ["rollback"]
-    changed = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=("rollback",))
+    changed = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        state.trusted_run_mode,
+        state.successor_reference,
+        state.successor_context,
+        state.expected_successor,
+        eligible_plan_kinds=("rollback",),
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=changed)
@@ -403,7 +892,15 @@ def test_terminal_eligible_kinds_match_canonical_context_and_process_state() -> 
 
 def test_retirement_plan_entry_requires_real_cutover() -> None:
     value, state = _terminal("apply")
-    changed = terminal.TerminalProjectionState(state.validated_request, value, "cloned-rehearsal", state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+    changed = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        "cloned-rehearsal",
+        state.successor_reference,
+        state.successor_context,
+        state.expected_successor,
+        eligible_plan_kinds=state.eligible_plan_kinds,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=changed)
@@ -413,7 +910,15 @@ def test_verify_plan_entry_requires_transport_verification() -> None:
     value, state = _terminal("verify")
     request = dict(state.validated_request)
     request["verification_kind"] = "in-process"
-    changed = terminal.TerminalProjectionState(request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+    changed = terminal.TerminalProjectionState(
+        request,
+        value,
+        state.trusted_run_mode,
+        state.successor_reference,
+        state.successor_context,
+        state.expected_successor,
+        eligible_plan_kinds=state.eligible_plan_kinds,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=changed)
@@ -421,28 +926,59 @@ def test_verify_plan_entry_requires_transport_verification() -> None:
 
 @pytest.mark.parametrize(
     ("plan_kind", "successor_kind", "next_actions"),
-    (("cutover", "apply", ["status", "apply"]), ("rollback", "rollback-terminal-plan", ["status", "rollback"]), ("retirement", "retire-source-clearance", ["status", "retire-source"])),
+    (
+        ("cutover", "apply", ["status", "apply"]),
+        ("rollback", "rollback-terminal-plan", ["status", "rollback"]),
+        ("retirement", "retire-source-clearance", ["status", "retire-source"]),
+    ),
 )
-def test_approve_exactly_binds_plan_kind_successor_and_next_actions(plan_kind: str, successor_kind: str, next_actions: list[str]) -> None:
+def test_approve_exactly_binds_plan_kind_successor_and_next_actions(
+    plan_kind: str, successor_kind: str, next_actions: list[str]
+) -> None:
     value, state = _terminal("approve")
     request = dict(state.validated_request)
     request["plan_kind"] = plan_kind
     value["request_digest"] = _request_digest(request)
     value["next_actions"] = next_actions
     if successor_kind == "apply":
-        facts = {"cutover_plan_digest": request["plan_digest"], "approval_token_digest": value["artifact_digests"]["approval_token_digest"]}
+        facts = {
+            "cutover_plan_digest": request["plan_digest"],
+            "approval_token_digest": value["artifact_digests"]["approval_token_digest"],
+        }
     elif successor_kind == "rollback-terminal-plan":
-        facts = {"rollback_plan_digest": request["plan_digest"], "rollback_token_digest": value["artifact_digests"]["approval_token_digest"]}
+        facts = {
+            "rollback_plan_digest": request["plan_digest"],
+            "rollback_token_digest": value["artifact_digests"]["approval_token_digest"],
+        }
     else:
-        facts = {"retirement_plan_digest": request["plan_digest"], "retirement_token_digest": value["artifact_digests"]["approval_token_digest"]}
+        facts = {
+            "retirement_plan_digest": request["plan_digest"],
+            "retirement_token_digest": value["artifact_digests"]["approval_token_digest"],
+        }
     context, expected = _successor(successor_kind, facts)
-    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "approval_token_ref": "approval-token"}
-    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+    value["trusted_outputs"] = {
+        "successor_context_ref": "output-context",
+        "successor_context_digest": context.digest,
+        "approval_token_ref": "approval-token",
+    }
+    state = terminal.TerminalProjectionState(
+        request,
+        value,
+        successor_reference="output-context",
+        successor_context=context,
+        expected_successor=expected,
+    )
 
     assert terminal.validate_terminal(value, request=state)["next_actions"] == tuple(next_actions)
 
     value["next_actions"] = ["status"]
-    bad_state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+    bad_state = terminal.TerminalProjectionState(
+        request,
+        value,
+        successor_reference="output-context",
+        successor_context=context,
+        expected_successor=expected,
+    )
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=bad_state)
 
@@ -452,7 +988,9 @@ def test_context_run_revision_is_the_resulting_terminal_revision() -> None:
     facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"]}
     context, expected = _successor("render-begin", facts, run_revision=2)
     value["trusted_outputs"]["successor_context_digest"] = context.digest
-    changed = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, "output-context", context, expected)
+    changed = terminal.TerminalProjectionState(
+        state.validated_request, value, state.trusted_run_mode, "output-context", context, expected
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=changed)
@@ -461,10 +999,20 @@ def test_context_run_revision_is_the_resulting_terminal_revision() -> None:
 def test_render_acknowledge_last_page_advances_to_render_complete() -> None:
     value, state = _terminal("plan:render-acknowledge")
     value["counts"]["render_pages"] = 1
-    facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": _digest("render-session")}
+    facts = {
+        "plan_kind": "cutover",
+        "plan_digest": value["artifact_digests"]["plan_digest"],
+        "render_session_digest": _digest("render-session"),
+    }
     context, expected = _successor("render-complete", facts)
     value["trusted_outputs"]["successor_context_digest"] = context.digest
-    state = terminal.TerminalProjectionState(state.validated_request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+    state = terminal.TerminalProjectionState(
+        state.validated_request,
+        value,
+        successor_reference="output-context",
+        successor_context=context,
+        expected_successor=expected,
+    )
 
     assert terminal.validate_terminal(value, request=state)["action"] == "plan:render-acknowledge"
 
@@ -474,7 +1022,13 @@ def test_render_request_plan_digest_must_match_the_terminal_artifact() -> None:
     request = dict(state.validated_request)
     request["plan_digest"] = _digest("foreign-plan")
     value["request_digest"] = _request_digest(request)
-    changed = terminal.TerminalProjectionState(request, value, successor_reference=state.successor_reference, successor_context=state.successor_context, expected_successor=state.expected_successor)
+    changed = terminal.TerminalProjectionState(
+        request,
+        value,
+        successor_reference=state.successor_reference,
+        successor_context=state.successor_context,
+        expected_successor=state.expected_successor,
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=changed)
@@ -493,8 +1047,12 @@ def test_schema_accepts_a_semantic_negative_but_projection_refuses_it() -> None:
 @pytest.mark.parametrize("action", ("start", "abort", "retire-source:clearance"))
 def test_noncontext_rows_never_accept_a_forged_successor_pair(action: str) -> None:
     value, state = _terminal(action)
-    value["trusted_outputs"].update({"successor_context_ref": "ref", "successor_context_digest": _digest("context")})
-    changed = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode)
+    value["trusted_outputs"].update(
+        {"successor_context_ref": "ref", "successor_context_digest": _digest("context")}
+    )
+    changed = terminal.TerminalProjectionState(
+        state.validated_request, value, state.trusted_run_mode
+    )
 
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
         terminal.validate_terminal(value, request=changed)
@@ -548,11 +1106,16 @@ def test_success_envelope_is_exact_json_and_detached_from_custom_mappings() -> N
     assert json.loads(encoded) == envelope
     assert envelope["data"]["terminal"] == replayed["data"]["terminal"]
     assert replayed["data"]["delivery"] == "replayed"
-    assert envelope["data"]["terminal"]["artifact_digests"]["source_fingerprint"] != artifacts["source_fingerprint"]
+    assert (
+        envelope["data"]["terminal"]["artifact_digests"]["source_fingerprint"]
+        != artifacts["source_fingerprint"]
+    )
     assert set(envelope) == {"success", "data"}
     assert set(envelope["data"]) == {"delivery", "terminal"}
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):
-        terminal.success_envelope({"action": "apply", "outcome": "committed", "secret": "owner-control-ref"})
+        terminal.success_envelope(
+            {"action": "apply", "outcome": "committed", "secret": "owner-control-ref"}
+        )
     status, status_state = _terminal("status")
     observed = terminal.validate_terminal(status, request=status_state)
     with pytest.raises(terminal.ConsolidationTerminalUnavailable):

--- a/tests/test_consolidation_terminal.py
+++ b/tests/test_consolidation_terminal.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Iterator, Mapping
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from exomem.governance import consolidation_plan
+from exomem.governance import consolidation_successor as successor
+from exomem.governance import consolidation_terminal as terminal
+
+RUN_ID = "00000000-0000-4000-8000-000000000011"
+OPERATION_ID = "00000000-0000-4000-8000-000000000012"
+OTHER_OPERATION_ID = "00000000-0000-4000-8000-000000000013"
+ISSUED_AT = "2026-08-28T12:00:00.000Z"
+EXPIRES_AT = "2026-08-28T12:15:00.000Z"
+PLAN_ENTRY_EXPIRES_AT = "9999-12-31T23:59:59.999Z"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+ROWS = {
+    "start": (("source_fingerprint", "destination_snapshot_fingerprint"), ("source_objects", "source_bytes", "destination_objects", "destination_bytes"), ("status", "reconcile"), "start"),
+    "status": (("run_state_digest", "journal_digest"), ("completed_effects", "pending_effects", "blocked_effects", "warnings"), ("status",), "active"),
+    "reconcile": (("inventory_digest", "reconciliation_digest", "mapping_set_digest"), ("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "unresolved", "mappings"), ("status", "reconcile", "plan"), "reconcile"),
+    "plan:materialize": (("plan_digest", "control_basis_digest", "plan_successor_automaton_digest"), ("content_actions", "policy_documents", "impact_rows", "render_pages"), ("status", "plan"), "materialize"),
+    "plan:render-begin": (("plan_digest", "render_session_digest"), ("render_pages", "acknowledged_pages"), ("status", "plan"), "render-begin"),
+    "plan:render-page": (("plan_digest", "render_page_digest"), ("page_ordinal", "page_rows", "render_pages"), ("status", "plan"), "render-page"),
+    "plan:render-acknowledge": (("plan_digest", "render_ack_digest"), ("acknowledged_pages", "render_pages"), ("status", "plan"), "render-acknowledge"),
+    "plan:render-complete": (("plan_digest", "rendering_completeness_digest"), ("acknowledged_pages", "render_pages"), ("status", "approve"), "render-complete"),
+    "approve": (("plan_digest", "approval_token_digest"), ("acknowledged_pages", "render_pages"), ("status", "apply"), "approved"),
+    "apply": (("cutover_terminal_digest", "post_cutover_census_digest", "apply_predecessor_digest"), ("policy_documents", "content_batches", "content_actions", "rebuild_kinds", "in_process_probes", "transport_probes"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"), "complete"),
+    "verify": (("verification_basis_digest", "verification_terminal_digest"), ("positive_probes", "negative_probes", "passed_probes", "failed_probes"), ("status", "plan", "apply", "verify", "recover", "rollback", "retire-source"), "complete"),
+    "recover": (("journal_digest", "recovery_terminal_digest"), ("classified_effects", "repaired_effects", "blocked_effects"), ("status", "plan", "apply", "verify", "recover", "abort", "rollback", "retire-source"), "repair-terminal"),
+    "abort": (("prior_census_digest", "abort_terminal_digest"), ("restored_entries", "removed_candidates", "evidence_events"), ("status",), "aborted"),
+    "rollback:nonterminal-contingency": (("cutover_plan_digest", "original_apply_journal_digest", "rollback_contingency_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback"), "rollback-complete"),
+    "rollback:terminal-plan": (("rollback_plan_digest", "target_census_digest", "rollback_terminal_digest"), ("restored_entries", "retained_entries", "reapplied_entries", "discarded_entries", "rebuild_kinds", "verification_probes"), ("status", "plan", "recover", "verify", "rollback"), "rollback-complete"),
+    "retire-source:clearance": (("retirement_plan_digest", "clearance_digest", "retirement_lifecycle_digest", "surviving_copy_ledger_digest"), ("survivor_rows", "verified_survivor_rows"), ("status", "retire-source"), "retirement-pending"),
+    "retire-source:finalize": (("retirement_plan_digest", "retirement_lifecycle_digest", "completion_digest", "finalization_digest", "surviving_copy_ledger_digest"), ("completion_records", "survivor_rows"), ("status", "plan"), "retirement-finalize"),
+}
+
+PLAN_ENTRY_BRANCHES = {
+    "reconcile": ("cutover",),
+    "apply": ("rollback", "retirement"),
+    "verify": ("rollback", "retirement"),
+    "recover": ("rollback",),
+    "rollback:nonterminal-contingency": ("rollback",),
+    "rollback:terminal-plan": ("rollback",),
+    "retire-source:finalize": ("rollback",),
+}
+
+
+def _cutover_options() -> dict[str, object]:
+    return {
+        "expected_reconciliation_digest": _digest("reconciliation"),
+        "expected_policy_bundle_digest": _digest("policy"),
+        "expected_principal_attestation_set_digest": _digest("principal"),
+        "expected_verification_plan_digest": _digest("verification"),
+        "expected_rollback_contingency_digest": _digest("contingency"),
+        "expected_source_retention_digest": _digest("retention"),
+        "expected_control_basis_digest": _digest("control"),
+        "expected_rehearsal_proof_digest": _digest("rehearsal"),
+    }
+
+
+def _request(action: str) -> tuple[dict[str, object], str | None]:
+    base: dict[str, object] = {
+        "schema": "exomem.consolidate-memory-request/v1",
+        "action": action.split(":", 1)[0],
+    }
+    if action == "start":
+        return base | {"operation_id": OPERATION_ID, "expected_run_revision": 0, "run_mode": "real-cutover", "source_artifact_ref": "source", "source_attestation_ref": "attestation"}, "real-cutover"
+    if action == "status":
+        return base | {"run_id": RUN_ID, "expected_run_revision": 1, "detail": "summary"}, None
+    mutation = {"operation_id": OPERATION_ID, "run_id": RUN_ID, "expected_run_revision": 0}
+    context = {"successor_context_ref": "input-context", "successor_context_digest": _digest("input-context")}
+    if action == "reconcile":
+        return base | mutation | {"expected_inventory_digest": _digest("inventory"), "decision_set_ref": "decisions", "decision_set_digest": _digest("decisions")}, None
+    if action.startswith("plan:"):
+        request = base | mutation | context | {"plan_kind": "cutover"}
+        variant = action.removeprefix("plan:")
+        if variant == "materialize":
+            return request | {"operation": "materialize", "cutover_options": _cutover_options()}, "real-cutover"
+        step = variant.removeprefix("render-")
+        request |= {"operation": "render", "render_step": step, "plan_digest": _digest("plan_digest")}
+        if step in {"page", "acknowledge", "complete"}:
+            request["render_session_ref"] = "render-session"
+        if step in {"page", "acknowledge"}:
+            request["page_ordinal"] = 0
+        if step == "acknowledge":
+            request["acknowledged_page_digest"] = _digest("render_page_digest")
+        return request, None
+    if action == "approve":
+        return base | mutation | context | {"plan_kind": "cutover", "plan_digest": _digest("plan_digest"), "rendering_completeness_ref": "completeness", "rendering_completeness_digest": _digest("rendering_completeness_digest")}, None
+    if action == "apply":
+        return base | mutation | context | {"cutover_plan_digest": _digest("plan_digest"), "approval_token_ref": "token", "approval_token_digest": _digest("approval_token_digest")}, "real-cutover"
+    if action == "verify":
+        return base | mutation | {"verification_kind": "transport", "expected_plan_digest": _digest("plan_digest"), "expected_verification_basis_digest": _digest("verification-basis")}, "real-cutover"
+    if action == "recover":
+        return base | mutation | {"expected_journal_digest": _digest("journal")}, None
+    if action == "abort":
+        return base | mutation | {"expected_journal_digest": _digest("journal"), "reason_code": "owner-cancelled"}, None
+    if action.startswith("rollback:"):
+        mode = action.removeprefix("rollback:")
+        request = base | mutation | context | {"rollback_mode": mode}
+        if mode == "terminal-plan":
+            request |= {"rollback_plan_digest": _digest("rollback_plan_digest"), "rollback_token_ref": "rollback-token", "rollback_token_digest": _digest("rollback-token")}
+        return request, None
+    if action == "retire-source:clearance":
+        return base | mutation | context | {"phase": "clearance", "retirement_plan_digest": _digest("retirement_plan_digest"), "retirement_token_ref": "retirement-token", "retirement_token_digest": _digest("retirement-token")}, None
+    if action == "retire-source:finalize":
+        return base | mutation | {"phase": "finalize", "retirement_plan_digest": _digest("retirement_plan_digest"), "retirement_lifecycle_ref": "lifecycle", "completion_attestation_ref": "completion", "completion_attestation_digest": _digest("completion")}, None
+    raise AssertionError(action)
+
+
+def _request_digest(request: Mapping[str, object]) -> str:
+    return hashlib.sha256(consolidation_plan.canonical_closed_jcs(request)).hexdigest()
+
+
+def _successor(
+    kind: str,
+    facts: dict[str, object],
+    *,
+    run_revision: int = 1,
+) -> tuple[successor.CanonicalSuccessorContext, successor.ExpectedSuccessorContext]:
+    expected_successors = {
+        "plan-materialize": ("plan", "materialize"),
+        "render-begin": ("plan", "render-begin"),
+        "render-page": ("plan", "render-page"),
+        "render-acknowledge": ("plan", "render-acknowledge"),
+        "render-complete": ("plan", "render-complete"),
+        "approve": ("approve", "plan-kind"),
+        "apply": ("apply", "cutover"),
+        "rollback-terminal-plan": ("rollback", "terminal-plan"),
+        "retire-source-clearance": ("retire-source", "clearance"),
+        "rollback-nonterminal-contingency": ("rollback", "nonterminal-contingency"),
+    }
+    action, variant = expected_successors[kind]
+    if kind == "approve":
+        variant = str(facts["plan_kind"])
+    basis = str(facts.get("plan_input_basis_digest", facts.get("original_apply_journal_digest", _digest("basis"))))
+    expiry = PLAN_ENTRY_EXPIRES_AT if kind == "plan-materialize" else EXPIRES_AT
+    owner = successor.SuccessorOwnerIdentity("vault", "installation", 1, _digest("fence"), _digest("principal"))
+    owner_digest = successor.build_owner_binding(owner).digest
+    seed = successor.build_seed(successor.SuccessorSeedInput(kind, RUN_ID, run_revision, _digest("destination"), owner_digest, basis, action, variant, ISSUED_AT, expiry, "nonce", facts))
+    context = successor.derive_context(seed, predecessor_event_id=f"{_digest('event')}:committed", predecessor_payload_digest=_digest("payload"))
+    expected = successor.ExpectedSuccessorContext(kind, RUN_ID, run_revision, _digest("destination"), owner_digest, basis, context.preimage["predecessor_event_id"], _digest("payload"), action, variant, facts, ISSUED_AT)
+    return context, expected
+
+
+def _terminal(action: str) -> tuple[dict[str, object], terminal.TerminalProjectionState]:
+    digests, counts, next_actions, phase = ROWS[action]
+    request, mode = _request(action)
+    value: dict[str, object] = {
+        "schema": terminal.TERMINAL_SCHEMA_NAME,
+        "action": action,
+        "outcome": "observed" if action == "status" else "committed",
+        "run_id": RUN_ID,
+        "run_revision": 1,
+        "phase": phase,
+        "artifact_digests": {key: _digest(key) for key in digests},
+        "counts": {key: 0 for key in counts},
+        "next_actions": list(next_actions),
+        "trusted_outputs": {},
+    }
+    if action != "status":
+        value.update({"operation_id": OPERATION_ID, "request_digest": _request_digest(request), "prior_state_digest": _digest("prior"), "final_state_digest": _digest("final")})
+
+    context = None
+    expected = None
+    eligible = PLAN_ENTRY_BRANCHES.get(action)
+    facts: dict[str, object] | None = None
+    if eligible is not None:
+        facts = {"eligible_plan_kinds": list(eligible), "plan_input_basis_digest": _digest(f"{action}-basis")}
+        context, expected = _successor("plan-materialize", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "eligible_plan_kinds": list(eligible)}
+    elif action == "plan:materialize":
+        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"]}
+        context, expected = _successor("render-begin", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    elif action == "plan:render-begin":
+        value["counts"].update({"render_pages": 2, "acknowledged_pages": 0})
+        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": value["artifact_digests"]["render_session_digest"], "page_ordinal": 0}
+        context, expected = _successor("render-page", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "render_session_ref": "render-session"}
+    elif action == "plan:render-page":
+        value["counts"].update({"page_ordinal": 0, "render_pages": 2})
+        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": _digest("render-session"), "page_ordinal": 0, "page_digest": value["artifact_digests"]["render_page_digest"]}
+        context, expected = _successor("render-acknowledge", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "render_session_ref": "render-session", "render_delivery_ref": "render-delivery"}
+    elif action == "plan:render-acknowledge":
+        value["counts"].update({"acknowledged_pages": 1, "render_pages": 2})
+        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": _digest("render-session"), "page_ordinal": 1}
+        context, expected = _successor("render-page", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "render_session_ref": "render-session"}
+    elif action == "plan:render-complete":
+        value["counts"].update({"acknowledged_pages": 2, "render_pages": 2})
+        facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "rendering_completeness_digest": value["artifact_digests"]["rendering_completeness_digest"]}
+        context, expected = _successor("approve", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "rendering_completeness_ref": "completeness"}
+    elif action == "approve":
+        value["counts"].update({"acknowledged_pages": 2, "render_pages": 2})
+        facts = {"cutover_plan_digest": value["artifact_digests"]["plan_digest"], "approval_token_digest": value["artifact_digests"]["approval_token_digest"]}
+        context, expected = _successor("apply", facts)
+        value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "approval_token_ref": "approval-token"}
+    elif action == "retire-source:clearance":
+        value["trusted_outputs"] = {"retirement_clearance_ref": "clearance", "retirement_lifecycle_ref": "lifecycle"}
+
+    eligibility = {}
+    if "eligible_plan_kinds" in terminal.TerminalProjectionState.__dataclass_fields__:
+        eligibility["eligible_plan_kinds"] = eligible
+    state = terminal.TerminalProjectionState(
+        request,
+        copy.deepcopy(value),
+        mode,
+        "output-context" if context is not None else None,
+        context,
+        expected,
+        **eligibility,
+    )
+    return value, state
+
+
+@pytest.mark.parametrize("action", tuple(ROWS))
+def test_all_closed_rows_bind_the_exact_coordinator_projection(action: str) -> None:
+    value, state = _terminal(action)
+    checked = terminal.validate_terminal(value, request=state)
+
+    assert checked["action"] == action
+    assert tuple(checked["next_actions"]) == tuple(value["next_actions"])
+    assert not list(Draft202012Validator(terminal.terminal_schema()).iter_errors(value))
+
+
+@pytest.mark.parametrize("action", tuple(action for action in ROWS if action != "status"))
+@pytest.mark.parametrize("field", ("operation_id", "request_digest", "run_revision"))
+def test_every_mutation_binds_identity_request_and_resulting_revision(action: str, field: str) -> None:
+    value, state = _terminal(action)
+    value[field] = OTHER_OPERATION_ID if field == "operation_id" else _digest("foreign-request") if field == "request_digest" else 2
+    state = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=state)
+
+
+def test_status_binds_an_optional_expected_revision() -> None:
+    value, state = _terminal("status")
+    value["run_revision"] = 2
+    state = terminal.TerminalProjectionState(state.validated_request, value)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=state)
+
+
+@pytest.mark.parametrize(
+    ("action", "bad_phase"),
+    (("reconcile", "complete"), ("apply", "seal-intent"), ("verify", "probe"), ("recover", "classify"), ("rollback:nonterminal-contingency", "rolling-back"), ("rollback:terminal-plan", "rolling-back"), ("retire-source:finalize", "finalizing")),
+)
+def test_plan_entry_contexts_only_appear_at_exact_product_terminal_phases(action: str, bad_phase: str) -> None:
+    value, state = _terminal(action)
+    value["phase"] = bad_phase
+    state = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=state)
+
+
+def test_apply_complete_rejects_a_valid_but_wrong_render_successor() -> None:
+    value, state = _terminal("apply")
+    context, expected = _successor("render-begin", {"plan_kind": "cutover", "plan_digest": _digest("plan_digest")})
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    state = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=state)
+
+
+def _contingency() -> tuple[successor.CanonicalSuccessorContext, successor.ExpectedSuccessorContext]:
+    facts = {
+        "original_apply_operation_id": OPERATION_ID,
+        "original_apply_journal_digest": _digest("apply-journal"),
+        "cutover_plan_digest": _digest("plan_digest"),
+        "rollback_contingency_digest": _digest("contingency"),
+        "publication_state_digest": _digest("publication"),
+        "contingency_authority_ref": "contingency-authority",
+        "contingency_authority_digest": _digest("authority"),
+        "recovery_window_deadline": "2026-08-28T12:30:00.000Z",
+    }
+    return _successor("rollback-nonterminal-contingency", facts)
+
+
+def test_apply_before_complete_only_accepts_an_explicitly_eligible_contingency() -> None:
+    value, state = _terminal("apply")
+    value["phase"] = "seal-intent"
+    context, expected = _contingency()
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    value["next_actions"] = [action for action in value["next_actions"] if action != "plan"]
+
+    ineligible = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected)
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=ineligible)
+
+    eligible = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected, nonterminal_contingency_eligible=True)
+    assert terminal.validate_terminal(value, request=eligible)["phase"] == "seal-intent"
+
+
+def test_contingency_context_never_advertises_plan() -> None:
+    value, state = _terminal("apply")
+    value["phase"] = "seal-intent"
+    context, expected = _contingency()
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    state = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected, nonterminal_contingency_eligible=True)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=state)
+
+
+def test_status_context_requires_owner_detail_and_plan_requires_plan_entry_context() -> None:
+    value, state = _terminal("status")
+    facts = {"eligible_plan_kinds": ["rollback"], "plan_input_basis_digest": _digest("status-basis")}
+    context, expected = _successor("plan-materialize", facts)
+    value["phase"] = "complete"
+    value["next_actions"] = ["status", "plan"]
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "eligible_plan_kinds": ["rollback"]}
+    summary = terminal.TerminalProjectionState(state.validated_request, value, "real-cutover", "output-context", context, expected, eligible_plan_kinds=("rollback",))
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=summary)
+
+    owner_request = dict(state.validated_request) | {"detail": "owner-detail"}
+    owner_state = terminal.TerminalProjectionState(owner_request, value, "real-cutover", "output-context", context, expected, eligible_plan_kinds=("rollback",))
+    assert terminal.validate_terminal(value, request=owner_state)["phase"] == "complete"
+
+    value["trusted_outputs"] = {}
+    no_context = terminal.TerminalProjectionState(owner_request, value, "real-cutover")
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=no_context)
+
+
+def test_owner_detail_status_may_return_another_current_context_with_a_cursor() -> None:
+    value, state = _terminal("status")
+    facts = {"cutover_plan_digest": _digest("plan_digest"), "approval_token_digest": _digest("approval")}
+    context, expected = _successor("apply", facts)
+    request = dict(state.validated_request) | {"detail": "owner-detail"}
+    value["next_actions"] = ["status", "apply"]
+    value["trusted_outputs"] = {"next_cursor": "cursor", "successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+
+    checked = terminal.validate_terminal(value, request=state)
+
+    assert checked["trusted_outputs"]["next_cursor"] == "cursor"
+
+
+@pytest.mark.parametrize(
+    ("kind", "facts", "next_action", "contingency"),
+    (
+        ("render-begin", {"plan_kind": "cutover", "plan_digest": _digest("plan")}, "plan", False),
+        ("render-page", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "render_session_digest": _digest("session"), "page_ordinal": 0}, "plan", False),
+        ("render-acknowledge", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "render_session_digest": _digest("session"), "page_ordinal": 0, "page_digest": _digest("page")}, "plan", False),
+        ("render-complete", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "render_session_digest": _digest("session")}, "plan", False),
+        ("approve", {"plan_kind": "cutover", "plan_digest": _digest("plan"), "rendering_completeness_digest": _digest("completeness")}, "approve", False),
+        ("apply", {"cutover_plan_digest": _digest("plan"), "approval_token_digest": _digest("approval")}, "apply", False),
+        ("rollback-terminal-plan", {"rollback_plan_digest": _digest("plan"), "rollback_token_digest": _digest("rollback-token")}, "rollback", False),
+        ("rollback-nonterminal-contingency", {"original_apply_operation_id": OPERATION_ID, "original_apply_journal_digest": _digest("journal"), "cutover_plan_digest": _digest("plan"), "rollback_contingency_digest": _digest("contingency"), "publication_state_digest": _digest("publication"), "contingency_authority_ref": "authority", "contingency_authority_digest": _digest("authority"), "recovery_window_deadline": "2026-08-28T12:30:00.000Z"}, "rollback", True),
+        ("retire-source-clearance", {"retirement_plan_digest": _digest("plan"), "retirement_token_digest": _digest("retirement-token")}, "retire-source", False),
+    ),
+)
+def test_owner_detail_status_reexposes_each_current_successor_context(kind: str, facts: dict[str, object], next_action: str, contingency: bool) -> None:
+    value, state = _terminal("status")
+    context, expected = _successor(kind, facts)
+    request = dict(state.validated_request) | {"detail": "owner-detail"}
+    value["next_actions"] = ["status", next_action]
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected, nonterminal_contingency_eligible=contingency)
+
+    assert terminal.validate_terminal(value, request=state)["trusted_outputs"]["successor_context_digest"] == context.digest
+
+
+def test_owner_detail_status_rejects_plan_for_an_unrelated_current_context() -> None:
+    value, state = _terminal("status")
+    facts = {"cutover_plan_digest": _digest("plan"), "approval_token_digest": _digest("approval")}
+    context, expected = _successor("apply", facts)
+    request = dict(state.validated_request) | {"detail": "owner-detail"}
+    value["next_actions"] = ["status", "plan", "apply"]
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest}
+    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=state)
+
+
+def test_terminal_eligible_kinds_match_canonical_context_and_process_state() -> None:
+    value, state = _terminal("apply")
+    value["trusted_outputs"]["eligible_plan_kinds"] = ["rollback"]
+    changed = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=("rollback",))
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=changed)
+
+
+def test_retirement_plan_entry_requires_real_cutover() -> None:
+    value, state = _terminal("apply")
+    changed = terminal.TerminalProjectionState(state.validated_request, value, "cloned-rehearsal", state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=changed)
+
+
+def test_verify_plan_entry_requires_transport_verification() -> None:
+    value, state = _terminal("verify")
+    request = dict(state.validated_request)
+    request["verification_kind"] = "in-process"
+    changed = terminal.TerminalProjectionState(request, value, state.trusted_run_mode, state.successor_reference, state.successor_context, state.expected_successor, eligible_plan_kinds=state.eligible_plan_kinds)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=changed)
+
+
+@pytest.mark.parametrize(
+    ("plan_kind", "successor_kind", "next_actions"),
+    (("cutover", "apply", ["status", "apply"]), ("rollback", "rollback-terminal-plan", ["status", "rollback"]), ("retirement", "retire-source-clearance", ["status", "retire-source"])),
+)
+def test_approve_exactly_binds_plan_kind_successor_and_next_actions(plan_kind: str, successor_kind: str, next_actions: list[str]) -> None:
+    value, state = _terminal("approve")
+    request = dict(state.validated_request)
+    request["plan_kind"] = plan_kind
+    value["request_digest"] = _request_digest(request)
+    value["next_actions"] = next_actions
+    if successor_kind == "apply":
+        facts = {"cutover_plan_digest": request["plan_digest"], "approval_token_digest": value["artifact_digests"]["approval_token_digest"]}
+    elif successor_kind == "rollback-terminal-plan":
+        facts = {"rollback_plan_digest": request["plan_digest"], "rollback_token_digest": value["artifact_digests"]["approval_token_digest"]}
+    else:
+        facts = {"retirement_plan_digest": request["plan_digest"], "retirement_token_digest": value["artifact_digests"]["approval_token_digest"]}
+    context, expected = _successor(successor_kind, facts)
+    value["trusted_outputs"] = {"successor_context_ref": "output-context", "successor_context_digest": context.digest, "approval_token_ref": "approval-token"}
+    state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+
+    assert terminal.validate_terminal(value, request=state)["next_actions"] == tuple(next_actions)
+
+    value["next_actions"] = ["status"]
+    bad_state = terminal.TerminalProjectionState(request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=bad_state)
+
+
+def test_context_run_revision_is_the_resulting_terminal_revision() -> None:
+    value, state = _terminal("plan:materialize")
+    facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"]}
+    context, expected = _successor("render-begin", facts, run_revision=2)
+    value["trusted_outputs"]["successor_context_digest"] = context.digest
+    changed = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode, "output-context", context, expected)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=changed)
+
+
+def test_render_acknowledge_last_page_advances_to_render_complete() -> None:
+    value, state = _terminal("plan:render-acknowledge")
+    value["counts"]["render_pages"] = 1
+    facts = {"plan_kind": "cutover", "plan_digest": value["artifact_digests"]["plan_digest"], "render_session_digest": _digest("render-session")}
+    context, expected = _successor("render-complete", facts)
+    value["trusted_outputs"]["successor_context_digest"] = context.digest
+    state = terminal.TerminalProjectionState(state.validated_request, value, successor_reference="output-context", successor_context=context, expected_successor=expected)
+
+    assert terminal.validate_terminal(value, request=state)["action"] == "plan:render-acknowledge"
+
+
+def test_render_request_plan_digest_must_match_the_terminal_artifact() -> None:
+    value, state = _terminal("plan:render-begin")
+    request = dict(state.validated_request)
+    request["plan_digest"] = _digest("foreign-plan")
+    value["request_digest"] = _request_digest(request)
+    changed = terminal.TerminalProjectionState(request, value, successor_reference=state.successor_reference, successor_context=state.successor_context, expected_successor=state.expected_successor)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=changed)
+
+
+def test_schema_accepts_a_semantic_negative_but_projection_refuses_it() -> None:
+    value, state = _terminal("start")
+    changed = copy.deepcopy(value)
+    changed["request_digest"] = _digest("foreign")
+
+    assert not list(Draft202012Validator(terminal.terminal_schema()).iter_errors(changed))
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(changed, request=state)
+
+
+@pytest.mark.parametrize("action", ("start", "abort", "retire-source:clearance"))
+def test_noncontext_rows_never_accept_a_forged_successor_pair(action: str) -> None:
+    value, state = _terminal(action)
+    value["trusted_outputs"].update({"successor_context_ref": "ref", "successor_context_digest": _digest("context")})
+    changed = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.validate_terminal(value, request=changed)
+
+
+class _UserMapping(Mapping[str, object]):
+    def __init__(self, value: Mapping[str, object]) -> None:
+        self._value = dict(value)
+
+    def __getitem__(self, key: str) -> object:
+        return self._value[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._value)
+
+    def __len__(self) -> int:
+        return len(self._value)
+
+
+class _ForgedTerminal(terminal._ValidatedTerminal):
+    def __getitem__(self, key: str) -> object:
+        return {"action": "start", "secret": "owner-control-ref"}[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(("action", "secret"))
+
+    def __len__(self) -> int:
+        return 2
+
+
+def test_success_envelope_rejects_an_unsealed_validated_terminal_subclass() -> None:
+    forged = object.__new__(_ForgedTerminal)
+
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.success_envelope(forged)
+
+
+def test_success_envelope_is_exact_json_and_detached_from_custom_mappings() -> None:
+    value, state = _terminal("start")
+    artifacts = _UserMapping(value["artifact_digests"])
+    value["artifact_digests"] = artifacts
+    value["counts"] = _UserMapping(value["counts"])
+    state = terminal.TerminalProjectionState(state.validated_request, value, state.trusted_run_mode)
+    checked = terminal.validate_terminal(value, request=state)
+    artifacts._value["source_fingerprint"] = _digest("changed-after-validation")
+
+    envelope = terminal.success_envelope(checked)
+    replayed = terminal.success_envelope(checked, delivery="replayed")
+    encoded = json.dumps(envelope, sort_keys=True)
+
+    assert json.loads(encoded) == envelope
+    assert envelope["data"]["terminal"] == replayed["data"]["terminal"]
+    assert replayed["data"]["delivery"] == "replayed"
+    assert envelope["data"]["terminal"]["artifact_digests"]["source_fingerprint"] != artifacts["source_fingerprint"]
+    assert set(envelope) == {"success", "data"}
+    assert set(envelope["data"]) == {"delivery", "terminal"}
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.success_envelope({"action": "apply", "outcome": "committed", "secret": "owner-control-ref"})
+    status, status_state = _terminal("status")
+    observed = terminal.validate_terminal(status, request=status_state)
+    with pytest.raises(terminal.ConsolidationTerminalUnavailable):
+        terminal.success_envelope(observed, delivery="replayed")


### PR DESCRIPTION
Adds the shared admission boundary for consolidation commands. The guard rechecks the issued owner session and destination cell binding, then validates the complete request before coercion or dispatch. Ambiguous JSON, invalid UTF-8, and invalid numeric types are refused.

The response validator binds all 17 terminal branches to the complete request, resulting state and verified successor context. It supports recovery of stored review continuations and emits detached JSON responses from validated immutable terminals.

Stacks on #1024. Lifecycle registration, execution, Hosted entitlement, and CLI JSON argument decoding remain in the active `add-governed-vault-consolidation` change.

Validation: independent security review and final verification approved. The lean corpus passed 17,216 tests with 272 declared optional/platform skips; the coverage audit found no missing cases or unresolved failures after isolated environment reruns. Performance gates, installed-wheel product tests, wheel/sdist builds, mypy, strict Ruff, generated capabilities, public-artifact checks and all 181 OpenSpec validations passed.
