### PR TITLE
feat(ingest): add bounded dataset source cards and text previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,11 @@ uv sync --extra media
 - `media`: OCR for images, PDF extraction, Office document extraction, and
   faster-whisper ASR for audio/video.
 
+CSV, TSV and JSON evidence uploads get dataset source cards for discovery and
+exact queries. YAML, JSONL, XML and TOML exports get bounded text previews.
+These paths need no optional extras; see [source formats](docs/source-formats.md)
+for limits and governance behavior.
+
 `lean` and `hybrid` remain available for constrained machines. Generated image
 captioning and speaker diarization are advanced opt-ins, not requirements for
 the standard multimodal path.

--- a/docs/source-formats.md
+++ b/docs/source-formats.md
@@ -6,6 +6,11 @@ New evidence uploads retain the original bytes and create a searchable source
 card. This applies to direct preservation, streaming uploads and client evidence
 attachments that use the shared preservation operation.
 
+Uploaded CSV/JSON are immutable source snapshots for recall, exact read-only
+queries, citations and connected findings. Ongoing editable state belongs in
+Records. This upload path does not add a CSV/JSON editor or turn an imported
+snapshot into a mutable collection.
+
 | Format | Automatic discovery | Exact content |
 | --- | --- | --- |
 | CSV, TSV, JSON | Dataset source card with structural counts; bounded field names for JSON | `query_dataset` reads rows, filters, nested JSON fields and aggregates from the original |

--- a/docs/source-formats.md
+++ b/docs/source-formats.md
@@ -1,0 +1,47 @@
+<!-- authority:non-specification -->
+
+# Structured files and text exports
+
+New evidence uploads retain the original bytes and create a searchable source
+card. This applies to direct preservation, streaming uploads and client evidence
+attachments that use the shared preservation operation.
+
+| Format | Automatic discovery | Exact content |
+| --- | --- | --- |
+| CSV, TSV, JSON | Dataset source card with structural counts; bounded field names for JSON | `query_dataset` reads rows, filters, nested JSON fields and aggregates from the original |
+| YAML/YML, JSONL/NDJSON, XML, TOML | Literal UTF-8 text preview | Original download; these formats do not gain structured query support |
+| Other permitted files | Original and source companion | Extraction depends on the installed media/document capability |
+
+For example, uploading `readings.csv` creates `readings.csv.md` with the
+`dataset-export` source kind and a `data_file` pointer. Search discovers that
+card, including with `file_types: [csv]`. Use its `data_file` with
+`query_dataset(aggregate="sum:reading")` for a computed total. The card can be
+cited as a source. Individual row values stay out of its automatic preview.
+
+Dataset inspection uses at most 1 MiB and 10,000 records. JSON lists at most 64
+fields, each shortened to 256 characters. CSV/TSV cards omit header labels, since a headerless first data row can look like a header. These cards state the first-record-as-header assumption and show column and parsed-record counts; authorized queries expose the actual fields. A 100,000-cell CSV/TSV shape budget prevents wide headers with short rows from expanding inspection memory. JSON field discovery samples the first
+500 records; a larger record set or shortened field listing is marked `limited`.
+JSON nesting beyond 64 levels is unavailable for automatic inspection. Exact
+queries retain their separate 25 MiB input, 10,000 parsed-record and bounded
+response limits.
+
+Literal previews inspect the first 64 KiB. They show truncation explicitly and
+reject malformed UTF-8 within the inspected prefix instead of substituting
+corrupted text. YAML tags and XML entities are displayed as data; inspection
+does not evaluate them or fetch references. Caller-provided text extraction
+retains its existing behavior for these formats.
+
+Oversize or malformed inspection does not discard an otherwise permitted
+upload. The card reports `byte_limit`, `row_limit`, `invalid_encoding` or
+`invalid_data` or `shape_limit` without inventing a schema. Download still returns the original
+bytes. A successful preview does not promise that every later query is valid.
+
+The card retains normal source governance. Uploading a dataset does not assert
+reviewed semantic classification for its raw bytes: policies that need that
+classification continue to withhold raw reads until the existing owner-reviewed
+`backfill_companion` flow supplies it. Path-based policies remain effective.
+
+These previews require no GPU, model, additional package or network service.
+Historical companions are not rewritten, and this core capability does not
+activate a hosted worker or change a deployment. Mutable ongoing datasets belong
+to the separate [Records](records.md) workflow.

--- a/openspec/changes/add-first-class-source-datasets/.openspec.yaml
+++ b/openspec/changes/add-first-class-source-datasets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/add-first-class-source-datasets/design.md
+++ b/openspec/changes/add-first-class-source-datasets/design.md
@@ -1,0 +1,40 @@
+## Context
+
+See proposal.md for the ingestion gap. The query engine accepts CSV, TSV and JSON with byte, row and response limits. Governance resolves these files through a unique `type: dataset` card with `data_file`, format and a closed descriptor bound to the exact original. Raw dataset rows are excluded from ordinary recall.
+
+## Goals / Non-Goals
+
+Create useful, citable source discovery within the existing atomic evidence writer. Inspection must consume the writer's private staged bytes, never reopen a published pathname or invoke a model. Keep upload-time memory and work modest.
+
+This change does not migrate existing companions, add dataset mutations, activate a hosted worker, or change Records and Planning discovery. Existing standalone source import and file-watcher reconciliation are not additional entrypoints in this change.
+
+## Decisions
+
+### Dataset cards belong to the canonical evidence writer
+
+Extend the shared sidecar renderer with an explicit dataset projection. Cards retain `type: source`, `source_type: dataset-export`, existing source tags, citation eligibility, capture and adoption metadata. `source_type: dataset-export`, `data_file` and format identify the dataset source card. The dataset companion locator accepts this explicit shape alongside legacy `type: dataset` cards. New cards carry exact provenance but omit a governance descriptor until owner-reviewed classification. Originals and cards remain one create-only publication batch. Reusing this path covers streaming upload, direct preservation and client evidence adoption without a new API.
+
+Automatic inspection reuses the existing row parser under a smaller 1 MiB input budget. A streaming CSV/TSV preflight caps the padded table shape at 100,000 cells before row dictionaries are allocated, preventing a wide header and many short rows from amplifying small input into large memory use. A successful card records the exact parsed row count. JSON cards show at most 64 observed field names, each bounded to 256 characters. CSV/TSV cards show column count but omit header labels: without an explicit header declaration, the first record can be sensitive data. The existing exact parser assumes a header, which the card states; header content remains behind authorized queries. Schema sampling/truncation is explicit. No row values or numeric/categorical summaries are copied into the card. Exact answers continue through `query_dataset`, whose existing limits and authorization remain unchanged. Caller-supplied extracted text is omitted from dataset cards; the description remains a caller-authored caption.
+
+Unavailable inspection produces a card with a stable status code and no fabricated row count. Oversize, malformed, excessive-row, invalid encoding and excessive nesting outcomes preserve the original. Error messages from parsers are not persisted. An upload-time preview budget is distinct from the larger exact-query budget.
+
+### Literal text previews keep binary companion compatibility
+
+YAML, YML, JSONL, NDJSON, XML and TOML are a separate explicit literal-text allowlist in a small dependency-free inspection module. Read at most 64 KiB plus a UTF-8 boundary/lookahead allowance, use strict decoding, and visibly mark truncation. Use a code fence longer than every backtick run in the original prefix so Markdown and graph scanners both treat the preview literally. Treat syntax, tags, entities and formulas as data; perform no format evaluation, file resolution or network fetch.
+
+Keep `media_types` unchanged: classifying these extensions as media would invalidate historical binary companion descriptors and require migration. The preview is written by preserve from its private stage and needs no media job. Existing caller-provided extraction remains supported for these source formats.
+
+### Preserve the governance boundary
+
+A dataset upload does not supply reviewed semantic classification. Automatically asserting empty semantics would change previously unresolved raw datasets into unmatched, fully released content under semantic-only policies. New dataset source cards therefore omit the descriptor: existing owner-only receipt-first companion backfill supplies it when classification is wanted. Policy-free and path/ref-only queries continue to work; still-undecided semantic scopes continue to withhold raw reads. The source page retains its existing type and tags, so its new preview obeys existing source policies and remains a valid citation. Dataset format/path values are safely serialized. Missing, duplicate or stale cards continue to fail closed under existing companion classification. No existing card is adopted or overwritten. Raw datasets and Records/Planning exclusion behavior are unchanged.
+
+## Risks / Trade-offs
+
+- A dataset larger than the automatic budget has a discoverable card without a schema; an explicit bounded query may still work within the query engine's larger budget.
+- Field names can be sensitive and are content. They appear only in the governed companion and are bounded and escaped as literal text.
+- Historical generic companions remain historical. Converting them requires a separately authorized migration that respects immutable evidence; this release does not silently rewrite them.
+- JSONL is searchable literal text in this change, not a new structured query format. YAML and XML are not evaluated.
+
+## Migration Plan
+
+Deliver the core behavior through a reviewed PR and the normal release process. Test new captures, original-byte identity, governed discovery and exact reads, failure cases, and legacy compatibility. Deploying or activating the hosted service is separate. Rolling back stops new inspection. Source cards remain discoverable and citable; a rollback also removes recognition of the new dataset source-card variant for raw semantic classification, so those raw reads fail closed until the matching code returns.

