### PR TITLE
feat(provisioner): bind target recovery to live stopped-cell proofs

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -46,6 +46,7 @@ from .provider_identity import (
     chunk_hcloud_identity_envelope,
     decode_hcloud_identity_envelope,
 )
+from .repository import ClaimConflict, StaleFence
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,6 +102,17 @@ def _require_cell_identity(
                 "Kubernetes cell identity annotations differ",
                 reason=ConflictReason.KUBERNETES_CELL_IDENTITY_ANNOTATIONS_DIFFER,
             )
+
+
+def _governance_unavailable() -> MetadataConflict:
+    return MetadataConflict(
+        "governance maintenance authority unavailable",
+        reason=ConflictReason.GOVERNANCE_MIGRATION_JOB_UNAVAILABLE,
+    )
+
+
+def _governance_retryable() -> DriverRetryable:
+    return DriverRetryable("governance maintenance authority is temporarily unavailable")
 
 
 class KubernetesVolumeAdapter:
@@ -507,6 +519,81 @@ class KubernetesCellAdapter:
                 ) from error
         volume_name = getattr(pvc.spec, "volume_name", None)
         return isinstance(volume_name, str) and bool(volume_name)
+
+    async def authenticated_volume_uid(self, metadata: OpaqueProviderMetadata) -> str:
+        """Return only a freshly authenticated fixed PVC UID for recovery guards."""
+        namespace = metadata.resource_name
+        name = namespace + "-data"
+        try:
+            pvc = await asyncio.to_thread(
+                self._core.read_namespaced_persistent_volume_claim,
+                name,
+                namespace,
+            )
+            identity = pvc.metadata
+            annotations = getattr(identity, "annotations", None)
+            if not isinstance(annotations, dict):
+                raise _governance_unavailable()
+            _require_annotations(annotations, metadata)
+            uid = getattr(identity, "uid", None)
+            volume_name = getattr(pvc.spec, "volume_name", None)
+            if (
+                getattr(identity, "name", None) != name
+                or getattr(identity, "namespace", None) != namespace
+                or getattr(identity, "deletion_timestamp", None) is not None
+                or not isinstance(uid, str)
+                or not uid
+                or getattr(pvc.status, "phase", None) != "Bound"
+                or not isinstance(volume_name, str)
+                or not volume_name
+            ):
+                raise _governance_unavailable()
+            if self._identity_verifier is None:
+                raise MetadataConflict(
+                    "PVC provider recovery identity did not authenticate",
+                    reason=ConflictReason.PVC_RECOVERY_IDENTITY_UNAUTHENTICATED,
+                )
+            try:
+                self._identity_verifier.authenticate(
+                    str(annotations.get("exomem.io/recovery-envelope", "")),
+                    provider="kubernetes",
+                    provider_reference=ProviderReference.kubernetes(
+                        provider="kubernetes",
+                        api_version="v1",
+                        kind="PersistentVolumeClaim",
+                        namespace=namespace,
+                        name=name,
+                    ),
+                    tenant_id=metadata.tenant_id,
+                    cell_id=metadata.subject_id,
+                    operation_id=metadata.operation_id,
+                    fence_generation=metadata.fence_generation,
+                )
+            except ProviderIdentityConflict as error:
+                raise MetadataConflict(
+                    "PVC provider recovery identity did not authenticate",
+                    reason=ConflictReason.PVC_RECOVERY_IDENTITY_UNAUTHENTICATED,
+                ) from error
+            return uid
+        except (ClaimConflict, StaleFence, MetadataConflict, DriverRetryable):
+            raise
+        except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+            if _retryable_kubernetes_error(error):
+                raise _governance_retryable() from None
+            raise _governance_unavailable() from None
+
+    async def verify_governance_stopped(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        pvc_uid: str,
+    ) -> None:
+        """Reprove fixed-volume identity immediately before physical stop proof."""
+        if await self.authenticated_volume_uid(metadata) != pvc_uid:
+            raise _governance_unavailable()
+        from .governance_stopped_cell import verify_stopped_cell
+
+        await verify_stopped_cell(self._core, self._apps, metadata=metadata, pvc_uid=pvc_uid)
 
     def __repr__(self) -> str:
         return "KubernetesCellAdapter()"
@@ -1393,6 +1480,52 @@ class KubernetesMaintenanceLeaseAdapter:
             body,
         )
         return True
+
+    async def assert_owned(self, metadata: OpaqueProviderMetadata, operation_id: str) -> None:
+        """Read and prove current maintenance ownership without renewing the Lease."""
+        name = self._name(metadata)
+        namespace = metadata.resource_name
+        try:
+            lease = await asyncio.to_thread(
+                self._coordination.read_namespaced_lease, name, namespace
+            )
+            identity = lease.metadata
+            spec = lease.spec
+            _require_annotations(getattr(identity, "annotations", None), metadata)
+            uid = getattr(identity, "uid", None)
+            resource_version = getattr(identity, "resource_version", None)
+            renew = getattr(spec, "renew_time", None)
+            duration = getattr(spec, "lease_duration_seconds", None)
+            now = self._now()
+            if (
+                not isinstance(operation_id, str)
+                or not operation_id
+                or getattr(identity, "name", None) != name
+                or getattr(identity, "namespace", None) != namespace
+                or getattr(identity, "deletion_timestamp", None) is not None
+                or not isinstance(uid, str)
+                or not uid
+                or not isinstance(resource_version, str)
+                or not resource_version
+                or getattr(spec, "holder_identity", None) != operation_id
+                or type(duration) is not int
+                or duration <= 0
+                or not isinstance(renew, datetime)
+                or renew.tzinfo is None
+                or renew.utcoffset() is None
+                or not isinstance(now, datetime)
+                or now.tzinfo is None
+                or now.utcoffset() is None
+                or renew > now
+                or renew + timedelta(seconds=duration) <= now
+            ):
+                raise _governance_unavailable()
+        except (ClaimConflict, StaleFence, MetadataConflict, DriverRetryable):
+            raise
+        except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+            if _retryable_kubernetes_error(error):
+                raise _governance_retryable() from None
+            raise _governance_unavailable() from None
 
     async def release(self, metadata: OpaqueProviderMetadata, operation_id: str) -> None:
         name = self._name(metadata)
@@ -2325,9 +2458,7 @@ class HelmCliAdapter:
                 "--version",
                 self._chart_version,
                 "--labels",
-                ",".join(
-                    f"{key}={value}" for key, value in sorted(metadata.hcloud_labels.items())
-                ),
+                ",".join(f"{key}={value}" for key, value in sorted(metadata.hcloud_labels.items())),
                 "--namespace",
                 metadata.resource_name,
                 "--create-namespace=false",

--- a/infra/provisioner/src/exomem_provisioner/governance_migration_coordinator.py
+++ b/infra/provisioner/src/exomem_provisioner/governance_migration_coordinator.py
@@ -40,6 +40,7 @@ from .governance_migration_membership import (
     complete_governance_migration_membership,
     repair_governance_schema_claim,
 )
+from .governance_target_recovery import recover_expired_serving_bundle
 from .lifecycle import MetadataConflict, OpaqueProviderMetadata
 from .repository import ClaimConflict, StaleFence
 from .wire_protocol import WIRE_PROTOCOL_V2
@@ -61,6 +62,167 @@ class HostedGovernanceMigrationCoordinator:
         now: Callable[[], float] = time.time,
     ) -> None:
         self._cell, self._jobs, self._now = cell, jobs, now