--- a/openspec/changes/add-first-class-source-datasets/proposal.md
+++ b/openspec/changes/add-first-class-source-datasets/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+CSV, TSV and JSON already have a bounded structured query engine, but preserved uploads receive generic source pages instead of the dataset cards required for discovery and governed dataset reads. Common textual exports also retain their bytes without making their content searchable.
+
+## What Changes
+
+- Create an addressable dataset card atomically with each new CSV, TSV or JSON evidence upload. Bind it to the original bytes and expose bounded structural metadata without copying rows into semantic search.
+- Reuse the existing structured query operation for exact rows, filters and aggregates.
+- Give new YAML, YML, JSONL, NDJSON, XML and TOML evidence uploads a bounded literal text preview with explicit truncation or encoding status.
+- Preserve originals when automatic inspection cannot complete; distinguish byte preservation, discovery and exact query support.
+- Keep existing companions and media classification unchanged. This adds no model, service, package dependency or hosted activation.
+
+## Capabilities
+
+### New Capabilities
+
+- `structured-source-preservation`: Atomic, bounded dataset cards and literal text previews for newly preserved evidence uploads.
+
+### Modified Capabilities
+
+- `governance-kernel`: Accept explicitly marked dataset source cards alongside legacy dataset pages; retain unresolved artifact semantics until owner-reviewed classification.
+
+## Impact
+
+The shared preserve leaf used by direct preservation, uploaded bytes and client evidence artifacts gains deterministic inspection of its private staged bytes. Dataset cards follow the existing governance companion format; ordinary recall continues to exclude raw dataset files. Existing file imports and historical companion migration are outside this change.

--- a/openspec/changes/add-first-class-source-datasets/specs/governance-kernel/spec.md
+++ b/openspec/changes/add-first-class-source-datasets/specs/governance-kernel/spec.md
@@ -1,0 +1,171 @@
+## MODIFIED Requirements
+
+### Requirement: Query-time scope membership
+
+Scope membership SHALL be evaluated at query time against an already-parsed Markdown
+page or an explicit non-Markdown classification outcome using the scope's selectors
+(path globs, projects, tags, types, detector classes, explicit refs) minus its `exclude`
+selectors, memoized per immutable content identity and policy fingerprint. Membership
+SHALL NOT be materialized as an index-time table and SHALL NOT add a component to the
+deletion/upsert fan-out. A policy change SHALL invalidate membership by fingerprint
+mismatch.
+
+Non-Markdown membership SHALL distinguish `CLASSIFIED(scope_ids)` from `UNRESOLVED`.
+For each scope, a path/ref exclusion SHALL first prove exclusion and a path/ref positive
+SHALL next prove membership without semantic metadata. Only a still-undecided scope
+whose positive selectors include project, tag, type, or class requires a valid companion.
+If that companion is missing, malformed, unreadable, stale, or unsafe, the entire
+artifact classification SHALL be `UNRESOLVED`. Missing companion metadata MUST NOT be
+interpreted as empty metadata or an empty scope set. Every release, structured-read,
+proposal, and grant-drift caller SHALL translate `UNRESOLVED` to the fail-closed
+L0/missing contract. A policy containing only path/ref selectors remains classifiable
+without a companion.
+
+Semantic companions SHALL be located and bound by a closed artifact-class registry:
+ordinary/media binaries use the sibling `<artifact-leaf>.md`; datasets use the unique
+canonical card whose normalized `data_file` equals the artifact path and whose shape is either legacy `type: dataset` or `type: source` with explicit `source_type: dataset-export`; and a
+scene frame uses its sibling `<frame-leaf>.md` inside the canonical
+`<parent-media>.frames/` directory. Every valid companion SHALL carry a versioned
+`governance_companion` descriptor with `state: classified`. Its immutable binding tuple
+SHALL contain class, normalized artifact path, artifact SHA-256, and byte size; media also
+contains media type and original filename; dataset also contains declared format; and a
+scene frame also contains parent path/hash and an integer frame timestamp that agrees with
+the canonical filename. That field SHALL be named `frame_timestamp_ms`, have integer
+range `0..4_294_967_295`, and equal the integer milliseconds encoded in
+`scene-<NNN>-t<frame_timestamp_ms>ms.jpg`. The descriptor SHALL also contain an exact `semantics` mapping
+whose only keys are canonical string lists `projects`, `tags`, `types`, and `classes`;
+these values classify the artifact and are distinct from metadata classifying the
+companion page. The artifact and companion SHALL be canonical regular files read
+from immutable snapshots. Zero/multiple dataset cards, a missing/incomplete descriptor,
+binding mismatch, unsafe locator, changed bytes, or frame-parent/timestamp mismatch SHALL
+be `UNRESOLVED` for every still-undecided semantic scope.
+
+A descriptor with `state: classified`, a valid binding tuple, and all four semantic lists
+deliberately empty SHALL be the only valid explicitly empty semantic companion.
+Missing semantic keys without that marker MUST NOT mean empty. Pre-descriptor legacy media
+sidecars—including the minimal stubs emitted by `preserve.py`, pending worker sidecars, and
+completed transcripts—SHALL remain classifiable by path/ref policy only.
+
+Backfill SHALL require an owner-authorized, receipt-first
+`govern_memory(operation="backfill_companion")` proposal/commit. Version-1 input SHALL
+contain exactly the artifact class, canonical artifact path, expected artifact SHA-256
+and size, expected companion path and SHA-256, complete explicit four-list `semantics`,
+and every class-specific binding field. The trusted adapter SHALL establish the local
+owner. Companion-page tags/projects/type/classes, artifact metadata, policy, model text,
+dataset rows, and media jobs MUST NOT authorize backfill or be inferred into artifact
+semantics. Preview SHALL return the exact target descriptor and immutable identities;
+commit SHALL revalidate them under the no-follow mutation boundary, write only the
+descriptor, and record owner, proposal, prior/target hashes, and terminal outcome. It
+SHALL preserve transcript/body, page-level metadata, and processing state, infer neither
+non-empty nor empty semantics, remain idempotent only for the same committed input, and
+refuse without partial metadata on ambiguity or drift.
+
+Legacy scene-frame conversion SHALL parse finite non-negative `frame_ts`, calculate
+`int(round(binary64(frame_ts) * 1000))` using round-to-nearest-ties-to-even, require the
+bounded result to equal both the filename milliseconds and indexed frame timestamp, and
+then store `frame_timestamp_ms`. A negative, non-finite, out-of-range, ambiguously
+indexed, or disagreeing value SHALL refuse. After migration, the float SHALL NOT be
+membership authority. New companions SHALL carry the descriptor at creation, except automatically captured dataset source cards whose artifact semantics have not been owner-reviewed; those cards SHALL omit the descriptor and remain unresolved for still-undecided semantic scopes.
+
+#### Scenario: Selector kinds resolve membership
+
+- **WHEN** a page matches a scope by any selector kind and is not caught by an
+  `exclude` selector
+- **THEN** the page is a member of that scope
+
+#### Scenario: Policy change invalidates the memo
+
+- **WHEN** the policy fingerprint changes
+- **THEN** previously memoized membership is recomputed against the new policy
+
+#### Scenario: Missing companion under semantic-only scope is unresolved
+
+- **WHEN** a non-Markdown artifact has no companion Markdown and a non-excluded scope
+  can select it only by project, tag, type, or class
+- **THEN** membership is `UNRESOLVED`, every non-owning content/structured surface treats
+  the artifact as L0/missing, and no caller receives an empty-scope open decision
+
+#### Scenario: Malformed companion is also unresolved
+
+- **WHEN** the required companion exists but cannot be parsed, read consistently, or
+  tied to the artifact's immutable identity
+- **THEN** membership fails closed identically to a missing companion
+
+#### Scenario: Path-only policy needs no companion
+
+- **WHEN** every scope uses only path/ref selectors and exclusions and a non-Markdown
+  artifact matches none of them
+- **THEN** membership is the classified empty set and the existing unmatched default
+  applies
+
+#### Scenario: Path exclusion proves semantic scope exclusion
+
+- **WHEN** a non-Markdown artifact matches a scope's path/ref exclusion before semantic
+  selectors are needed
+- **THEN** that scope is proven excluded without requiring companion metadata
+
+#### Scenario: A path match does not erase an unresolved sibling scope
+
+- **WHEN** a path/ref selector proves membership in scope A while semantic-only scope B
+  cannot be evaluated because companion metadata is missing
+- **THEN** the artifact remains `UNRESOLVED` and a grant for A cannot make it public
+
+#### Scenario: Explicitly empty companion is classified only when bound
+
+- **WHEN** a non-Markdown artifact's canonical companion carries `state: classified`, no
+  semantic selector values, and the complete tuple matches its immutable artifact snapshot
+- **THEN** the semantic result is a valid explicit empty classification rather than
+  unresolved
+
+#### Scenario: Legacy preserve stub needs verified backfill
+
+- **WHEN** a `preserve.py` legacy media stub or pending/completed sidecar lacks the complete
+  descriptor under an applicable semantic-only scope
+- **THEN** the artifact is unresolved until backfill verifies and binds the current binary,
+  and backfill preserves the existing body and processing state
+
+#### Scenario: Backfill semantics require explicit owner input
+
+- **WHEN** a legacy companion page has tags/projects/type/classes but the reviewed
+  backfill input omits or differs from its explicit artifact `semantics`
+- **THEN** Exomem does not copy page metadata, refuses incomplete input, and writes no
+  descriptor without an authenticated owner proposal and receipt-backed commit
+
+#### Scenario: Backfill race is receipt-first and atomic
+
+- **WHEN** artifact, companion, parent, dataset card, or expected bytes drift after
+  preview or the operation crashes at any receipt/mutation boundary
+- **THEN** state is exact prior or the one reviewed descriptor with a recoverable
+  terminal; no partial tuple or inferred semantics appears
+
+#### Scenario: Dataset card is unique and content-bound
+
+- **WHEN** no card, two cards, or a stale card points at the same dataset, or its declared
+  format/hash/size does not match the immutable data snapshot
+- **THEN** dataset membership is unresolved and no row, aggregate, profile, count, or parse
+  diagnostic crosses the boundary
+
+#### Scenario: Scene frame binds its parent and timestamp
+
+- **WHEN** a scene-frame companion's parent hash/path or timestamp differs from the frame
+  directory, canonical filename, or current parent snapshot
+- **THEN** both semantic membership and the frame-to-parent recall mapping are unresolved
+
+#### Scenario: Legacy frame timestamp migration is canonical
+
+- **WHEN** a legacy finite `frame_ts` rounds ties-to-even to the same bounded integer
+  milliseconds encoded in the canonical filename and index
+- **THEN** owner-reviewed backfill stores that exact `frame_timestamp_ms`; any rounding,
+  range, filename, parent, or index mismatch refuses without choosing a source
+
+
+#### Scenario: Dataset source card retains unreviewed semantics
+
+- **WHEN** a new evidence upload produces a `type: source`, `source_type: dataset-export` card without a governance descriptor
+- **THEN** its source type and tags govern the Markdown card and it remains eligible as a source citation
+- **AND** raw dataset membership stays unresolved for still-undecided semantic scopes until owner-reviewed receipt-first backfill supplies a bound descriptor
+
+#### Scenario: Mixed dataset card variants are ambiguous
+
+- **WHEN** a legacy dataset page and an explicitly marked dataset source card both identify the same original
+- **THEN** classification and companion backfill refuse the duplicate set without choosing one variant