+
+    async def recover_target(
+        self,
+        *,
+        context: EffectContext,
+        metadata: OpaqueProviderMetadata,
+        owner: OpaqueProviderMetadata,
+        pvc_uid: str,
+        runtime_image: str,
+        custody_recovery_envelope: str,
+        software_version: str,
+    ) -> DriverPending | None:
+        """Reconcile an exact stopped-target commitment; never start or admit.
+
+        The live caller composes claim authority with fresh maintenance, closed
+        routes and stopped-volume proof. ``None`` only means no expiry recovery
+        is needed; it is not a readiness or target-start authorization.
+        """
+        await context.assert_effect_authority()
+        if (
+            context.wire_protocol != WIRE_PROTOCOL_V2
+            or (
+                context.tenant_id,
+                context.cell_id,
+                context.provider_operation_id,
+                context.fence_generation,
+            )
+            != (
+                metadata.tenant_id,
+                metadata.subject_id,
+                metadata.operation_id,
+                metadata.fence_generation,
+            )
+            or (owner.tenant_id, owner.subject_id) != (metadata.tenant_id, metadata.subject_id)
+            or owner.fence_generation > metadata.fence_generation
+        ):
+            raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+        checkpoint = MigrationCheckpoint.decode(context.checkpoint)
+        if checkpoint.binding != migration_binding(
+            context, pvc_uid=pvc_uid, runtime_image=runtime_image
+        ) or checkpoint.phase not in {
+            "complete",
+            "confirmed",
+            "recover-complete",
+            "recover-confirmed",
+        }:
+            raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+        try:
+            files = await self._cell.read_authorization_session_bundle(owner)
+            if files is None:
+                raise _refuse()
+            current = int(self._now())
+            identity = {
+                "expected_cell_id": metadata.subject_id,
+                "expected_logical_vault_id": metadata.tenant_id,
+                "expected_replica_id": metadata.resource_name + "-0",
+                "expected_software_version": software_version,
+                "expected_recovery_envelope": custody_recovery_envelope,
+            }
+            source = inspect_hosted_authorization_bundle(
+                files,
+                **identity,
+                expected_schema_version=4,
+                now=current,
+                _require_fresh=False,
+            )
+            control = json.loads(source.control)
+            if source.governance_enrolled is not True or control["issued_at"] > current:
+                raise _refuse()
+            publication = source
+
+            async def target_authority() -> None:
+                await context.assert_effect_authority()
+                # Route/PVC/lease proofs involve I/O. Authenticate at the time
+                # they finish, not at the earlier predecessor observation.
+                effect_time = int(self._now())
+                authenticated = inspect_hosted_authorization_bundle(
+                    publication.files,
+                    **identity,
+                    expected_schema_version=4,
+                    now=effect_time,
+                    _require_fresh=False,
+                )
+                if json.loads(authenticated.control)["issued_at"] > effect_time:
+                    raise _refuse()
+
+            recovering = checkpoint.recovery_revision is not None
+            if not recovering and (
+                source.replica_state == "DRAINING" or source.expires_at > current
+            ):
+                await target_authority()
+                return None
+            if recovering and source.revision == checkpoint.recovery_revision:
+                if (
+                    source.replica_state != "DRAINING"
+                    or not source.no_in_flight
+                    or not source.issuance_stopped
+                    or control["issued_at"] != checkpoint.recovery_issued_at
+                ):
+                    raise _refuse()
+            else:
+                successor = recover_expired_serving_bundle(
+                    files,
+                    **identity,
+                    now=current,
+                    successor_issued_at=checkpoint.recovery_issued_at if recovering else current,
+                )
+                publication = successor
+                if not recovering:
+                    # A new window must outlast the bounded five-minute Helm
+                    # start. Retained commitments are reconciled even after
+                    # their window elapses, never replaced with a new revision.
+                    await target_authority()
+                    if successor.expires_at - int(self._now()) <= 300:
+                        raise _refuse()
+                    return DriverPending(
+                        replace(
+                            checkpoint,
+                            phase="recover-" + checkpoint.phase,
+                            recovery_revision=successor.revision,
+                            recovery_issued_at=current,
+                        ).encode(),
+                        1,
+                    )
+                if successor.revision != checkpoint.recovery_revision:
+                    raise _refuse()
+                await self._cell.write_authorization_session_bundle(
+                    owner,
+                    successor.files,
+                    recovery_envelope=custody_recovery_envelope,
+                    membership_epoch=successor.epoch,
+                    membership_digest=successor.membership_digest,
+                    revision=successor.revision,
+                    expected_revision=source.revision,
+                    effect_guard=target_authority,
+                )
+            await target_authority()
+            return DriverPending(
+                replace(
+                    checkpoint,
+                    phase="complete",
+                    recovery_revision=None,
+                    recovery_issued_at=None,
+                ).encode(),
+                1,
+            )
+        except (DriverRetryable, LostAcknowledgement):
+            return DriverPending(context.checkpoint, 30)
+        except MetadataConflict as error:
+            if error.reason == ConflictReason.AUTHORIZATION_SESSION_BUNDLE_PREDECESSOR_DIFFERS:
+                # A delayed identical CAS can win between our observation and
+                # the adapter's predecessor read. Reread under the same durable
+                # commitment before deciding whether the successor is foreign.
+                return DriverPending(context.checkpoint, 30)
+            raise
+        except (ClaimConflict, StaleFence, DriverTerminal):
+            raise
+        except Exception as error:  # noqa: BLE001 - provider errors remain content-free
+            if _retryable_kubernetes_error(error):
+                return DriverPending(context.checkpoint, 30)
+            raise _refuse() from None
 
     async def advance(
         self,

--- a/infra/provisioner/src/exomem_provisioner/governance_stopped_cell.py
+++ b/infra/provisioner/src/exomem_provisioner/governance_stopped_cell.py
@@ -1,0 +1,196 @@
+"""Read-only physical stopped-cell proof for migration-only target recovery."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from kubernetes.client import ApiClient
+
+from .adapters import _retryable_kubernetes_error
+from .conflict_reason import ConflictReason
+from .driver import DriverRetryable
+from .lifecycle import MetadataConflict, OpaqueProviderMetadata
+from .repository import ClaimConflict, StaleFence
+
+
+def _refuse() -> MetadataConflict:
+    return MetadataConflict(
+        "governance migration Job is unavailable",
+        reason=ConflictReason.GOVERNANCE_MIGRATION_JOB_UNAVAILABLE,
+    )
+
+
+def _retry() -> DriverRetryable:
+    return DriverRetryable("governance migration Job is temporarily unavailable")
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _refuse()
+    return value
+
+
+def _string(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise _refuse()
+    return value
+
+
+def _pvc_is_bound(value: object, *, metadata: OpaqueProviderMetadata, pvc_uid: str) -> None:
+    resource = metadata.resource_name
+    pvc = _mapping(value)
+    identity = _mapping(pvc.get("metadata"))
+    annotations = _mapping(identity.get("annotations"))
+    spec = _mapping(pvc.get("spec"))
+    status = _mapping(pvc.get("status"))
+    expected = metadata.kubernetes_annotations
+    if (
+        identity.get("name") != resource + "-data"
+        or identity.get("namespace") != resource
+        or identity.get("uid") != pvc_uid
+        or identity.get("deletionTimestamp") is not None
+        or status.get("phase") != "Bound"
+        or not _string(spec.get("volumeName"))
+        or any(
+            annotations.get(key) != expected[key]
+            for key in (
+                "exomem.io/tenant-id",
+                "exomem.io/cell-id",
+                "exomem.io/tenant-digest",
+                "exomem.io/subject-digest",
+            )
+        )
+    ):
+        raise _refuse()
+
+
+def _runtime_is_stopped(value: object, *, resource: str) -> None:
+    runtime = _mapping(value)
+    identity = _mapping(runtime.get("metadata"))
+    spec = _mapping(runtime.get("spec"))
+    replicas = spec.get("replicas")
+    if (
+        identity.get("name") != resource
+        or identity.get("namespace") != resource
+        or type(replicas) is not int
+        or replicas != 0
+    ):
+        raise _refuse()
+
+
+def _pod_uses_runtime_or_pvc(value: object, *, resource: str) -> bool:
+    pod = _mapping(value)
+    identity = _mapping(pod.get("metadata"))
+    if identity.get("namespace") != resource:
+        raise _refuse()
+    name = _string(identity.get("name"))
+    _string(identity.get("uid"))
+
+    labels_value = identity.get("labels")
+    if labels_value is None:
+        labels: dict[str, Any] = {}
+    else:
+        labels = _mapping(labels_value)
+        if any(
+            not isinstance(key, str) or not isinstance(item, str) for key, item in labels.items()
+        ):
+            raise _refuse()
+
+    owners_value = identity.get("ownerReferences")
+    if owners_value is None:
+        owners: list[object] = []
+    elif isinstance(owners_value, list):
+        owners = owners_value
+    else:
+        raise _refuse()
+    for owner in owners:
+        owner_identity = _mapping(owner)
+        _string(owner_identity.get("name"))
+
+    spec = _mapping(pod.get("spec"))
+    volumes_value = spec.get("volumes")
+    if volumes_value is None:
+        volumes: list[object] = []
+    elif isinstance(volumes_value, list):
+        volumes = volumes_value
+    else:
+        raise _refuse()
+    for volume in volumes:
+        source = _mapping(volume)
+        claim = source.get("persistentVolumeClaim")
+        if claim is None:
+            continue
+        claim_identity = _mapping(claim)
+        if _string(claim_identity.get("claimName")) == resource + "-data":
+            return True
+
+    return (
+        name == resource + "-0"
+        or any(owner["name"] == resource for owner in owners if isinstance(owner, dict))
+        or (
+            labels.get("app.kubernetes.io/name") == "exomem-cell"
+            and labels.get("exomem.io/cell") == resource
+        )
+    )
+
+
+async def verify_stopped_cell(
+    core_v1: Any,
+    apps_v1: Any,
+    *,
+    metadata: OpaqueProviderMetadata,
+    pvc_uid: str,
+) -> None:
+    """Prove that a bound cell volume has no workload before target recovery."""
+    try:
+        if (
+            not isinstance(metadata, OpaqueProviderMetadata)
+            or not isinstance(pvc_uid, str)
+            or not pvc_uid
+        ):
+            raise _refuse()
+        resource = metadata.resource_name
+        serializer = ApiClient()
+        pvc = serializer.sanitize_for_serialization(
+            await asyncio.to_thread(
+                core_v1.read_namespaced_persistent_volume_claim,
+                resource + "-data",
+                resource,
+            )
+        )
+        _pvc_is_bound(pvc, metadata=metadata, pvc_uid=pvc_uid)
+        try:
+            runtime = serializer.sanitize_for_serialization(
+                await asyncio.to_thread(apps_v1.read_namespaced_stateful_set, resource, resource)
+            )
+        except Exception as error:
+            if getattr(error, "status", None) != 404:
+                raise
+        else:
+            _runtime_is_stopped(runtime, resource=resource)
+
+        page = serializer.sanitize_for_serialization(
+            await asyncio.to_thread(core_v1.list_namespaced_pod, resource)
+        )
+        page_value = _mapping(page)
+        page_metadata = _mapping(page_value.get("metadata"))
+        continuation = page_metadata.get("continue")
+        if continuation is not None and not isinstance(continuation, str):
+            raise _refuse()
+        remaining = page_metadata.get("remainingItemCount")
+        if remaining is not None and (type(remaining) is not int or remaining < 0):
+            raise _refuse()
+        if continuation or remaining:
+            raise _retry()
+        items = page_value.get("items")
+        if not isinstance(items, list):
+            raise _refuse()
+        if any(_pod_uses_runtime_or_pvc(item, resource=resource) for item in items):
+            raise _refuse()
+    except (ClaimConflict, StaleFence, MetadataConflict, DriverRetryable):
+        raise
+    except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+        if _retryable_kubernetes_error(error):
+            raise _retry() from None
+        raise _refuse() from None

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal
 
 from .adapters import (
@@ -19,6 +19,7 @@ from .adapters import (
     TraefikRoutingAdapter,
     _api_status,
     _require_annotations,
+    _retryable_kubernetes_error,
     mint_maintenance_transfer_grant,
 )
 from .authorization_membership import (
@@ -31,8 +32,15 @@ from .authorization_membership import (
 )
 from .capacity import CapacityError
 from .conflict_reason import ConflictReason
-from .driver import DriverPending, EffectContext
+from .driver import (
+    DriverPending,
+    DriverRetryable,
+    DriverTerminal,
+    EffectContext,
+    LostAcknowledgement,
+)
 from .governance_migration_checkpoint import CHECKPOINT_VERSION, MigrationCheckpoint
+from .governance_migration_coordinator import HostedGovernanceMigrationCoordinator
 from .lifecycle import (
     HealthObservation,
     LifecycleConfig,
@@ -50,7 +58,7 @@ from .provider_identity import (
     authenticate_cell_provider_recovery_envelopes,
     provider_operation_resource_name,
 )
-from .repository import OperationRepository, canonical_request_sha256
+from .repository import ClaimConflict, OperationRepository, StaleFence, canonical_request_sha256
 from .wire_protocol import WIRE_PROTOCOL_V2, runtime_identity
 
 
@@ -403,12 +411,17 @@ class KubernetesProviderRegistry:
             getattr(item, "type", None) == "Complete" and getattr(item, "status", None) == "True"
             for item in conditions
         )
-        init_failed = migration_job == "absent" and not init_complete and (
-            any(
-                getattr(item, "type", None) == "Failed" and getattr(item, "status", None) == "True"
-                for item in conditions
+        init_failed = (
+            migration_job == "absent"
+            and not init_complete
+            and (
+                any(
+                    getattr(item, "type", None) == "Failed"
+                    and getattr(item, "status", None) == "True"
+                    for item in conditions
+                )
+                or bool(getattr(getattr(init_job, "status", None), "failed", 0))
             )
-            or bool(getattr(getattr(init_job, "status", None), "failed", 0))
         )
         stateful_set = await exists(
             self._apps.read_namespaced_stateful_set,
@@ -654,6 +667,7 @@ class LiveLifecyclePlane:
         identity_verifier: ProviderRecoveryIdentityVerifier,
         config: LifecycleConfig,
         fingerprint: KubernetesVaultFingerprintAdapter | None = None,
+        governance_migration: HostedGovernanceMigrationCoordinator | None = None,
         now: Any = time.time,
     ) -> None:
         self._repository = repository
@@ -667,6 +681,7 @@ class LiveLifecyclePlane:
         self._identity_verifier = identity_verifier
         self._config = config
         self._fingerprint = fingerprint
+        self._governance_migration = governance_migration
         self._now = now
         self._owned: dict[str, OpaqueProviderMetadata] = {}
         self._snapshots: dict[str, KubernetesProviderSnapshot] = {}
@@ -1344,7 +1359,9 @@ class LiveLifecyclePlane:
 
         original = self._helm_requests.get(self._key(metadata))
         envelopes = original.get("_providerRecoveryEnvelopes") if original else None
-        envelope = envelopes.get("authorizationSessionSecret") if isinstance(envelopes, dict) else None
+        envelope = (
+            envelopes.get("authorizationSessionSecret") if isinstance(envelopes, dict) else None
+        )
         if not isinstance(envelope, str) or not envelope:
             raise MetadataConflict(
                 "authorization Secret provider authority is absent",
@@ -1509,6 +1526,78 @@ class LiveLifecyclePlane:
     async def runtime_stopped(self, metadata: OpaqueProviderMetadata) -> bool:
         snapshot = await self._refresh(metadata)
         return snapshot.runtime_desired_replicas == 0 and snapshot.runtime_pods == 0
+
+    async def recover_governance_target(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        context: EffectContext,
+    ) -> DriverPending | None:
+        """Bind target recovery to live evidence, without stop/start or route effects.
+
+        The lifecycle must first close routes and stop the workload under its
+        current claim. This read-only guard re-proves that boundary at custody
+        publication, rather than trusting a cached stop or maintenance result.
+        """
+
+        def unavailable() -> MetadataConflict:
+            return MetadataConflict(
+                "governance target recovery is unavailable",
+                reason=ConflictReason.AUTHORIZATION_MEMBERSHIP_TRANSITION_IS_INVALID,
+            )
+
+        if (
+            self._config.migration_mode != "governance-v3-to-v4"
+            or context.wire_protocol != WIRE_PROTOCOL_V2
+            or self._governance_migration is None
+            or runtime_identity(request) != self._config.runtime_target_for(request, v2=True)
+        ):
+            raise unavailable()
+        try:
+            await context.assert_effect_authority()
+            key = self._key(metadata)
+            # These records were authenticated by observe_operation, not supplied
+            # by the caller or inferred from the new operation's annotations.
+            owner = self._owned[key]
+            envelope = self._helm_requests[key]["_providerRecoveryEnvelopes"][
+                "authorizationSessionSecret"
+            ]
+            pvc_uid = await self._cell.authenticated_volume_uid(owner)
+
+            async def stopped_authority() -> None:
+                await context.assert_effect_authority()
+                await self._maintenance.assert_owned(metadata, context.provider_operation_id)
+                snapshot = await self._refresh(metadata)
+                if (
+                    not snapshot.namespace
+                    or snapshot.init_job_present
+                    or snapshot.routes != (False, False)
+                    or not await self.prove_external_rejection(metadata, request)
+                ):
+                    raise unavailable()
+                await self._cell.verify_governance_stopped(owner, pvc_uid=pvc_uid)
+                # Probes and Kubernetes reads can outlast either lease. Recheck
+                # both after those reads and immediately before the guarded CAS.
+                await self._maintenance.assert_owned(metadata, context.provider_operation_id)
+                await context.assert_effect_authority()
+
+            return await self._governance_migration.recover_target(
+                context=replace(context, effect_guard=stopped_authority),
+                metadata=metadata,
+                owner=owner,
+                pvc_uid=pvc_uid,
+                runtime_image=self._config.image,
+                custody_recovery_envelope=envelope,
+                software_version=runtime_identity(request)["releaseVersion"],
+            )
+        except (DriverRetryable, LostAcknowledgement):
+            return DriverPending(context.checkpoint, 30)
+        except (ClaimConflict, StaleFence, DriverTerminal, MetadataConflict):
+            raise
+        except Exception as error:  # noqa: BLE001 - no raw provider response in progress
+            if _retryable_kubernetes_error(error):
+                return DriverPending(context.checkpoint, 30)
+            raise unavailable() from None
 
     async def resume(
         self,

--- a/infra/provisioner/src/exomem_provisioner/production.py
+++ b/infra/provisioner/src/exomem_provisioner/production.py
@@ -26,6 +26,8 @@ from .crypto import AesGcmEnvelopeCodec
 from .database import ProvisionerDatabase
 from .durability_driver import DurabilityActionDriver
 from .entrypoint import help_requested
+from .governance_migration_coordinator import HostedGovernanceMigrationCoordinator
+from .governance_migration_job import KubernetesGovernanceMigrationAdapter
 from .lifecycle import CellLifecycleDriver, LifecycleConfig
 from .live import (
     KubernetesProviderRegistry,
@@ -204,6 +206,14 @@ def build_live_provider_components(
         capacity=capacity,
         identity_verifier=identity_verifier,
         config=lifecycle_config,
+        governance_migration=HostedGovernanceMigrationCoordinator(
+            cell=cell,
+            jobs=KubernetesGovernanceMigrationAdapter(
+                core_v1=core_v1,
+                apps_v1=apps_v1,
+                batch_v1=batch_v1,
+            ),
+        ),
         fingerprint=KubernetesVaultFingerprintAdapter(
             core_v1=core_v1,
             batch_v1=batch_v1,

--- a/infra/provisioner/tests/test_governance_live_recovery.py
+++ b/infra/provisioner/tests/test_governance_live_recovery.py
@@ -1,0 +1,344 @@
+"""Recovery exercises real live, registry, custody, lease and route adapters."""
+
+import base64
+import hashlib
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from kubernetes.client import V1Lease, V1LeaseSpec, V1ListMeta, V1ObjectMeta, V1PodList
+from test_governance_live_readiness import ReadinessHarness
+from test_governance_readiness import METADATA
+from test_governance_stopped_cell import _model
+
+from exomem_provisioner.adapters import KubernetesMaintenanceLeaseAdapter, TraefikRoutingAdapter
+from exomem_provisioner.driver import DriverPending, EffectContext
+from exomem_provisioner.governance_migration_checkpoint import (
+    MigrationCheckpoint,
+    migration_binding,
+)
+from exomem_provisioner.governance_migration_coordinator import HostedGovernanceMigrationCoordinator
+from exomem_provisioner.lifecycle import MetadataConflict
+from exomem_provisioner.live import KubernetesProviderRegistry
+from exomem_provisioner.provider_identity import ProviderRecoveryIdentityCodec
+from exomem_provisioner.repository import ClaimConflict
+from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V2
+
+
+class Missing(Exception):
+    status = 404
+
+
+class RecoveryHarness(ReadinessHarness):
+    def __init__(self):
+        super().__init__()
+        self.now = self.bundle.expires_at + 1
+        self.envelopes = self.plane._helm_requests[self.plane._key(self.current)][
+            "_providerRecoveryEnvelopes"
+        ]
+        self.rv = 1
+        self.patches = []
+        self.pvc_uid = "pvc-alpha"
+        self.pods = []
+        self.probe_status = 404
+        self.claim_valid = True
+        self.after_secret_read = lambda: None
+        self.events = []
+        self.lease = V1Lease(
+            metadata=V1ObjectMeta(
+                name=METADATA.resource_name + "-maintenance",
+                namespace=METADATA.resource_name,
+                uid="lease-alpha",
+                resource_version="1",
+                annotations=self.current.kubernetes_annotations,
+            ),
+            spec=V1LeaseSpec(
+                holder_identity=self.current.operation_id,
+                lease_duration_seconds=120,
+                renew_time=datetime.fromtimestamp(self.now, UTC),
+            ),
+        )
+        verifier = ProviderRecoveryIdentityCodec.from_secret(
+            "readiness-test-provider-root"
+        ).verifier()
+        self.plane._registry = KubernetesProviderRegistry(
+            core_v1=self,
+            apps_v1=self,
+            batch_v1=self,
+            custom_objects=self,
+            identity_verifier=verifier,
+        )
+        self.plane._cell._apps = self
+        self.plane._maintenance = KubernetesMaintenanceLeaseAdapter(
+            coordination_v1=self,
+            now=lambda: datetime.fromtimestamp(self.now, UTC),
+        )
+        self.plane._routes = TraefikRoutingAdapter(
+            custom_objects=self,
+            control_hostname=self.config.control_hostname,
+            transfer_hostname=self.config.transfer_hostname,
+            probe=self.probe,
+        )
+        self.plane._governance_migration = HostedGovernanceMigrationCoordinator(
+            cell=self.plane._cell,
+            jobs=SimpleNamespace(),
+            now=lambda: self.now,
+        )
+        context = EffectContext(
+            "internal-upgrade",
+            self.current.operation_id,
+            self.current.tenant_id,
+            self.current.subject_id,
+            self.current.fence_generation,
+            wire_protocol=WIRE_PROTOCOL_V2,
+            effect_guard=self.guard,
+        )
+        self.context = replace(
+            context,
+            checkpoint=MigrationCheckpoint(
+                "confirmed",
+                "a" * 64,
+                migration_binding(context, pvc_uid=self.pvc_uid, runtime_image=self.config.image),
+                "b" * 64,
+                "c" * 64,
+            ).encode(),
+        )
+
+    async def guard(self):
+        self.events.append("claim")
+        if not self.claim_valid:
+            raise ClaimConflict("claim lost")
+
+    def annotations_for(self, key):
+        return METADATA.kubernetes_annotations | {
+            "exomem.io/recovery-envelope": self.envelopes[key]
+        }
+
+    def read_namespace(self, name):
+        return SimpleNamespace(
+            metadata=SimpleNamespace(annotations=self.annotations_for("namespace"))
+        )
+
+    def read_namespaced_persistent_volume_claim(self, name, namespace):
+        self.events.append("pvc")
+        return _model(
+            {
+                "metadata": {
+                    "name": name,
+                    "namespace": namespace,
+                    "uid": self.pvc_uid,
+                    "annotations": self.annotations_for("vaultPvc"),
+                },
+                "spec": {"volumeName": "pv-alpha"},
+                "status": {"phase": "Bound"},
+            },
+            "V1PersistentVolumeClaim",
+        )
+
+    def read_namespaced_stateful_set(self, *args):
+        raise Missing
+
+    def read_namespaced_job(self, *args):
+        raise Missing
+
+    def list_namespaced_config_map(self, *args, **kwargs):
+        return SimpleNamespace(items=[])
+
+    def list_namespaced_pod(self, *args, **kwargs):
+        self.events.append("pods-all" if not kwargs else "pods-selected")
+        return V1PodList(items=self.pods if not kwargs else [], metadata=V1ListMeta())
+
+    def get_namespaced_custom_object(self, **kwargs):
+        self.events.append("route")
+        raise Missing
+
+    def read_namespaced_lease(self, *args):
+        self.events.append("lease")
+        return self.lease
+
+    async def probe(self, *args):
+        self.events.append("probe")
+        return self.probe_status
+
+    def read_namespaced_secret(self, name, namespace):
+        if name == "exomem-cell-credentials":
+            return SimpleNamespace(
+                metadata=SimpleNamespace(
+                    annotations=self.annotations_for("credentialSecret")
+                    | {"exomem.io/active-credential-version": "1"}
+                ),
+                data={
+                    "credentials.json": base64.b64encode(
+                        json.dumps(
+                            {
+                                "schema_version": 1,
+                                "credentials": {"1": self.request["serviceCredential"]},
+                            }
+                        ).encode()
+                    ).decode()
+                },
+            )
+        result = super().read_namespaced_secret(name, namespace)
+        result.metadata.uid = "secret-alpha"
+        result.metadata.resource_version = str(self.rv)
+        result.metadata.annotations = result.metadata.annotations | {
+            "exomem.io/authorization-session-revision": hashlib.sha256(
+                self.files["keyring.json"]
+                + self.files["control.json"]
+                + self.files["serving-membership.json"]
+            ).hexdigest()
+        }
+        self.events.append("secret")
+        self.after_secret_read()
+        return result
+
+    def patch_namespaced_secret(self, name, namespace, body):
+        assert body["metadata"]["uid"] == "secret-alpha"
+        assert body["metadata"]["resourceVersion"] == str(self.rv)
+        self.events.append("patch")
+        self.patches.append(body)
+        self.files = {key: value.encode() for key, value in body["stringData"].items()}
+        self.rv += 1
+
+    async def recover(self):
+        return await self.plane.recover_governance_target(self.current, self.request, self.context)
+
+
+@pytest.mark.asyncio
+async def test_live_recovery_uses_fresh_real_proofs_and_original_owner_cas():
+    h = RecoveryHarness()
+    result = await h.recover()
+    assert isinstance(result, DriverPending) and not h.patches
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+    result = await h.recover()
+    assert MigrationCheckpoint.decode(result.checkpoint).phase == "complete"
+    assert len(h.patches) == 1
+    assert (
+        h.patches[0]["metadata"]["annotations"]["exomem.io/operation-id"] == METADATA.operation_id
+    )
+    before_patch = h.events[: h.events.index("patch")]
+    after_read = before_patch[
+        1 + max(i for i, event in enumerate(before_patch) if event == "secret") :
+    ]
+    for required in ("claim", "lease", "route", "probe", "pvc", "pods-all"):
+        assert required in after_read
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["claim", "lease", "pvc", "pod", "probe"])
+async def test_live_recovery_rechecks_each_authority_after_secret_predecessor_read(failure):
+    h = RecoveryHarness()
+    result = await h.recover()
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+
+    def change():
+        if failure == "claim":
+            h.claim_valid = False
+        elif failure == "lease":
+            h.lease.spec.holder_identity = "foreign"
+        elif failure == "pvc":
+            h.pvc_uid = "replacement"
+        elif failure == "probe":
+            h.probe_status = 200
+        else:
+            h.pods = [
+                _model(
+                    {
+                        "metadata": {
+                            "name": "unlabelled",
+                            "namespace": METADATA.resource_name,
+                            "uid": "pod-alpha",
+                        },
+                        "spec": {
+                            "containers": [{"name": "runtime", "image": "example"}],
+                            "volumes": [
+                                {
+                                    "name": "vault",
+                                    "persistentVolumeClaim": {
+                                        "claimName": METADATA.resource_name + "-data"
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "V1Pod",
+                )
+            ]
+
+    h.after_secret_read = change
+    with pytest.raises((MetadataConflict, ClaimConflict)):
+        await h.recover()
+    assert not h.patches
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["none", "binding-v1-to-v2", "state-root-v1"])
+async def test_live_recovery_cannot_be_used_by_ordinary_modes(mode):
+    h = RecoveryHarness()
+    h.plane._config = replace(h.config, migration_mode=mode)
+    with pytest.raises(MetadataConflict):
+        await h.recover()
+    assert not h.patches
+
+
+@pytest.mark.asyncio
+async def test_delayed_exact_cas_between_predecessor_reads_is_reconciled_not_terminal():
+    from test_governance_readiness import SOFTWARE_VERSION, _identity
+
+    from exomem_provisioner.governance_target_recovery import recover_expired_serving_bundle
+
+    h = RecoveryHarness()
+    result = await h.recover()
+    checkpoint = MigrationCheckpoint.decode(result.checkpoint)
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+    successor = recover_expired_serving_bundle(
+        h.files,
+        **{
+            k: v
+            for k, v in _identity(4).items()
+            if k not in {"expected_schema_version", "expected_recovery_envelope"}
+        },
+        expected_recovery_envelope=h.envelope,
+        now=h.now,
+        successor_issued_at=checkpoint.recovery_issued_at,
+    )
+    assert successor.software_version == SOFTWARE_VERSION
+
+    def delayed_cas():
+        h.files = successor.files
+        h.rv += 1
+        h.after_secret_read = lambda: None
+
+    h.after_secret_read = delayed_cas
+    pending = await h.recover()
+    assert pending.checkpoint == h.context.checkpoint
+    result = await h.recover()
+    assert MigrationCheckpoint.decode(result.checkpoint).phase == "complete"
+    assert not h.patches
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("applied", [False, True])
+async def test_guarded_api_conflict_retains_commitment_until_exact_reread(applied):
+    h = RecoveryHarness()
+    result = await h.recover()
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+    patch = h.patch_namespaced_secret
+
+    class Conflict(Exception):
+        status = 409
+
+    def conflict(*args):
+        if applied:
+            patch(*args)
+        h.patch_namespaced_secret = patch
+        raise Conflict("provider-private-response")
+
+    h.patch_namespaced_secret = conflict
+    pending = await h.recover()
+    assert pending.checkpoint == h.context.checkpoint
+    result = await h.recover()
+    assert MigrationCheckpoint.decode(result.checkpoint).phase == "complete"
+    assert len(h.patches) == 1

--- a/infra/provisioner/tests/test_governance_recovery_adapters.py
+++ b/infra/provisioner/tests/test_governance_recovery_adapters.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from kubernetes.client import ApiClient, V1ListMeta, V1PodList
+
+from exomem_provisioner.adapters import KubernetesCellAdapter, KubernetesMaintenanceLeaseAdapter
+from exomem_provisioner.conflict_reason import ConflictReason
+from exomem_provisioner.driver import DriverRetryable
+from exomem_provisioner.lifecycle import MetadataConflict, OpaqueProviderMetadata
+from exomem_provisioner.provider_identity import ProviderRecoveryIdentityCodec, ProviderReference
+from exomem_provisioner.repository import ClaimConflict, StaleFence
+
+
+def test_governance_recovery_adapters_expose_read_only_guards() -> None:
+    assert hasattr(KubernetesCellAdapter, "authenticated_volume_uid")
+    assert hasattr(KubernetesCellAdapter, "verify_governance_stopped")
+    assert hasattr(KubernetesMaintenanceLeaseAdapter, "assert_owned")
+
+
+NOW = datetime(2030, 1, 1, tzinfo=UTC)
+METADATA = OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "operation-alpha", 7)
+CODEC = ProviderRecoveryIdentityCodec.from_secret("governance-recovery-adapters")
+
+
+def _model(value: dict[str, object], kind: str):
+    return ApiClient().deserialize(SimpleNamespace(data=json.dumps(value)), kind)
+
+
+def _envelope() -> str:
+    resource = METADATA.resource_name
+    return CODEC.seal(
+        provider="kubernetes",
+        provider_reference=ProviderReference.kubernetes(
+            provider="kubernetes",
+            api_version="v1",
+            kind="PersistentVolumeClaim",
+            namespace=resource,
+            name=resource + "-data",
+        ),
+        tenant_id=METADATA.tenant_id,
+        cell_id=METADATA.subject_id,
+        operation_id=METADATA.operation_id,
+        fence_generation=METADATA.fence_generation,
+    )
+
+
+def _pvc(**changes: object):
+    resource = METADATA.resource_name
+    value: dict[str, object] = {
+        "metadata": {
+            "name": resource + "-data",
+            "namespace": resource,
+            "uid": "pvc-alpha",
+            "annotations": {
+                **METADATA.kubernetes_annotations,
+                "exomem.io/recovery-envelope": _envelope(),
+            },
+        },
+        "spec": {"volumeName": "pv-alpha"},
+        "status": {"phase": "Bound"},
+    }
+    for path, replacement in changes.items():
+        parent = value
+        *keys, key = path.split(".")
+        for item in keys:
+            parent = parent[item]  # type: ignore[assignment,index]
+        parent[key] = replacement
+    return _model(value, "V1PersistentVolumeClaim")
+
+
+def _lease(**changes: object):
+    resource = METADATA.resource_name
+    value: dict[str, object] = {
+        "metadata": {
+            "name": resource + "-maintenance",
+            "namespace": resource,
+            "uid": "lease-alpha",
+            "resourceVersion": "1",
+            "annotations": dict(METADATA.kubernetes_annotations),
+        },
+        "spec": {
+            "holderIdentity": METADATA.operation_id,
+            "leaseDurationSeconds": 120,
+            "renewTime": (NOW - timedelta(seconds=1)).isoformat(),
+        },
+    }
+    for path, replacement in changes.items():
+        parent = value
+        *keys, key = path.split(".")
+        for item in keys:
+            parent = parent[item]  # type: ignore[assignment,index]
+        parent[key] = replacement
+    return _model(value, "V1Lease")
+
+
+class Missing(Exception):
+    status = 404
+
+
+class Cluster:
+    def __init__(self) -> None:
+        self.pvc = _pvc()
+        self.pvc_reads = 0
+
+    def read_namespaced_persistent_volume_claim(self, name: str, namespace: str):
+        assert (name, namespace) == (METADATA.resource_name + "-data", METADATA.resource_name)
+        self.pvc_reads += 1
+        return self.pvc
+
+    def read_namespaced_stateful_set(self, name: str, namespace: str):
+        assert (name, namespace) == (METADATA.resource_name, METADATA.resource_name)
+        raise Missing
+
+    def list_namespaced_pod(self, namespace: str):
+        assert namespace == METADATA.resource_name
+        return V1PodList(items=[], metadata=V1ListMeta())
+
+
+async def test_authenticated_volume_uid_requires_the_signed_fixed_pvc() -> None:
+    cluster = Cluster()
+    adapter = KubernetesCellAdapter(
+        core_v1=cluster,
+        apps_v1=cluster,
+        identity_verifier=CODEC.verifier(),
+    )
+
+    assert await adapter.authenticated_volume_uid(METADATA) == "pvc-alpha"
+
+
+@pytest.mark.parametrize(
+    "pvc",
+    [
+        lambda: _pvc(**{"metadata.uid": None}),
+        lambda: _pvc(**{"metadata.deletionTimestamp": NOW.isoformat()}),
+        lambda: _pvc(**{"status.phase": "Pending"}),
+        lambda: _pvc(**{"spec.volumeName": None}),
+        lambda: _pvc(**{"metadata.annotations": {}}),
+    ],
+)
+async def test_authenticated_volume_uid_refuses_invalid_physical_or_identity_evidence(pvc) -> None:
+    cluster = Cluster()
+    cluster.pvc = pvc()
+    adapter = KubernetesCellAdapter(
+        core_v1=cluster,
+        apps_v1=cluster,
+        identity_verifier=CODEC.verifier(),
+    )
+
+    with pytest.raises(MetadataConflict):
+        await adapter.authenticated_volume_uid(METADATA)
+
+
+async def test_authenticated_volume_uid_never_allows_optional_identity_authentication() -> None:
+    cluster = Cluster()
+    adapter = KubernetesCellAdapter(core_v1=cluster, apps_v1=cluster)
+
+    with pytest.raises(MetadataConflict) as raised:
+        await adapter.authenticated_volume_uid(METADATA)
+    assert raised.value.reason is ConflictReason.PVC_RECOVERY_IDENTITY_UNAUTHENTICATED
+
+
+async def test_authenticated_volume_uid_maps_transient_provider_failure_without_payload() -> None:
+    class ProviderError(Exception):
+        status = 503
+
+    cluster = Cluster()
+
+    def unavailable(name: str, namespace: str):
+        raise ProviderError("private-provider-payload")
+
+    cluster.read_namespaced_persistent_volume_claim = unavailable  # type: ignore[method-assign]
+    adapter = KubernetesCellAdapter(
+        core_v1=cluster,
+        apps_v1=cluster,
+        identity_verifier=CODEC.verifier(),
+    )
+
+    with pytest.raises(DriverRetryable) as raised:
+        await adapter.authenticated_volume_uid(METADATA)
+    assert "private-provider-payload" not in str(raised.value)
+
+
+async def test_stopped_wrapper_refuses_a_pvc_replacement_after_authenticated_read() -> None:
+    cluster = Cluster()
+    original = cluster.read_namespaced_persistent_volume_claim
+
+    def changed(name: str, namespace: str):
+        result = original(name, namespace)
+        if cluster.pvc_reads == 1:
+            cluster.pvc = _pvc(**{"metadata.uid": "pvc-replacement"})
+        return result
+
+    cluster.read_namespaced_persistent_volume_claim = changed  # type: ignore[method-assign]
+    adapter = KubernetesCellAdapter(
+        core_v1=cluster,
+        apps_v1=cluster,
+        identity_verifier=CODEC.verifier(),
+    )
+
+    with pytest.raises(MetadataConflict):
+        await adapter.verify_governance_stopped(METADATA, pvc_uid="pvc-alpha")
+    assert cluster.pvc_reads == 2
+
+
+async def test_stopped_wrapper_refuses_a_caller_uid_different_from_fresh_evidence() -> None:
+    cluster = Cluster()
+    adapter = KubernetesCellAdapter(
+        core_v1=cluster,
+        apps_v1=cluster,
+        identity_verifier=CODEC.verifier(),
+    )
+
+    with pytest.raises(MetadataConflict):
+        await adapter.verify_governance_stopped(METADATA, pvc_uid="pvc-other")
+    assert cluster.pvc_reads == 1
+
+
+@pytest.mark.parametrize(
+    "lease",
+    [
+        lambda: _lease(**{"metadata.uid": None}),
+        lambda: _lease(**{"metadata.resourceVersion": None}),
+        lambda: _lease(**{"metadata.deletionTimestamp": NOW.isoformat()}),
+        lambda: _lease(**{"spec.holderIdentity": "foreign-operation"}),
+        lambda: _lease(**{"spec.leaseDurationSeconds": True}),
+        lambda: _lease(**{"spec.leaseDurationSeconds": 0}),
+        lambda: _lease(**{"spec.renewTime": (NOW + timedelta(seconds=1)).isoformat()}),
+        lambda: _lease(**{"spec.renewTime": (NOW - timedelta(seconds=120)).isoformat()}),
+    ],
+)
+async def test_maintenance_assert_owned_refuses_unproven_or_expired_authority(lease) -> None:
+    class Coordination:
+        def read_namespaced_lease(self, name: str, namespace: str):
+            assert (name, namespace) == (
+                METADATA.resource_name + "-maintenance",
+                METADATA.resource_name,
+            )
+            return lease()
+
+    adapter = KubernetesMaintenanceLeaseAdapter(
+        coordination_v1=Coordination(),
+        now=lambda: NOW,
+    )
+    with pytest.raises(MetadataConflict) as raised:
+        await adapter.assert_owned(METADATA, METADATA.operation_id)
+    assert raised.value.reason is ConflictReason.GOVERNANCE_MIGRATION_JOB_UNAVAILABLE
+
+
+async def test_maintenance_assert_owned_accepts_fresh_exact_current_lease() -> None:
+    class Coordination:
+        def read_namespaced_lease(self, name: str, namespace: str):
+            return _lease()
+
+    adapter = KubernetesMaintenanceLeaseAdapter(
+        coordination_v1=Coordination(),
+        now=lambda: NOW,
+    )
+    await adapter.assert_owned(METADATA, METADATA.operation_id)
+
+
+async def test_maintenance_assert_owned_refuses_a_missing_lease() -> None:
+    class Coordination:
+        def read_namespaced_lease(self, name: str, namespace: str):
+            raise Missing
+
+    adapter = KubernetesMaintenanceLeaseAdapter(
+        coordination_v1=Coordination(),
+        now=lambda: NOW,
+    )
+    with pytest.raises(MetadataConflict) as raised:
+        await adapter.assert_owned(METADATA, METADATA.operation_id)
+    assert raised.value.reason is ConflictReason.GOVERNANCE_MIGRATION_JOB_UNAVAILABLE
+
+
+@pytest.mark.parametrize("failure", [ClaimConflict, StaleFence])
+async def test_recovery_adapter_guards_preserve_claim_and_fence_conflicts(failure) -> None:
+    refused = failure("AUTHORITY_LOST")
+
+    class Coordination:
+        def read_namespaced_lease(self, name: str, namespace: str):
+            raise refused
+
+    adapter = KubernetesMaintenanceLeaseAdapter(
+        coordination_v1=Coordination(),
+        now=lambda: NOW,
+    )
+    with pytest.raises(failure) as raised:
+        await adapter.assert_owned(METADATA, METADATA.operation_id)
+    assert raised.value is refused
+
+
+async def test_transient_lease_provider_failure_is_retryable_and_content_free() -> None:
+    class ProviderError(Exception):
+        status = 503
+
+    class Coordination:
+        def read_namespaced_lease(self, name: str, namespace: str):
+            raise ProviderError("private-provider-payload")
+
+    adapter = KubernetesMaintenanceLeaseAdapter(
+        coordination_v1=Coordination(),
+        now=lambda: NOW,
+    )
+    with pytest.raises(DriverRetryable) as raised:
+        await adapter.assert_owned(METADATA, METADATA.operation_id)
+    assert "private-provider-payload" not in str(raised.value)

--- a/infra/provisioner/tests/test_governance_stopped_cell.py
+++ b/infra/provisioner/tests/test_governance_stopped_cell.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from types import SimpleNamespace
+
+import pytest
+from kubernetes.client import ApiClient, V1ListMeta, V1PodList
+
+from exomem_provisioner.driver import DriverRetryable
+from exomem_provisioner.lifecycle import MetadataConflict, OpaqueProviderMetadata
+from exomem_provisioner.repository import ClaimConflict, StaleFence
+
+
+def test_stopped_cell_verifier_has_a_dedicated_provisioner_boundary() -> None:
+    assert importlib.util.find_spec("exomem_provisioner.governance_stopped_cell") is not None
+
+
+METADATA = OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "operation-alpha", 7)
+
+
+def _model(value: dict[str, object], kind: str):
+    return ApiClient().deserialize(SimpleNamespace(data=json.dumps(value)), kind)
+
+
+def _pvc(**changes: object):
+    resource = METADATA.resource_name
+    value: dict[str, object] = {
+        "metadata": {
+            "name": resource + "-data",
+            "namespace": resource,
+            "uid": "pvc-alpha",
+            "annotations": dict(METADATA.kubernetes_annotations),
+        },
+        "spec": {"volumeName": "pv-alpha"},
+        "status": {"phase": "Bound"},
+    }
+    for path, replacement in changes.items():
+        parent = value
+        *keys, key = path.split(".")
+        for item in keys:
+            parent = parent[item]  # type: ignore[assignment,index]
+        parent[key] = replacement
+    return _model(value, "V1PersistentVolumeClaim")
+
+
+def _stateful_set(replicas: object = 0):
+    resource = METADATA.resource_name
+    return _model(
+        {
+            "metadata": {"name": resource, "namespace": resource},
+            "spec": {
+                "replicas": replicas,
+                "serviceName": resource,
+                "selector": {"matchLabels": {"app": "example"}},
+                "template": {
+                    "metadata": {"labels": {"app": "example"}},
+                    "spec": {"containers": [{"name": "exomem", "image": "example"}]},
+                },
+            },
+        },
+        "V1StatefulSet",
+    )
+
+
+def _pod(
+    name: str = "unrelated",
+    *,
+    labels: dict[str, str] | None = None,
+    owners: list[dict[str, object]] | None = None,
+    volumes: list[dict[str, object]] | None = None,
+    deleting: bool = False,
+    phase: str | None = None,
+):
+    resource = METADATA.resource_name
+    metadata: dict[str, object] = {
+        "name": name,
+        "namespace": resource,
+        "uid": "pod-" + name,
+    }
+    if labels is not None:
+        metadata["labels"] = labels
+    if owners is not None:
+        metadata["ownerReferences"] = [
+            {
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "uid": "owner-alpha",
+                "controller": True,
+                "blockOwnerDeletion": True,
+                **owner,
+            }
+            for owner in owners
+        ]
+    if deleting:
+        metadata["deletionTimestamp"] = "2026-09-08T12:00:00Z"
+    value: dict[str, object] = {
+        "metadata": metadata,
+        "spec": {"containers": [{"name": "exomem", "image": "example"}], "volumes": volumes or []},
+    }
+    if phase is not None:
+        value["status"] = {"phase": phase}
+    return _model(value, "V1Pod")
+
+
+def _pod_page(*items: object, continuation: str | None = None) -> V1PodList:
+    return V1PodList(items=list(items), metadata=V1ListMeta(_continue=continuation))
+
+
+class ApiMissing(Exception):
+    status = 404
+
+
+class Cluster:
+    def __init__(self) -> None:
+        self.pvc = _pvc()
+        self.runtime: object = ApiMissing
+        self.pods: object = _pod_page()
+
+    def read_namespaced_persistent_volume_claim(self, name: str, namespace: str):
+        assert (name, namespace) == (METADATA.resource_name + "-data", METADATA.resource_name)
+        return self.pvc
+
+    def read_namespaced_stateful_set(self, name: str, namespace: str):
+        assert (name, namespace) == (METADATA.resource_name, METADATA.resource_name)
+        if self.runtime is ApiMissing:
+            raise ApiMissing
+        return self.runtime
+
+    def list_namespaced_pod(self, namespace: str, **kwargs: object):
+        assert namespace == METADATA.resource_name
+        assert kwargs == {}
+        return self.pods
+
+
+async def _verify(cluster: Cluster) -> None:
+    from exomem_provisioner.governance_stopped_cell import verify_stopped_cell
+
+    await verify_stopped_cell(
+        cluster,
+        cluster,
+        metadata=METADATA,
+        pvc_uid="pvc-alpha",
+    )
+
+
+async def test_verifies_bound_identity_matched_pvc_and_absent_runtime() -> None:
+    await _verify(Cluster())
+
+
+async def test_accepts_the_original_pvc_operation_and_fence_annotations() -> None:
+    cluster = Cluster()
+    annotations = dict(METADATA.kubernetes_annotations)
+    annotations.update({"exomem.io/operation-id": "original-operation", "exomem.io/fence": "1"})
+    cluster.pvc = _pvc(**{"metadata.annotations": annotations})
+    await _verify(cluster)
+
+
+@pytest.mark.parametrize("replicas", [1, True, None])
+async def test_refuses_present_runtime_that_is_not_strictly_zero(replicas: object) -> None:
+    cluster = Cluster()
+    cluster.runtime = _stateful_set(replicas)
+    with pytest.raises(MetadataConflict):
+        await _verify(cluster)
+
+
+@pytest.mark.parametrize(
+    "pvc",
+    [
+        lambda: _pvc(**{"metadata.uid": "wrong-pvc"}),
+        lambda: _pvc(**{"metadata.deletionTimestamp": "2026-09-08T12:00:00Z"}),
+        lambda: _pvc(**{"status.phase": "Pending"}),
+        lambda: _pvc(**{"spec.volumeName": None}),
+        lambda: _pvc(**{"metadata.annotations": {}}),
+    ],
+)
+async def test_refuses_wrong_or_nonbound_pvc_evidence(pvc) -> None:
+    cluster = Cluster()
+    cluster.pvc = pvc()
+    with pytest.raises(MetadataConflict):
+        await _verify(cluster)
+
+
+async def test_unlabelled_pvc_mount_blocks_stopped_proof() -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(
+        _pod(
+            volumes=[
+                {
+                    "name": "data",
+                    "persistentVolumeClaim": {"claimName": METADATA.resource_name + "-data"},
+                }
+            ]
+        )
+    )
+    with pytest.raises(MetadataConflict):
+        await _verify(cluster)
+
+
+@pytest.mark.parametrize(
+    "pod",
+    [
+        lambda: _pod(METADATA.resource_name + "-0"),
+        lambda: _pod(
+            owners=[
+                {"apiVersion": "apps/v1", "kind": "StatefulSet", "name": METADATA.resource_name}
+            ]
+        ),
+        lambda: _pod(
+            labels={
+                "app.kubernetes.io/name": "exomem-cell",
+                "exomem.io/cell": METADATA.resource_name,
+            }
+        ),
+    ],
+)
+async def test_runtime_identity_blocks_stopped_proof_without_a_pvc_mount(pod) -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(pod())
+    with pytest.raises(MetadataConflict):
+        await _verify(cluster)
+
+
+@pytest.mark.parametrize(
+    "pod",
+    [
+        lambda: _pod(
+            volumes=[
+                {
+                    "name": "data",
+                    "persistentVolumeClaim": {"claimName": METADATA.resource_name + "-data"},
+                }
+            ],
+            phase="Succeeded",
+        ),
+        lambda: _pod(
+            volumes=[
+                {
+                    "name": "data",
+                    "persistentVolumeClaim": {"claimName": METADATA.resource_name + "-data"},
+                }
+            ],
+            deleting=True,
+        ),
+    ],
+)
+async def test_terminal_or_terminating_pvc_pods_remain_present(pod) -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(pod())
+    with pytest.raises(MetadataConflict):
+        await _verify(cluster)
+
+
+async def test_well_formed_unrelated_pod_does_not_block_stopped_proof() -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(_pod())
+    await _verify(cluster)
+
+
+async def test_incomplete_pod_inventory_is_retryable_not_absence() -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(continuation="next-page")
+    with pytest.raises(DriverRetryable) as raised:
+        await _verify(cluster)
+    assert str(raised.value) == "governance migration Job is temporarily unavailable"
+
+
+async def test_empty_continuation_is_a_complete_inventory() -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(continuation="")
+    await _verify(cluster)
+
+
+async def test_remaining_items_without_a_token_do_not_prove_absence() -> None:
+    cluster = Cluster()
+    cluster.pods = V1PodList(items=[], metadata=V1ListMeta(remaining_item_count=1))
+    with pytest.raises(DriverRetryable):
+        await _verify(cluster)
+
+
+@pytest.mark.parametrize("bad", [{"metadata": {}, "spec": []}, {"metadata": [], "spec": {}}])
+async def test_malformed_pod_evidence_fails_closed(bad: dict[str, object]) -> None:
+    cluster = Cluster()
+    cluster.pods = _pod_page(bad)
+    with pytest.raises(MetadataConflict):
+        await _verify(cluster)
+
+
+async def test_transient_provider_errors_are_retryable_and_content_free() -> None:
+    cluster = Cluster()
+
+    class ProviderError(Exception):
+        status = 503
+
+    def unavailable(*args: object, **kwargs: object):
+        raise ProviderError("private-provider-payload")
+
+    cluster.list_namespaced_pod = unavailable  # type: ignore[method-assign]
+    with pytest.raises(DriverRetryable) as raised:
+        await _verify(cluster)
+    assert str(raised.value) == "governance migration Job is temporarily unavailable"
+    assert "private-provider-payload" not in str(raised.value)
+
+
+@pytest.mark.parametrize("failure", [ClaimConflict, StaleFence])
+async def test_claim_and_fence_conflicts_are_not_disguised_as_provider_state(failure) -> None:
+    cluster = Cluster()
+    refused = failure("AUTHORITY_LOST")
+
+    def unavailable(*args: object, **kwargs: object):
+        raise refused
+
+    cluster.read_namespaced_persistent_volume_claim = unavailable  # type: ignore[method-assign]
+    with pytest.raises(failure) as raised:
+        await _verify(cluster)
+    assert raised.value is refused

--- a/infra/provisioner/tests/test_governance_target_coordinator.py
+++ b/infra/provisioner/tests/test_governance_target_coordinator.py
@@ -1,0 +1,233 @@
+"""Persisted target recovery survives fresh coordinators and uncertain publication."""
+
+import json
+from dataclasses import replace
+
+import pytest
+from test_governance_migration_coordinator import (
+    CURRENT,
+    IMAGE,
+    OWNER,
+    PLAN,
+    SECRET_ENVELOPE,
+    SOURCE,
+    Scenario,
+    identity,
+)
+
+from exomem_provisioner import authorization_membership as membership
+from exomem_provisioner.driver import DriverPending, DriverTerminal
+from exomem_provisioner.governance_migration_checkpoint import MigrationCheckpoint
+from exomem_provisioner.governance_migration_coordinator import HostedGovernanceMigrationCoordinator
+from exomem_provisioner.lifecycle import MetadataConflict
+from exomem_provisioner.repository import ClaimConflict
+
+
+async def scenario_at_target(phase="complete"):
+    scenario = Scenario()
+    for _ in range(6):
+        await scenario.step()
+    source = membership.transition_hosted_authorization_bundle(
+        scenario.cell.files,
+        **identity(4),
+        target_state="SERVING",
+        target_no_in_flight=False,
+        target_software_version="0.75.0",
+        now=scenario.now,
+    )
+    scenario.cell.files = source.files
+    checkpoint = replace(MigrationCheckpoint.decode(scenario.context.checkpoint), phase=phase)
+    scenario.context = replace(scenario.context, checkpoint=checkpoint.encode())
+    scenario.cell.writes.clear()
+    scenario.jobs.requests.clear()
+    scenario.now = source.expires_at + 1
+    return scenario
+
+
+async def recover(scenario, **overrides):
+    return await HostedGovernanceMigrationCoordinator(
+        cell=scenario.cell,
+        jobs=scenario.jobs,
+        now=lambda: scenario.now,
+    ).recover_target(
+        **{
+            "context": scenario.context,
+            "metadata": CURRENT,
+            "owner": OWNER,
+            "pvc_uid": "pvc-alpha",
+            "runtime_image": IMAGE,
+            "custody_recovery_envelope": SECRET_ENVELOPE,
+            "software_version": "0.75.0",
+            **overrides,
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["complete", "confirmed"])
+async def test_recovery_commits_exact_intent_before_any_cas_then_returns_to_complete(phase):
+    scenario = await scenario_at_target(phase)
+    initial = scenario.cell.files
+    result = await recover(scenario)
+    assert isinstance(result, DriverPending)
+    committed = MigrationCheckpoint.decode(result.checkpoint)
+    assert committed.phase == "recover-" + phase
+    assert committed.recovery_issued_at == scenario.now
+    assert (committed.source_store_digest, committed.plan_digest) == (SOURCE, PLAN)
+    assert scenario.cell.files == initial
+    assert not scenario.cell.writes and not scenario.jobs.requests
+
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    result = await recover(scenario)
+    completed = MigrationCheckpoint.decode(result.checkpoint)
+    assert completed.phase == "complete" and completed.recovery_revision is None
+    observed = membership.inspect_hosted_authorization_bundle(
+        scenario.cell.files,
+        **identity(4),
+        now=scenario.now,
+    )
+    assert observed.revision == committed.recovery_revision
+    assert observed.replica_state == "DRAINING"
+    assert observed.governance_enrolled and observed.no_in_flight
+    assert len(scenario.cell.writes) == 1 and not scenario.jobs.requests
+
+
+@pytest.mark.asyncio
+async def test_uncertain_cas_keeps_commitment_and_reconciles_exact_successor_after_expiry():
+    scenario = await scenario_at_target("confirmed")
+    result = await recover(scenario)
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    scenario.cell.fail_after_write = True
+    uncertain = await recover(scenario)
+    assert uncertain.checkpoint == result.checkpoint
+    scenario.now += 4000
+    recovered = await recover(scenario)
+    assert MigrationCheckpoint.decode(recovered.checkpoint).phase == "complete"
+    assert len(scenario.cell.writes) == 1
+
+
+@pytest.mark.asyncio
+async def test_late_unapplied_commitment_reconstructs_same_bytes_without_replanning():
+    scenario = await scenario_at_target()
+    result = await recover(scenario)
+    commitment = MigrationCheckpoint.decode(result.checkpoint)
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    scenario.now += 4000
+    await recover(scenario)
+    observed = membership.inspect_hosted_authorization_bundle(
+        scenario.cell.files,
+        **identity(4),
+        now=scenario.now,
+        _require_fresh=False,
+    )
+    assert observed.revision == commitment.recovery_revision
+    assert observed.expires_at < scenario.now
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override", [{"pvc_uid": "replacement"}, {"runtime_image": "repo@sha256:" + "f" * 64}]
+)
+async def test_recovery_recomputes_operation_binding(override):
+    scenario = await scenario_at_target()
+    with pytest.raises(DriverTerminal):
+        await recover(scenario, **override)
+    assert not scenario.cell.writes
+
+
+@pytest.mark.asyncio
+async def test_recovery_guard_is_rechecked_after_predecessor_read_before_cas():
+    scenario = await scenario_at_target()
+    result = await recover(scenario)
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    read = scenario.cell.read_authorization_session_bundle
+    lost = False
+
+    async def lose_after_read(metadata):
+        nonlocal lost
+        value = await read(metadata)
+        lost = True
+        return value
+
+    async def guard():
+        if lost:
+            raise ClaimConflict("claim lost")
+
+    scenario.cell.read_authorization_session_bundle = lose_after_read
+    scenario.context = replace(scenario.context, effect_guard=guard)
+    with pytest.raises(ClaimConflict):
+        await recover(scenario)
+    assert not scenario.cell.writes
+
+
+@pytest.mark.asyncio
+async def test_recovery_refuses_a_different_legitimate_successor():
+    from exomem_provisioner.governance_target_recovery import recover_expired_serving_bundle
+
+    scenario = await scenario_at_target()
+    result = await recover(scenario)
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    scenario.now += 1
+    different = recover_expired_serving_bundle(
+        scenario.cell.files,
+        **{
+            k: v
+            for k, v in identity(4).items()
+            if k not in {"expected_schema_version", "expected_software_version"}
+        },
+        expected_software_version="0.75.0",
+        now=scenario.now,
+        successor_issued_at=scenario.now,
+    )
+    scenario.cell.files = different.files
+    with pytest.raises(MetadataConflict):
+        await recover(scenario)
+    assert not scenario.cell.writes
+
+
+@pytest.mark.asyncio
+async def test_fresh_target_is_not_renewed_or_moved_to_recovery():
+    scenario = await scenario_at_target()
+    scenario.now = json.loads(scenario.cell.files["control.json"])["expires_at"] - 1
+    assert await recover(scenario) is None
+    assert not scenario.cell.writes
+
+
+@pytest.mark.asyncio
+async def test_a_new_commitment_requires_enough_key_lifetime_for_bounded_start(monkeypatch):
+    monkeypatch.setattr(membership, "_KEY_TTL_SECONDS", 3670)
+    scenario = await scenario_at_target()
+    with pytest.raises(MetadataConflict):
+        await recover(scenario)
+    assert not scenario.cell.writes
+
+
+@pytest.mark.asyncio
+async def test_an_existing_commitment_never_uses_its_old_time_to_accept_an_expired_key():
+    scenario = await scenario_at_target()
+    result = await recover(scenario)
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    scenario.now = json.loads(scenario.cell.files["keyring.json"])["accepted_keys"][0]["not_after"]
+    with pytest.raises(MetadataConflict):
+        await recover(scenario)
+    assert not scenario.cell.writes
+
+
+@pytest.mark.asyncio
+async def test_key_expiry_during_async_effect_proofs_prevents_publication():
+    scenario = await scenario_at_target()
+    result = await recover(scenario)
+    scenario.context = replace(scenario.context, checkpoint=result.checkpoint)
+    key_expiry = json.loads(scenario.cell.files["keyring.json"])["accepted_keys"][0]["not_after"]
+    calls = 0
+
+    async def slow_guard():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            scenario.now = key_expiry
+
+    scenario.context = replace(scenario.context, effect_guard=slow_guard)
+    with pytest.raises(MetadataConflict):
+        await recover(scenario)
+    assert not scenario.cell.writes

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -558,6 +558,16 @@ def test_production_factory_wires_the_live_plane_without_a_fake_selection_path(
     assert components.driver._volumes is None
     assert components.capacity is components.plane._capacity
     assert components.plane._fingerprint._image == components.lock.components.provisioner.image
+    from exomem_provisioner.governance_migration_coordinator import (
+        HostedGovernanceMigrationCoordinator,
+    )
+    from exomem_provisioner.governance_migration_job import KubernetesGovernanceMigrationAdapter
+
+    assert isinstance(components.plane._governance_migration, HostedGovernanceMigrationCoordinator)
+    assert components.plane._governance_migration._cell is components.plane._cell
+    assert isinstance(
+        components.plane._governance_migration._jobs, KubernetesGovernanceMigrationAdapter
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds migration-only recovery publication for expired enrolled custody. The coordinator persists an exact successor before Secret CAS and retains it across lost acknowledgements. The live guard rechecks claim, maintenance, route rejection, authenticated PVC identity, namespace-wide pod absence and current signing-key validity before publication.

This is the recovery-publication slice of OpenSpec `simplify-hosted-launch-boundaries`, Task 6. Deployment-mode activation is unchanged; target start/admission and fresh-cell lifecycle integration remain gated.

Verification: full provisioner suite **1,203 passed, 39 skipped**; independent security review **75 focused tests passed**; Ruff, package build, public-artifact privacy and pinned OpenSpec strict validation (**190 passed**) passed.