--- a/openspec/changes/add-first-class-source-datasets/specs/structured-source-preservation/spec.md
+++ b/openspec/changes/add-first-class-source-datasets/specs/structured-source-preservation/spec.md
@@ -1,0 +1,81 @@
+## Purpose
+
+Make newly preserved structured files discoverable and useful while retaining exact original bytes and bounded, governed access to their content.
+
+## ADDED Requirements
+
+### Requirement: Dataset preservation creates a bound discovery card
+
+New CSV, TSV and JSON evidence captures SHALL publish their original bytes and an addressable dataset card in the same create-only batch. The card MUST identify the original path, format, hash and byte size and use the explicit dataset source-card shape (`type: source`, `source_type: dataset-export`, `data_file`, `format`). It SHALL remain a citable source governed by its existing source type and tags. Automatic capture MUST NOT assert reviewed artifact semantics: a missing descriptor remains unresolved wherever semantic classification is required. The system MUST NOT inline dataset rows or caller-supplied extracted text into automatic dataset cards.
+
+#### Scenario: Discover and query an uploaded table
+- **WHEN** a valid table is preserved through a supported evidence capture entrypoint
+- **THEN** ordinary source discovery can find its dataset card and authorized exact queries can read the original table
+- **AND** downloading the original returns the uploaded bytes unchanged
+- **AND** raw table rows do not become semantic search documents
+
+#### Scenario: Ambiguous or changed dataset identity
+- **WHEN** a dataset has duplicate cards or the bound original bytes change
+- **THEN** existing governed raw-content classification fails closed
+- **AND** automatic preservation does not weaken that refusal
+
+### Requirement: Automatic dataset inspection is bounded and truthful
+
+Automatic cards SHALL expose only bounded structural metadata: parsed row count, column count, and bounded JSON field names. CSV/TSV header labels MUST NOT be copied into automatic cards because a headerless first data record cannot be distinguished reliably from a header. The first-record-as-header assumption used by exact tabular queries SHALL be explicit. Automatic inspection MUST use at most 1 MiB of original input, at most the existing 10,000 parsed rows, a CSV/TSV padded table shape of at most 100,000 cells, at most 64 displayed fields and at most 256 characters per field. Cards MUST distinguish available, limited and unavailable inspection without inventing counts or claiming exact query support for malformed content. Exact query limits remain independent.
+
+#### Scenario: Valid nested JSON
+- **WHEN** the existing JSON parser can locate records within the automatic inspection budget
+- **THEN** the card identifies the observed fields and parsed row count
+- **AND** existing nested-field query behavior remains available
+
+#### Scenario: Inspection cannot complete
+- **WHEN** a capture exceeds inspection limits or has malformed, non-UTF-8 or excessively nested data
+- **THEN** preservation succeeds within the upload limit with a truthful inspection status
+- **AND** the original is retained without raw parser errors or fabricated schema metadata in the card
+
+### Requirement: Common text exports receive literal previews
+
+New YAML, YML, JSONL, NDJSON, XML and TOML evidence uploads SHALL receive a literal UTF-8 preview bounded to 64 KiB of original input when no caller extraction is supplied. Truncation and invalid encoding MUST be explicit. Inspection MUST NOT execute document instructions, expand entities, resolve local references or access the network.
+
+#### Scenario: Search a text export
+- **WHEN** a UTF-8 text export is preserved
+- **THEN** its bounded preview is available through the governed source companion
+- **AND** the original remains byte-exact
+
+#### Scenario: Large or invalid text
+- **WHEN** an export is too large for the preview or contains invalid UTF-8 within the inspected prefix
+- **THEN** the companion records truncation or unavailable encoding status
+- **AND** preservation retains the original without falsely claiming full-content indexing
+
+### Requirement: Existing privacy and compatibility boundaries remain intact
+
+Inspection SHALL run locally without additional packages, models or network services. Newly supported literal formats MUST retain their existing binary companion class. Existing source companions MUST NOT be migrated or overwritten implicitly. Ordinary Records and Planning recall exclusions and authorization before raw dataset parsing MUST remain effective.
+
+#### Scenario: Historical companion remains valid
+- **WHEN** an existing literal-format artifact has a valid binary companion
+- **THEN** introducing automatic previews for new captures does not invalidate or rewrite that companion
+
+#### Scenario: Dataset is excluded from a reader
+- **WHEN** governance excludes the uploaded dataset from the requesting reader
+- **THEN** its rows and aggregates remain unavailable before parsing
+- **AND** its generated card does not bypass governed retrieval
+
+
+### Requirement: Sparse tabular inputs cannot amplify inspection memory
+
+Automatic CSV/TSV inspection SHALL refuse table shapes exceeding 100,000 cells before allocating padded row dictionaries. This inspection limit MUST preserve the original with a stable `shape_limit` status and leave exact query limits unchanged.
+
+#### Scenario: Wide header with many short records
+- **WHEN** a small uploaded CSV declares many fields followed by enough short records to exceed the padded-cell budget
+- **THEN** automatic inspection reports `shape_limit` without allocating the amplified table
+- **AND** the original upload remains preserved
+
+
+### Requirement: Ambiguous tabular headers stay behind exact queries
+
+Automatic CSV/TSV source cards MUST NOT publish the first record as field labels. Discovery SHALL use the source filename, caption, format and structural counts; exact header and record content remains available through authorized structured reads.
+
+#### Scenario: Headerless CSV first record contains sensitive values
+- **WHEN** a headerless CSV is uploaded without explicit format metadata
+- **THEN** no first-record values are copied into its source card
+- **AND** the card states the header assumption and records structural counts

--- a/openspec/changes/add-first-class-source-datasets/tasks.md
+++ b/openspec/changes/add-first-class-source-datasets/tasks.md
@@ -7,5 +7,5 @@
 ## 2. Compatibility and delivery
 
 - [x] 2.1 Verify companion identity, withheld raw reads, atomic rollback and legacy classification with preservation and governance suites; obtain independent review of the implementation.
-- [ ] 2.2 Document format behavior and run completion checks, strict OpenSpec validation and the public-artifact gate; commit and push a ready PR with CI evidence.
-- [ ] 2.3 After merge authority and successful integration, synchronize and archive this change through OpenSpec; verify strict validation before and after closure.
+- [x] 2.2 Document format behavior, record local test/build/lint evidence, run strict OpenSpec validation and the public-artifact gate, and deliver a committed, pushed, ready PR.
+- [ ] 2.3 After full CI passes, merge authority and successful integration, synchronize and archive this change through OpenSpec; verify strict validation before and after closure.

--- a/openspec/changes/add-first-class-source-datasets/tasks.md
+++ b/openspec/changes/add-first-class-source-datasets/tasks.md
@@ -1,0 +1,11 @@
+## 1. Capture behavior
+
+- [x] 1.1 Add failing tests for dataset upload, governed discovery, exact queries and byte identity; record the failing assertions before implementation.
+- [x] 1.2 Implement bounded dataset cards in the shared preservation path; verify CSV, TSV, nested JSON, parse limits and no row-value copying with scoped tests.
+- [x] 1.3 Implement bounded literal previews for the explicit text export formats; verify encoding, truncation, inert syntax and unchanged original bytes with scoped tests.
+
+## 2. Compatibility and delivery
+
+- [x] 2.1 Verify companion identity, withheld raw reads, atomic rollback and legacy classification with preservation and governance suites; obtain independent review of the implementation.
+- [ ] 2.2 Document format behavior and run completion checks, strict OpenSpec validation and the public-artifact gate; commit and push a ready PR with CI evidence.
+- [ ] 2.3 After merge authority and successful integration, synchronize and archive this change through OpenSpec; verify strict validation before and after closure.

--- a/src/exomem/find_types.py
+++ b/src/exomem/find_types.py
@@ -142,7 +142,11 @@ class ParsedPage:
 
     @property
     def file_kind(self) -> str:
-        if self.page_type == "dataset":
+        if self.page_type == "dataset" or (
+            self.page_type == "source"
+            and self.frontmatter.get("source_type") == "dataset-export"
+            and self.frontmatter.get("data_file")
+        ):
             fmt = self.frontmatter.get("format")
             return str(fmt).lower() if fmt else "dataset"
         if self.media_type:

--- a/src/exomem/governance/companions.py
+++ b/src/exomem/governance/companions.py
@@ -240,7 +240,13 @@ def _dataset_cards(vault_root, artifact_path: str):
             continue
         if (
             marker is not None
-            and frontmatter.get("type") == "dataset"
+            and (
+                frontmatter.get("type") == "dataset"
+                or (
+                    frontmatter.get("type") == "source"
+                    and frontmatter.get("source_type") == "dataset-export"
+                )
+            )
             and frontmatter.get("data_file") == artifact_path
         ):
             cards.append(

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -39,6 +39,7 @@ from typing import IO, BinaryIO
 
 from . import indexes, memory_refs, privacy_log, semantic_contract, temporal
 from .kbdir import kb_prefix
+from .source_inspection import Inspection, inspect_source
 from .vault import (
     MISSING_CONTENT_HASH,
     ContentHashMismatchError,
@@ -378,6 +379,16 @@ def preserve(
         # the sidecar belongs alongside, not as a double-ext twin of the artifact.
         desc_clean = description.strip() if description and description.strip() else None
         text_clean = text.strip() if text and text.strip() else None
+        inspection = inspect_source(
+            artifact_stage, filename=filename_safe, size=artifact_size
+        )
+        if inspection is not None and inspection.dataset_format:
+            if text_clean:
+                warnings.append("dataset extracted text omitted; use exact queries for row values")
+            text_clean = None
+        elif text_clean:
+            # An explicit uploader extraction keeps its existing behavior.
+            inspection = None
         # A media binary (audio/video/image/pdf) with no provided text gets a STUB
         # sidecar — pointer + media_type + `extracted_by: pending` — so it's a
         # first-class find() result immediately and the extraction worker fills the
@@ -447,6 +458,7 @@ def preserve(
                 governance_artifact_size=artifact_size,
                 tree="Evidence",
                 adoption_receipt=adoption_receipt,
+                inspection=inspection,
             )
             sidecar_ref = memory_refs.ref_from_markdown(sidecar_md)
             writes.append(
@@ -777,6 +789,7 @@ def _render_sidecar(
     governance_frame_timestamp_ms: int | None = None,
     tree: str = "Evidence",
     adoption_receipt: Mapping[str, object] | None = None,
+    inspection: Inspection | None = None,
 ) -> str:
     """Sidecar .md describing a preserved binary artifact.
 
@@ -801,20 +814,33 @@ def _render_sidecar(
     vectors own visual search).
     """
     lines = ["---"]
+    dataset_format = inspection.dataset_format if inspection is not None else None
+    if dataset_format and governance_artifact_path is None:
+        raise ValueError("dataset card requires an exact artifact binding")
     lines.append("type: source")
     lines.append(f"exomem_id: {memory_refs.new_id()}")
     label = _ARTIFACT_TREE_LABELS.get(tree, "Evidence")
     display_title = f"{label}: {artifact_name}"
     lines.append(f"title: {yaml_scalar(display_title)}")
-    lines.append("source_type: other")
+    lines.append("source_type: dataset-export" if dataset_format else "source_type: other")
     lines.append(f"captured: {date_iso}")
+    if inspection is not None:
+        lines.append(f"inspection_status: {inspection.status}")
+    if dataset_format:
+        lines.append(f"data_file: {yaml_scalar(governance_artifact_path)}")
+        lines.append(f"format: {dataset_format}")
+        if inspection.rows is not None:
+            lines.append(f"rows: {inspection.rows}")
     if media_type:
         lines.append(f"media_type: {media_type}")
     if evidence_file:
         lines.append(f"evidence_file: {evidence_file}")
     if extracted_by:
         lines.append(f"extracted_by: {extracted_by}")
-    if governance_artifact_path is not None:
+    # Upload supplies byte identity, not a reviewed semantic classification.
+    # Dataset backfill can add the descriptor after an owner review. Retaining
+    # unresolved semantics prevents new raw releases under semantic policies.
+    if governance_artifact_path is not None and not dataset_format:
         if governance_artifact_sha256 is None or governance_artifact_size is None:
             raise ValueError("governance companion requires an exact artifact identity")
         scene_binding = any(
@@ -900,6 +926,11 @@ def _render_sidecar(
         lines.append("")
         lines.append(description)
         lines.append("")
+    if inspection is not None:
+        lines.extend([
+            "## Dataset" if dataset_format else "## Text preview",
+            "", inspection.body, "",
+        ])
     # Emit the section when there's extracted text, or as an empty anchor for a
     # media stub the worker will fill. A pure-description (non-media) sidecar omits it.
     if text or media_type:

--- a/src/exomem/source_inspection.py
+++ b/src/exomem/source_inspection.py
@@ -1,0 +1,186 @@
+"""Bounded, local inspection of privately staged evidence bytes.
+
+These projections describe content; they neither classify its policy nor
+evaluate document syntax. Dataset values stay in the exact-query path.
+"""
+
+from __future__ import annotations
+
+import codecs
+import csv
+import html
+import io
+import itertools
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+from . import query_data
+
+DATASET_PREVIEW_BYTES = 1024 * 1024
+TEXT_PREVIEW_BYTES = 64 * 1024
+MAX_FIELDS = 64
+MAX_FIELD_CHARS = 256
+MAX_JSON_DEPTH = 64
+MAX_TABLE_CELLS = 100_000
+LITERAL_SUFFIXES = frozenset({".yaml", ".yml", ".jsonl", ".ndjson", ".xml", ".toml"})
+
+
+@dataclass(frozen=True)
+class Inspection:
+    status: str
+    body: str
+    dataset_format: str | None = None
+    rows: int | None = None
+
+
+def inspect_source(stream: BinaryIO, *, filename: str, size: int) -> Inspection | None:
+    """Inspect a bounded prefix and restore the private stage's seek position."""
+    suffix = Path(filename).suffix.lower()
+    if suffix not in query_data.ALLOWED_SUFFIXES and suffix not in LITERAL_SUFFIXES:
+        return None
+    position = stream.tell()
+    try:
+        stream.seek(0)
+        if suffix in query_data.ALLOWED_SUFFIXES:
+            if size > DATASET_PREVIEW_BYTES:
+                return _dataset_unavailable(suffix, "byte_limit")
+            data = stream.read(DATASET_PREVIEW_BYTES + 1)
+            if len(data) > DATASET_PREVIEW_BYTES:
+                return _dataset_unavailable(suffix, "byte_limit")
+            return _inspect_dataset(data, suffix)
+        return _inspect_literal(stream.read(TEXT_PREVIEW_BYTES + 3))
+    finally:
+        stream.seek(position)
+
+
+def _dataset_unavailable(suffix: str, status: str) -> Inspection:
+    return Inspection(
+        status,
+        "Automatic schema inspection unavailable: " + status + ". "
+        "The original is preserved. Exact queries have separate format and size limits.",
+        dataset_format=suffix[1:],
+    )
+
+
+def _literal_field(value: str) -> str:
+    # JSON quoting prevents newlines; escaping Markdown/HTML prevents field
+    # names from creating links, frontmatter, headings or rendered markup.
+    encoded = html.escape(json.dumps(value, ensure_ascii=False), quote=False)
+    for char in "`[]\\":
+        encoded = encoded.replace(char, f"&#{ord(char)};")
+    return f"`{encoded}`"
+
+
+def _inspect_dataset(data: bytes, suffix: str) -> Inspection:
+    try:
+        data.decode("utf-8")  # distinguish encoding from format, including JSON
+    except UnicodeDecodeError:
+        return _dataset_unavailable(suffix, "invalid_encoding")
+    if suffix == ".json" and _json_too_deep(data):
+        return _dataset_unavailable(suffix, "invalid_data")
+    try:
+        if suffix in {".csv", ".tsv"} and _table_shape_exceeds_budget(data, suffix):
+            return _dataset_unavailable(suffix, "shape_limit")
+        fmt, rows, columns, _warnings = query_data.load_rows_bytes(data, suffix)
+    except query_data.QueryDataError as error:
+        status = "row_limit" if error.code == "TOO_MANY_ROWS" else "invalid_data"
+        return _dataset_unavailable(suffix, status)
+    except (csv.Error, RecursionError, ValueError):
+        return _dataset_unavailable(suffix, "invalid_data")
+
+    if fmt in {"csv", "tsv"}:
+        return Inspection(
+            "ready",
+            f"Parsed records: {len(rows)}.\n\nObserved columns: {len(columns)}.\n\n"
+            "The first record is assumed to be a header by the tabular query parser. "
+            "Header labels are omitted here because a headerless first record can contain data. "
+            "Use query_dataset with data_file for authorized fields, rows and aggregates.",
+            fmt,
+            len(rows),
+        )
+
+    # JSON column inference observes the first 500 records. Describe that
+    # sampling explicitly rather than claiming a complete schema.
+    sampled = fmt == "json" and len(rows) > 500
+    limited = sampled or len(columns) > MAX_FIELDS
+    fields = []
+    for column in columns[:MAX_FIELDS]:
+        if len(column) > MAX_FIELD_CHARS:
+            limited = True
+        fields.append(_literal_field(column[:MAX_FIELD_CHARS]))
+    body = [f"Parsed records: {len(rows)}.", "", "Observed fields:"]
+    body.extend(f"- {field}" for field in fields)
+    if not fields:
+        body.append("No fields observed.")
+    if limited:
+        body.extend(["", "Field listing is limited or sampled; use an exact query to inspect records."])
+    body.extend(["", "Use query_dataset with data_file for exact rows, filters and aggregates. "
+                 "Row values are not copied into this card."])
+    return Inspection("limited" if limited else "ready", "\n".join(body), fmt, len(rows))
+
+
+def _table_shape_exceeds_budget(data: bytes, suffix: str) -> bool:
+    """Bound DictReader's missing-field padding before allocating its rows."""
+    with io.StringIO(data.decode("utf-8"), newline="") as stream:
+        reader = csv.reader(stream, delimiter="\t" if suffix == ".tsv" else ",")
+        header = next(reader, [])
+        cells = len(header)
+        if cells > MAX_TABLE_CELLS:
+            return True
+        nonempty_rows = (row for row in reader if row)
+        for row in itertools.islice(nonempty_rows, query_data.MAX_PARSED_ROWS + 1):
+            # DictReader skips empty rows and pads short records to header width.
+            cells += max(len(header), len(row))
+            if cells > MAX_TABLE_CELLS:
+                return True
+    return False
+
+
+def _json_too_deep(data: bytes) -> bool:
+    """Bound nesting before decoding; braces inside strings are ordinary data."""
+    depth = 0
+    quoted = escaped = False
+    for char in data:
+        if escaped:
+            escaped = False
+        elif quoted and char == 92:
+            escaped = True
+        elif char == 34:
+            quoted = not quoted
+        elif not quoted:
+            if char in (91, 123):
+                depth += 1
+                if depth > MAX_JSON_DEPTH:
+                    return True
+            elif char in (93, 125):
+                depth -= 1
+    return False
+
+
+def _inspect_literal(data: bytes) -> Inspection:
+    truncated = len(data) > TEXT_PREVIEW_BYTES
+    try:
+        # A non-final incremental decode retains a character split at the
+        # prefix boundary, but still rejects malformed bytes within it.
+        decoder = codecs.getincrementaldecoder("utf-8")("strict")
+        text = decoder.decode(data[:TEXT_PREVIEW_BYTES], final=not truncated)
+        pending = decoder.getstate()[0]
+        if pending:
+            width = 2 if pending[0] < 0xE0 else 3 if pending[0] < 0xF0 else 4
+            remaining = width - len(pending)
+            # Validate only the character that starts within the prefix. Its
+            # completed text stays omitted so output never exceeds the cap.
+            decoder.decode(data[TEXT_PREVIEW_BYTES:TEXT_PREVIEW_BYTES + remaining], final=True)
+    except UnicodeDecodeError:
+        return Inspection("invalid_encoding", "Text preview unavailable: invalid UTF-8. Original preserved.")
+    # A fence longer than any run in the input is literal to Markdown and to
+    # the substrate's graph/link scanner. Indentation alone does not mask
+    # wikilinks there; uploaded syntax must never manufacture graph edges.
+    fence = "`" * max(3, 1 + max((len(run) for run in re.findall(r"`+", text)), default=0))
+    body = f"{fence}text\n{text}\n{fence}"
+    if truncated:
+        body += "\n\n[Preview truncated at 64 KiB; the full content remains in the original.]"
+    return Inspection("truncated" if truncated else "ready", body)

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -360,6 +360,9 @@ def test_local_runtime_activation_waits_for_terminal_warm_after_catalog_failure(
 def test_disable_warmup_preserves_unverified_lazy_runtime_admission(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # Start before any warm-up; earlier tests in the same shard may leave
+    # process-global readiness from a different scenario behind.
+    readiness.reset()
     monkeypatch.setenv("EXOMEM_DISABLE_WARMUP", "1")
     vault = tmp_path / "vault"
     vault.mkdir()

--- a/tests/test_source_preservation.py
+++ b/tests/test_source_preservation.py
@@ -1,0 +1,307 @@
+"""New uploads expose bounded source discovery without changing their bytes."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import commands, embeddings, media_types, preserve, source_closure
+from exomem.governance import companions
+from exomem.vault import parse_frontmatter
+
+
+def _capture(vault: Path, filename: str, data: bytes, **kwargs):
+    result = preserve.preserve_stream(
+        vault, scope="Test", category="exports", filename=filename,
+        stream=io.BytesIO(data), **kwargs,
+    )
+    assert (vault / result.path).read_bytes() == data
+    assert result.hash == hashlib.sha256(data).hexdigest()
+    page = (vault / result.sidecar_path).read_text(encoding="utf-8")
+    frontmatter = parse_frontmatter(page, strict=True)[0]
+    return result, frontmatter, page
+
+
+@pytest.mark.parametrize(
+    ("filename", "data", "fmt"),
+    [
+        ("readings.csv", b"sensor_name,reading\nraw-value-sentinel,7\n", "csv"),
+        ("readings.TSV", b"sensor_name\treading\nraw-value-sentinel\t7\n", "tsv"),
+        ("readings.json", b'{"rows":[{"sensor_name":"raw-value-sentinel","reading":7}]}', "json"),
+    ],
+)
+def test_dataset_capture_is_discoverable_and_exactly_queryable(vault, filename, data, fmt):
+    result, fm, page = _capture(vault, filename, data, text="raw-extracted-sentinel")
+    assert fm["type"] == "source"
+    assert fm["source_type"] == "dataset-export"
+    assert fm["data_file"] == result.path
+    assert fm["format"] == fmt
+    assert fm["rows"] == 1
+    assert fm["inspection_status"] == "ready"
+    assert "raw-value-sentinel" not in page
+    assert "raw-extracted-sentinel" not in page
+    assert ("sensor_name" in page) == (fmt == "json")
+    assert "governance_companion" not in fm
+    assert not embeddings._is_embeddable_path(Path(result.path))
+    found = commands.op_find(vault, query="readings", mode="keyword", graph=False)
+    assert any(hit["path"] == result.sidecar_path for hit in found)
+    filtered = commands.op_find(
+        vault, query="readings", mode="keyword", graph=False, file_types=[fmt]
+    )
+    assert any(hit["path"] == result.sidecar_path for hit in filtered)
+    queried = commands.op_query_dataset(vault, path=result.path, aggregate="sum:reading")
+    assert queried["aggregate"]["sum"] == 7
+
+
+def test_nested_json_exact_fields_remain_queryable(vault):
+    data = b'{"items":[{"measurement":{"amount":12}},{"measurement":{"amount":3}}]}'
+    result, fm, page = _capture(vault, "nested.json", data)
+    assert fm["type"] == "source"
+    assert fm["source_type"] == "dataset-export"
+    assert fm["rows"] == 2
+    assert "measurement" in page
+    assert commands.op_query_dataset(
+        vault, path=result.path, aggregate="sum:measurement.amount"
+    )["aggregate"]["sum"] == 15
+
+
+@pytest.mark.parametrize(
+    ("filename", "data", "status"),
+    [
+        ("broken.json", b'{"private-parse-sentinel":', "invalid_data"),
+        ("broken.csv", b"column\n\xff\n", "invalid_encoding"),
+        ("deep.json", b"[" * 2000 + b"0" + b"]" * 2000, "invalid_data"),
+        ("rows.csv", b"column\n" + b"1\n" * 10001, "row_limit"),
+        ("large.json", b" " * (1024 * 1024 + 1), "byte_limit"),
+    ],
+    ids=["malformed", "encoding", "nesting", "rows", "bytes"],
+)
+def test_unavailable_dataset_inspection_still_preserves(vault, filename, data, status):
+    result, fm, page = _capture(vault, filename, data)
+    assert fm["type"] == "source"
+    assert fm["source_type"] == "dataset-export"
+    assert fm["inspection_status"] == status
+    assert "rows" not in fm
+    assert "private-parse-sentinel" not in page
+    assert "governance_companion" not in fm
+
+
+def test_dataset_fields_cannot_inject_frontmatter_or_unbounded_content(vault):
+    fields = {"\n---\ntype: note\n[[injected-link]]": "value", "x" * 5000: "value"}
+    fields.update({f"field_{i}": "row-value-sentinel" for i in range(70)})
+    result, fm, page = _capture(vault, "hostile.json", json.dumps([fields]).encode())
+    assert fm["type"] == "source"
+    assert fm["source_type"] == "dataset-export"
+    assert fm["inspection_status"] == "limited"
+    assert len(page.encode()) < 24000
+    assert "row-value-sentinel" not in page
+    assert "[[injected-link]]" not in page
+    assert "governance_companion" not in fm
+
+
+@pytest.mark.parametrize("suffix", ["yaml", "yml", "jsonl", "ndjson", "xml", "toml"])
+def test_literal_export_gets_searchable_preview(vault, suffix, monkeypatch):
+    import os
+
+    monkeypatch.setattr(os, "system", lambda *a: pytest.fail("source syntax executed"))
+    data = b'export-sentinel: !!python/object/apply:os.system ["never-execute"]\n'
+    result, fm, page = _capture(vault, f"export.{suffix}", data)
+    assert fm["inspection_status"] == "ready"
+    assert "export-sentinel" in page
+    assert fm["governance_companion"]["artifact_class"] == "binary"
+    assert media_types.media_type_for(f"export.{suffix}") is None
+    assert companions.classify(vault, result.path).projects == ()
+    found = commands.op_find(vault, query="export-sentinel", mode="keyword", graph=False)
+    assert any(hit["path"] == result.sidecar_path for hit in found)
+
+
+def test_text_preview_is_bounded_on_a_utf8_boundary(vault):
+    result, fm, page = _capture(vault, "large.yaml", "é".encode() * 40000)
+    assert fm["inspection_status"] == "truncated"
+    assert len(page.encode()) < 68000
+    assert "�" not in page
+    assert "truncated" in page
+
+
+def test_invalid_utf8_is_preserved_without_a_corrupted_preview(vault):
+    result, fm, page = _capture(vault, "encoding.yaml", b"private-prefix\xff")
+    assert fm["inspection_status"] == "invalid_encoding"
+    assert "private-prefix" not in page
+    assert "�" not in page
+
+
+def test_inspection_restores_stage_cursor_and_bounds_reads():
+    from exomem.source_inspection import inspect_source
+
+    class BoundedStage(io.BytesIO):
+        def read(self, size=-1):
+            assert 0 <= size <= 64 * 1024 + 3
+            return super().read(size)
+
+    data = b"a\n" * (1024 * 1024)
+    stage = BoundedStage(data)
+    stage.seek(7)
+    result = inspect_source(stage, filename="large.yaml", size=len(data))
+    assert result.status == "truncated"
+    assert stage.tell() == 7
+    assert inspect_source(stage, filename="large.csv", size=len(data)).status == "byte_limit"
+    assert stage.tell() == 7
+
+
+def test_csv_parser_field_limit_preserves_original(vault):
+    import csv
+
+    data = b"field\n" + b"x" * (csv.field_size_limit() + 1)
+    result, fm, page = _capture(vault, "wide.csv", data)
+    assert fm["inspection_status"] == "invalid_data"
+    assert "rows" not in fm
+
+
+@pytest.mark.parametrize("blank_lines", [0, 10002])
+def test_sparse_wide_csv_cannot_expand_into_unbounded_row_dictionaries(monkeypatch, blank_lines):
+    from exomem import query_data
+    from exomem.source_inspection import inspect_source
+
+    data = (",".join(f"field{i}" for i in range(6000)) + "\n" * (blank_lines + 1) + "x\n" * 20).encode()
+    monkeypatch.setattr(query_data, "load_rows_bytes", lambda *a, **kw: pytest.fail("amplifying shape parsed"))
+    assert inspect_source(io.BytesIO(data), filename="sparse.csv", size=len(data)).status == "shape_limit"
+
+
+def test_non_ascii_field_names_remain_searchable(vault):
+    result, fm, page = _capture(vault, "unicode.json", '[{"mätning": 3}]'.encode())
+    assert "mätning" in page
+    assert any(
+        hit["path"] == result.sidecar_path
+        for hit in commands.op_find(vault, query="mätning", mode="keyword", graph=False)
+    )
+
+
+def test_headerless_csv_cannot_publish_first_record_as_field_names(vault):
+    result, fm, page = _capture(vault, "headerless.csv", b"private-first-value,another-secret\nsecond,value\n")
+    assert "private-first-value" not in page
+    assert "another-secret" not in page
+    assert "Observed columns: 2" in page
+
+
+def test_literal_preview_cannot_create_graph_relationships(vault):
+    from exomem.vault import find_body_wikilinks
+
+    data = b'field: "[[Knowledge Base/Notes/Insights/forged]]"\n```\n[[second-forged]]\n'
+    result, fm, page = _capture(vault, "links.yaml", data)
+    assert not find_body_wikilinks(page)
+
+
+@pytest.mark.parametrize(
+    ("ending", "status"),
+    [(b"\xf0\x9f\x98\x80", "truncated"), (b"\xf0\x9f\xff", "invalid_encoding"), (b"\xf0\x9f", "invalid_encoding")],
+    ids=["complete", "invalid", "incomplete"],
+)
+def test_utf8_character_crossing_preview_boundary_is_validated(ending, status):
+    from exomem.source_inspection import inspect_source
+
+    data = b"a" * (64 * 1024 - 1) + ending
+    inspection = inspect_source(io.BytesIO(data), filename="boundary.yaml", size=len(data))
+    assert inspection.status == status
+
+
+def test_existing_companion_is_never_rewritten(vault):
+    result, _, _ = _capture(vault, "source.yaml", b"field: value")
+    page_path = vault / result.sidecar_path
+    before = page_path.read_bytes()
+    page, created = preserve.ensure_artifact_page(vault, vault / result.path)
+    assert not created
+    assert page == page_path
+    assert page.read_bytes() == before
+
+
+def test_original_bytes_changed_after_capture_fail_closed(vault):
+    result, _, _ = _capture(vault, "changed.csv", b"field\nvalue\n")
+    _classify_dataset(vault, result)
+    (vault / result.path).write_bytes(b"field\nchanged\n")
+    with pytest.raises(companions.CompanionClassificationError):
+        companions.classify(vault, result.path)
+
+
+def _classify_dataset(vault, result):
+    from exomem import reserved_paths
+    from exomem.governance.principal import owner_principal
+    from exomem.governance.tool import op_govern_memory
+
+    payload = {
+        "version": 1,
+        "artifact_class": "dataset",
+        "artifact_path": result.path,
+        "expected_artifact_sha256": result.hash,
+        "expected_artifact_size": result.size,
+        "expected_companion_path": result.sidecar_path,
+        "expected_companion_sha256": hashlib.sha256((vault / result.sidecar_path).read_bytes()).hexdigest(),
+        "format": Path(result.path).suffix[1:].lower(),
+        "semantics": {"projects": [], "tags": [], "types": ["source"], "classes": []},
+    }
+    with reserved_paths._owner_authority_scope("govern_memory"):
+        preview = op_govern_memory(
+            vault, operation="backfill_companion", backfill_action="preview",
+            companion_input=payload, principal=owner_principal(),
+        )
+        return op_govern_memory(
+            vault, operation="backfill_companion", backfill_action="commit",
+            proposal_id=preview["proposal_id"], companion_input=payload,
+            principal=owner_principal(),
+        )
+
+
+def test_owner_backfill_classifies_new_dataset_source_card(vault):
+    data = b"field\nvalue\n"
+    result, _, _ = _capture(vault, "classified.csv", data)
+    with pytest.raises(companions.CompanionClassificationError, match="descriptor_missing"):
+        companions.classify(vault, result.path)
+    _classify_dataset(vault, result)
+    assert companions.classify(vault, result.path).types == ("source",)
+    assert (vault / result.path).read_bytes() == data
+
+
+def test_mixed_card_variants_remain_ambiguous(vault):
+    result, _, _ = _capture(vault, "ambiguous.csv", b"field\nvalue\n")
+    _classify_dataset(vault, result)
+    (vault / result.sidecar_path).with_name("legacy-card.md").write_text(
+        f'---\ntype: dataset\ndata_file: "{result.path}"\nformat: csv\n---\nLegacy card.\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(companions.CompanionClassificationError, match="companion_ambiguous"):
+        companions.classify(vault, result.path)
+
+
+def test_dataset_upload_is_a_citable_source(vault):
+    result, fm, page = _capture(vault, "citation.csv", b"field\nvalue\n")
+    compiled = f'---\ntype: insight\nsources: ["[[{result.ref}]]"]\n---\nDerived conclusion.\n'
+    assert source_closure.inspect_source_closure(vault, compiled).closed
+
+
+def test_dataset_upload_does_not_release_unclassified_semantic_content(vault, monkeypatch):
+    from exomem import query_data
+    from exomem.governance import policy
+    from exomem.governance.principal import RequestPrincipal, request_scope
+
+    result, fm, page = _capture(vault, "restricted.csv", b"field\nsecret-value\n")
+    root = vault / "Knowledge Base" / "_Governance"
+    (root / "scopes").mkdir(parents=True, exist_ok=True)
+    (root / "rules").mkdir(parents=True, exist_ok=True)
+    (root / "scopes" / "sources.yaml").write_text(
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntypes: [source]\n',
+        encoding="utf-8",
+    )
+    (root / "rules" / "sources.yaml").write_text(
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB0\n'
+        'scope_ids: [01ARZ3NDEKTSV4RRFFQ69G5FAV]\naudience: external\nceiling: 0\n',
+        encoding="utf-8",
+    )
+    policy._CACHE.clear()
+    monkeypatch.setattr(query_data, "load_generic_rows", lambda *a, **kw: pytest.fail("withheld bytes parsed"))
+    with request_scope(RequestPrincipal(audience_id="external", surface="mcp")):
+        with pytest.raises(ValueError, match="^NOT_FOUND:"):
+            commands.op_query_dataset(vault, path=result.path)
+        assert not commands.op_find(vault, query="restricted.csv", mode="keyword", graph=False)

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -110,6 +110,39 @@ def test_upload_happy_path_lands_in_evidence(vault, monkeypatch: pytest.MonkeyPa
     assert written.read_bytes() == b"\x89PNGrealbytes"
 
 
+@pytest.mark.parametrize(
+    ("filename", "data", "query"),
+    [
+        ("readings.csv", b"instrument,reading\nprivate-row-value,7\n", "readings"),
+        ("export.yaml", b"export-marker: literal content\n", "export-marker"),
+    ],
+)
+def test_structured_upload_search_and_unchanged_download(vault, monkeypatch, filename, data, query):
+    from exomem import commands, upload_tokens
+
+    client = _client(vault, monkeypatch, EXOMEM_UPLOAD_TOKEN="sekret")
+    response = client.post(
+        "/upload", files={"file": (filename, data, "application/octet-stream")},
+        data={"scope": "Test", "category": "exports"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert response.status_code == 201, response.text
+    result = response.json()
+    found = commands.op_find(vault, query=query, mode="keyword", graph=False)
+    assert any(hit["path"] == result["sidecar_path"] for hit in found)
+    if filename.endswith(".csv"):
+        assert commands.op_query_dataset(
+            vault, path=result["path"], aggregate="sum:reading"
+        )["aggregate"]["sum"] == 7
+        assert "private-row-value" not in (vault / result["sidecar_path"]).read_text()
+    downloaded = client.get(
+        "/download", params={"path": result["path"]},
+        headers={"Authorization": f"Bearer {upload_tokens.mint('sekret', scope='download')}"},
+    )
+    assert downloaded.status_code == 200, downloaded.text
+    assert downloaded.content == data
+
+
 def test_upload_supported_media_routes_through_canonical_reconciliation(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Evidence uploads now create citable dataset source cards for CSV, TSV and JSON, plus bounded literal previews for YAML/YML, JSONL/NDJSON, XML and TOML. Search discovers datasets by file type; exact rows and aggregates come from unchanged originals. Uploaded files are preserved snapshots for recall, citation and connected findings. Ongoing editable state belongs in Records; this change adds no CSV/JSON editing path.

Inspection runs locally with byte, row, table-shape and nesting limits. CSV headers remain behind authorized reads, previews cannot create graph links, and unreviewed raw dataset semantics continue to fail closed. Existing source companions remain intact.

The runtime admission test explicitly initializes its never-warmed state so earlier tests cannot change the scenario.

Validation: preservation, structured query, citation, governance, retrieval and HTTP upload/search/download tests; independent security review; package build, Ruff, public-artifact scan and strict OpenSpec validation.
