### PR TITLE
feat(provisioner): enroll fresh cells before admission

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -621,6 +621,7 @@ class KubernetesCellAdapter:
         credentials: dict[str, str],
         *,
         lifecycle_annotations: dict[str, str] | None = None,
+        effect_guard: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         try:
             valid_credentials = all(
@@ -661,6 +662,47 @@ class KubernetesCellAdapter:
             "immutable": False,
             "stringData": {"credentials.json": bundle},
         }
+        if effect_guard is not None:
+            # Bootstrap is create-or-verify, never an unversioned credential reset.
+            try:
+                current = await asyncio.to_thread(
+                    self._core.read_namespaced_secret,
+                    "exomem-cell-credentials",
+                    metadata.resource_name,
+                )
+            except Exception as error:
+                if _api_status(error) != 404:
+                    if _retryable_kubernetes_error(error):
+                        raise _governance_retryable() from None
+                    raise
+            else:
+                identity = getattr(current, "metadata", None)
+                actual_annotations = getattr(identity, "annotations", None) or {}
+                data = getattr(current, "data", None)
+                if (
+                    getattr(identity, "deletion_timestamp", None) is not None
+                    or getattr(identity, "name", None) != "exomem-cell-credentials"
+                    or getattr(identity, "namespace", None) != metadata.resource_name
+                    or not isinstance(actual_annotations, dict)
+                    or any(actual_annotations.get(k) != v for k, v in annotations.items())
+                    or data != {"credentials.json": base64.b64encode(bundle.encode()).decode()}
+                ):
+                    raise MetadataConflict(
+                        "cell credential bundle differs",
+                        reason=ConflictReason.CELL_CREDENTIAL_BUNDLE_IS_INVALID,
+                    )
+                await effect_guard()
+                return
+            await effect_guard()
+            try:
+                await asyncio.to_thread(
+                    self._core.create_namespaced_secret, metadata.resource_name, body
+                )
+            except Exception as error:
+                if _retryable_kubernetes_error(error):
+                    raise _governance_retryable() from None
+                raise
+            return
         try:
             await asyncio.to_thread(
                 self._core.patch_namespaced_secret,
@@ -754,6 +796,7 @@ class KubernetesCellAdapter:
         membership_digest: str,
         revision: str,
         expected_revision: str | None = None,
+        create_only: bool = False,
         effect_guard: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         if (
@@ -775,8 +818,10 @@ class KubernetesCellAdapter:
             or not recovery_envelope
             or (
                 effect_guard is not None
-                and (not callable(effect_guard) or expected_revision is None)
+                and (not callable(effect_guard) or (expected_revision is None and not create_only))
             )
+            or type(create_only) is not bool
+            or (create_only and (expected_revision is not None or effect_guard is None))
             or (
                 expected_revision is not None
                 and re.fullmatch(r"[0-9a-f]{64}", expected_revision) is None
@@ -816,6 +861,17 @@ class KubernetesCellAdapter:
             "immutable": False,
             "stringData": string_data,
         }
+        if create_only:
+            await effect_guard()
+            try:
+                await asyncio.to_thread(
+                    self._core.create_namespaced_secret, metadata.resource_name, body
+                )
+            except Exception as error:
+                if _retryable_kubernetes_error(error):
+                    raise _governance_retryable() from None
+                raise
+            return
         if expected_revision is not None:
             try:
                 current = await asyncio.to_thread(
@@ -1106,12 +1162,14 @@ class KubernetesVaultFingerprintAdapter:
         core_v1: Any,
         batch_v1: Any,
         image: str,
+        apps_v1: Any = None,
         sleep: Callable[[float], Any] = asyncio.sleep,
         poll_attempts: int = 150,
     ) -> None:
         self._core = core_v1
         self._batch = batch_v1
         self._image = image
+        self._apps = apps_v1
         self._sleep = sleep
         self._poll_attempts = poll_attempts
         self._serializer = ApiClient()
@@ -1425,11 +1483,7 @@ class KubernetesVaultFingerprintAdapter:
             reason=ConflictReason.VAULT_FINGERPRINT_RESULT_IS_INVALID,
         )
 
-    async def _candidate_pods(
-        self, metadata: OpaqueProviderMetadata, uid: str
-    ) -> list[dict[str, Any]]:
-        # The post-upgrade runtime intentionally shares this PVC. Inventory the
-        # namespace, but classify only fixed-slot Job evidence, not all PVC users.
+    async def _namespace_pods(self, metadata: OpaqueProviderMetadata) -> list[dict[str, Any]]:
         listed = await asyncio.to_thread(self._core.list_namespaced_pod, metadata.resource_name)
         page = self._wire(listed)
         page_meta = page.get("metadata", {})
@@ -1444,6 +1498,14 @@ class KubernetesVaultFingerprintAdapter:
         items = page.get("items")
         if not isinstance(items, list):
             raise self._invalid_result()
+        return items
+
+    async def _candidate_pods(
+        self, metadata: OpaqueProviderMetadata, uid: str
+    ) -> list[dict[str, Any]]:
+        # The post-upgrade runtime intentionally shares this PVC. Inventory the
+        # namespace, but classify only fixed-slot Job evidence, not all PVC users.
+        items = await self._namespace_pods(metadata)
         candidates = []
         name = self._name(metadata)
         for pod in items:
@@ -1470,6 +1532,117 @@ class KubernetesVaultFingerprintAdapter:
                 candidates.append(pod)
         return candidates
 
+    def _require_pod_execution(
+        self,
+        pod: dict[str, Any],
+        metadata: OpaqueProviderMetadata,
+        uid: str,
+        expected: dict[str, Any],
+        *,
+        allow_terminating: bool = False,
+    ) -> None:
+        meta, spec = pod["metadata"], pod.get("spec")
+        owners = meta.get("ownerReferences", [])
+        if (
+            not isinstance(spec, dict)
+            or meta.get("namespace") != metadata.resource_name
+            or not isinstance(meta.get("uid"), str)
+            or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}", meta["uid"]) is None
+            or (meta.get("deletionTimestamp") and not allow_terminating)
+            or not meta["name"].startswith(self._name(metadata) + "-")
+            or not metadata_matches(meta, expected["metadata"])
+            or not pod_spec_matches(spec, expected["spec"], scheduled=True)
+            or len(owners) != 1
+        ):
+            raise self._invalid_result()
+        owner = owners[0]
+        if (
+            set(owner) - {"apiVersion", "kind", "name", "uid", "controller", "blockOwnerDeletion"}
+            or any(
+                owner.get(key) != value
+                for key, value in {
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "name": self._name(metadata),
+                    "uid": uid,
+                }.items()
+            )
+            or owner.get("controller") is not True
+            or ("blockOwnerDeletion" in owner and type(owner["blockOwnerDeletion"]) is not bool)
+        ):
+            raise self._invalid_result()
+        self._require_controller_labels(meta, name=self._name(metadata), uid=uid)
+
+    async def prove_stopped_before_fingerprint(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        owner: OpaqueProviderMetadata,
+        pvc_uid: str,
+        operation_id: str,
+        recovery_envelope: str,
+    ) -> None:
+        """Exclude only our exact read-only Job, so interrupted observation can resume."""
+        from .governance_stopped_cell import _pod_evidence, _pvc_is_bound, _runtime_is_stopped
+
+        try:
+            pvc = self._wire(
+                await asyncio.to_thread(
+                    self._core.read_namespaced_persistent_volume_claim,
+                    metadata.resource_name + "-data",
+                    metadata.resource_name,
+                )
+            )
+            _pvc_is_bound(pvc, metadata=owner, pvc_uid=pvc_uid)
+            try:
+                runtime = self._wire(
+                    await asyncio.to_thread(
+                        self._apps.read_namespaced_stateful_set,
+                        metadata.resource_name,
+                        metadata.resource_name,
+                    )
+                )
+            except Exception as error:
+                if _api_status(error) != 404:
+                    raise
+            else:
+                _runtime_is_stopped(runtime, resource=metadata.resource_name)
+            job = await self._read(metadata)
+            uid = None
+            template = self._body(
+                metadata,
+                operation_id=operation_id,
+                phase="before",
+                recovery_envelope=recovery_envelope,
+            )["spec"]["template"]
+            if job is not None:
+                self._require_job(
+                    job,
+                    metadata,
+                    operation_id=operation_id,
+                    phase="before",
+                    recovery_envelope=recovery_envelope,
+                )
+                uid = self._job_revision(job, allow_terminating=True)[0]
+            count = 0
+            for pod in await self._namespace_pods(metadata):
+                forbidden, _ = _pod_evidence(pod, metadata=owner, runtime_uid=None)
+                if forbidden:
+                    if uid is None:
+                        raise self._invalid_result()
+                    self._require_pod_execution(
+                        pod, metadata, uid, template, allow_terminating=True
+                    )
+                    count += 1
+            if count > 1:
+                raise self._invalid_result()
+        except (ClaimConflict, StaleFence, DriverRetryable, MetadataConflict):
+            raise
+        except Exception as error:  # noqa: BLE001 - content-free provider observation boundary
+            if _retryable_kubernetes_error(error):
+                raise _governance_retryable() from None
+            raise self._invalid_result() from None
+
     async def _result(
         self, metadata: OpaqueProviderMetadata, job: dict[str, Any], expected: dict[str, Any]
     ) -> str | None:
@@ -1493,39 +1666,10 @@ class KubernetesVaultFingerprintAdapter:
         if len(candidates) != 1:
             raise self._invalid_result()
         pod = candidates[0]
-        meta, spec, pod_status = pod["metadata"], pod.get("spec"), pod.get("status")
-        owners = meta.get("ownerReferences", [])
-        if (
-            not isinstance(spec, dict)
-            or not isinstance(pod_status, dict)
-            or meta.get("namespace") != metadata.resource_name
-            or not isinstance(meta.get("uid"), str)
-            or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}", meta["uid"]) is None
-            or meta.get("deletionTimestamp")
-            or not meta["name"].startswith(self._name(metadata) + "-")
-            or not metadata_matches(meta, expected["metadata"])
-            or not pod_spec_matches(spec, expected["spec"], scheduled=True)
-            or len(owners) != 1
-        ):
+        self._require_pod_execution(pod, metadata, uid, expected)
+        pod_status = pod.get("status")
+        if not isinstance(pod_status, dict) or pod_status.get("phase") != "Succeeded":
             raise self._invalid_result()
-        owner = owners[0]
-        if (
-            set(owner) - {"apiVersion", "kind", "name", "uid", "controller", "blockOwnerDeletion"}
-            or any(
-                owner.get(key) != value
-                for key, value in {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "name": self._name(metadata),
-                    "uid": uid,
-                }.items()
-            )
-            or owner.get("controller") is not True
-            or ("blockOwnerDeletion" in owner and type(owner["blockOwnerDeletion"]) is not bool)
-            or pod_status.get("phase") != "Succeeded"
-        ):
-            raise self._invalid_result()
-        self._require_controller_labels(meta, name=self._name(metadata), uid=uid)
         statuses = pod_status.get("containerStatuses")
         if (
             not isinstance(statuses, list)

--- a/infra/provisioner/src/exomem_provisioner/governance_provision_membership.py
+++ b/infra/provisioner/src/exomem_provisioner/governance_provision_membership.py
@@ -1,0 +1,66 @@
+"""Never-served bootstrap drain; not ordinary renewal or migration-plan recovery."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from . import authorization_membership as membership
+from .conflict_reason import ConflictReason
+from .governance_target_recovery import _draining_successor_files
+from .lifecycle import MetadataConflict
+
+
+def drain_fresh_bootstrap_bundle(
+    files: Mapping[str, bytes],
+    *,
+    expected_cell_id: str,
+    expected_logical_vault_id: str,
+    expected_replica_id: str,
+    expected_software_version: str,
+    expected_recovery_envelope: str,
+    now: int,
+) -> membership.HostedAuthorizationBundle:
+    """Drain an unenrolled schema-3 genesis, preserving its custody and lineage.
+
+    The caller must prove this exact provision owns never-started storage with
+    closed routes and no workload, before any plan or enrollment exists. Keys
+    authenticate at real current time; only the genesis window may have elapsed.
+    """
+    current = membership._required_time(now)
+    identity = {
+        "expected_cell_id": expected_cell_id,
+        "expected_logical_vault_id": expected_logical_vault_id,
+        "expected_replica_id": expected_replica_id,
+        "expected_software_version": membership._required_identifier(expected_software_version),
+        "expected_recovery_envelope": expected_recovery_envelope,
+        "expected_schema_version": membership.AUTHORIZATION_BOOTSTRAP_SCHEMA_VERSION,
+        "now": current,
+    }
+    source = membership.inspect_hosted_authorization_bundle(files, **identity, _require_fresh=False)
+    if source.governance_enrolled or json.loads(source.control)["issued_at"] > current:
+        raise MetadataConflict(
+            "authorization bootstrap drain is unavailable",
+            reason=ConflictReason.AUTHORIZATION_MEMBERSHIP_TRANSITION_IS_INVALID,
+        )
+    if (
+        source.epoch == 2
+        and source.replica_state == "DRAINING"
+        and source.no_in_flight
+        and source.issuance_stopped
+    ):
+        return source
+    if (
+        source.epoch != 1
+        or source.replica_state != "SERVING"
+        or source.no_in_flight
+        or source.issuance_stopped
+        or json.loads(source.membership)["previous_epoch_digest"] is not None
+    ):
+        raise MetadataConflict(
+            "authorization bootstrap drain is unavailable",
+            reason=ConflictReason.AUTHORIZATION_MEMBERSHIP_TRANSITION_IS_INVALID,
+        )
+    return membership.inspect_hosted_authorization_bundle(
+        _draining_successor_files(source, issued_at=current), **identity
+    )

--- a/infra/provisioner/src/exomem_provisioner/governance_storage_init.py
+++ b/infra/provisioner/src/exomem_provisioner/governance_storage_init.py
@@ -1,0 +1,936 @@
+"""Read and cleanup boundary for the fixed fresh-storage initializer Job."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from kubernetes.client import ApiClient
+
+from .adapters import _retryable_kubernetes_error
+from .conflict_reason import ConflictReason
+from .driver import DriverRetryable, LostAcknowledgement
+from .job_execution import metadata_matches, pod_spec_matches
+from .lifecycle import MetadataConflict, OpaqueProviderMetadata
+from .provider_identity import ProviderIdentityConflict, ProviderReference
+from .repository import ClaimConflict, StaleFence
+
+_IDENTITY = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}\Z")
+_IMAGE = re.compile(r"[a-z0-9][a-z0-9./:_-]{0,511}@sha256:[0-9a-f]{64}\Z")
+_OPAQUE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,127}\Z")
+_OPERATION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}\Z")
+_PROTOCOL = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,31}\Z")
+_CREDENTIAL_VERSION = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+_INIT_REQUEST_KEYS = {
+    "request_id",
+    "operation_id",
+    "cell_id",
+    "vault_id",
+    "vault_root",
+    "state_root",
+    "log_root",
+    "expected_release",
+    "expected_protocol",
+    "runtime_uid",
+    "runtime_gid",
+    "active_credential_version",
+}
+
+
+def _refuse() -> MetadataConflict:
+    return MetadataConflict(
+        "governance storage initializer is unavailable",
+        reason=ConflictReason.GOVERNANCE_MIGRATION_JOB_UNAVAILABLE,
+    )
+
+
+def _retry() -> DriverRetryable:
+    return DriverRetryable("governance storage initializer is temporarily unavailable")
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _refuse()
+    return value
+
+
+def _string(value: object) -> str:
+    if not isinstance(value, str) or _IDENTITY.fullmatch(value) is None:
+        raise _refuse()
+    return value
+
+
+def _closed_values(
+    value: object,
+    expected: dict[str, str],
+    allowed: dict[str, str] | None = None,
+) -> bool:
+    if value is None:
+        actual: dict[str, Any] = {}
+    elif isinstance(value, dict):
+        actual = value
+    else:
+        return False
+    optional = allowed or {}
+    return (
+        set(actual) <= set(expected) | set(optional)
+        and all(actual.get(key) == expected_value for key, expected_value in expected.items())
+        and all(actual[key] == optional[key] for key in actual if key not in expected)
+    )
+
+
+class KubernetesGovernanceStorageInitAdapter:
+    """Prove and remove exactly the chart-created initializer; never submit it."""
+
+    def __init__(
+        self,
+        *,
+        core_v1: Any,
+        batch_v1: Any,
+        apps_v1: Any,
+        identity_verifier: Any,
+        runtime_image: str,
+    ) -> None:
+        if not isinstance(runtime_image, str) or _IMAGE.fullmatch(runtime_image) is None:
+            raise _refuse()
+        self._core, self._batch, self._apps = core_v1, batch_v1, apps_v1
+        self._identity_verifier, self._image = identity_verifier, runtime_image
+        self._serializer = ApiClient()
+
+    @staticmethod
+    def _name(metadata: OpaqueProviderMetadata) -> str:
+        return metadata.resource_name + "-init"
+
+    def _wire(self, value: Any) -> Any:
+        return self._serializer.sanitize_for_serialization(value)
+
+    async def _job(self, metadata: OpaqueProviderMetadata) -> dict[str, Any] | None:
+        try:
+            value = await asyncio.to_thread(
+                self._batch.read_namespaced_job,
+                self._name(metadata),
+                metadata.resource_name,
+            )
+        except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+            if getattr(error, "status", None) == 404:
+                return None
+            raise
+        return _mapping(self._wire(value))
+
+    async def _config_map(self, metadata: OpaqueProviderMetadata) -> dict[str, Any]:
+        value = await asyncio.to_thread(
+            self._core.read_namespaced_config_map,
+            metadata.resource_name + "-init-request",
+            metadata.resource_name,
+        )
+        return _mapping(self._wire(value))
+
+    def _authenticate(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        envelope: str,
+        api_version: str,
+        kind: str,
+        name: str,
+    ) -> None:
+        if self._identity_verifier is None:
+            raise _refuse()
+        try:
+            self._identity_verifier.authenticate(
+                envelope,
+                provider="kubernetes",
+                provider_reference=ProviderReference.kubernetes(
+                    provider="kubernetes",
+                    api_version=api_version,
+                    kind=kind,
+                    namespace=metadata.resource_name,
+                    name=name,
+                ),
+                tenant_id=metadata.tenant_id,
+                cell_id=metadata.subject_id,
+                operation_id=metadata.operation_id,
+                fence_generation=metadata.fence_generation,
+            )
+        except ProviderIdentityConflict as error:
+            raise _refuse() from error
+
+    @staticmethod
+    def _labels(
+        metadata: OpaqueProviderMetadata,
+        *,
+        template: bool = False,
+        storage_init: bool = False,
+    ) -> dict[str, str]:
+        labels = {
+            "app.kubernetes.io/name": "exomem-cell",
+            "exomem.io/cell": metadata.resource_name,
+        }
+        if not template:
+            labels.update(
+                {
+                    "app.kubernetes.io/instance": metadata.resource_name,
+                    "app.kubernetes.io/part-of": "exomem-hosted",
+                }
+            )
+        if storage_init:
+            labels["exomem.io/storage-init"] = "true"
+        return labels
+
+    def _pod_spec(self, metadata: OpaqueProviderMetadata) -> dict[str, Any]:
+        resource = metadata.resource_name
+        return {
+            "runtimeClassName": "exomem-storage-init",
+            "serviceAccountName": resource,
+            "automountServiceAccountToken": False,
+            "restartPolicy": "Never",
+            "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+            "containers": [
+                {
+                    "name": "exomem",
+                    "image": self._image,
+                    "imagePullPolicy": "IfNotPresent",
+                    "terminationMessagePath": "/dev/termination-log",
+                    "terminationMessagePolicy": "File",
+                    "args": [
+                        "hosted",
+                        "init",
+                        "--contract-version",
+                        "1",
+                        "--request-file",
+                        "/run/exomem/operator-requests/init.json",
+                    ],
+                    "env": [
+                        {"name": "EXOMEM_LOG_DIR", "value": "/dev"},
+                        {"name": "EXOMEM_HOSTED_OFFLINE_STATE_MIGRATION", "value": "1"},
+                    ],
+                    "resources": {
+                        "requests": {"cpu": "100m", "memory": "128Mi"},
+                        "limits": {"cpu": "1", "memory": "1Gi"},
+                    },
+                    "securityContext": {
+                        "runAsUser": 0,
+                        "runAsGroup": 0,
+                        "allowPrivilegeEscalation": False,
+                        "readOnlyRootFilesystem": True,
+                        "capabilities": {
+                            "drop": ["ALL"],
+                            "add": ["CHOWN", "DAC_OVERRIDE", "FOWNER"],
+                        },
+                    },
+                    "volumeMounts": [
+                        {"name": "data", "mountPath": "/var/lib/exomem"},
+                        {
+                            "name": "credentials",
+                            "mountPath": "/run/exomem/credentials",
+                            "readOnly": True,
+                        },
+                        {
+                            "name": "init-request",
+                            "mountPath": "/run/exomem/operator-requests/init.json",
+                            "subPath": "init.json",
+                            "readOnly": True,
+                        },
+                    ],
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "data",
+                    "persistentVolumeClaim": {"claimName": resource + "-data"},
+                },
+                {
+                    "name": "credentials",
+                    "secret": {"secretName": "exomem-cell-credentials", "defaultMode": 292},
+                },
+                {
+                    "name": "init-request",
+                    "configMap": {"name": resource + "-init-request", "defaultMode": 292},
+                },
+            ],
+        }
+
+    def _job_body(
+        self,
+        metadata: OpaqueProviderMetadata,
+        recovery_envelope: str,
+    ) -> dict[str, Any]:
+        return {
+            "metadata": {
+                "name": self._name(metadata),
+                "namespace": metadata.resource_name,
+                "labels": self._labels(metadata, storage_init=True),
+                "annotations": {
+                    **metadata.kubernetes_annotations,
+                    "exomem.io/recovery-envelope": recovery_envelope,
+                },
+            },
+            "spec": {
+                "backoffLimit": 1,
+                "activeDeadlineSeconds": 120,
+                "ttlSecondsAfterFinished": 300,
+                "template": {
+                    "metadata": {
+                        "labels": self._labels(
+                            metadata,
+                            template=True,
+                            storage_init=True,
+                        ),
+                        "annotations": {},
+                    },
+                    "spec": self._pod_spec(metadata),
+                },
+            },
+        }
+
+    async def _stopped(self, metadata: OpaqueProviderMetadata, pvc_uid: str) -> None:
+        resource = metadata.resource_name
+        pvc = _mapping(
+            self._wire(
+                await asyncio.to_thread(
+                    self._core.read_namespaced_persistent_volume_claim,
+                    resource + "-data",
+                    resource,
+                )
+            )
+        )
+        identity = _mapping(pvc.get("metadata"))
+        annotations = _mapping(identity.get("annotations"))
+        spec = _mapping(pvc.get("spec"))
+        status = _mapping(pvc.get("status"))
+        expected = metadata.kubernetes_annotations
+        if (
+            identity.get("name") != resource + "-data"
+            or identity.get("namespace") != resource
+            or identity.get("uid") != pvc_uid
+            or identity.get("deletionTimestamp") is not None
+            or status.get("phase") != "Bound"
+            or not isinstance(spec.get("volumeName"), str)
+            or not spec["volumeName"]
+            or any(
+                annotations.get(key) != expected[key]
+                for key in (
+                    "exomem.io/tenant-id",
+                    "exomem.io/cell-id",
+                    "exomem.io/tenant-digest",
+                    "exomem.io/subject-digest",
+                )
+            )
+        ):
+            raise _refuse()
+        try:
+            runtime = _mapping(
+                self._wire(
+                    await asyncio.to_thread(
+                        self._apps.read_namespaced_stateful_set,
+                        resource,
+                        resource,
+                    )
+                )
+            )
+        except Exception as error:
+            if getattr(error, "status", None) == 404:
+                return
+            raise
+        runtime_identity = _mapping(runtime.get("metadata"))
+        runtime_spec = _mapping(runtime.get("spec"))
+        if (
+            runtime_identity.get("name") != resource
+            or runtime_identity.get("namespace") != resource
+            or type(runtime_spec.get("replicas")) is not int
+            or runtime_spec["replicas"] != 0
+        ):
+            raise _refuse()
+
+    def _prove_config_map(
+        self,
+        value: dict[str, Any],
+        metadata: OpaqueProviderMetadata,
+        *,
+        recovery_envelope: str,
+        init_request: dict[str, Any],
+    ) -> tuple[str, str]:
+        resource = metadata.resource_name
+        identity = _mapping(value.get("metadata"))
+        annotations = _mapping(identity.get("annotations"))
+        envelope = annotations.get("exomem.io/recovery-envelope")
+        expected_labels = self._labels(metadata)
+        expected_annotations = {
+            **metadata.kubernetes_annotations,
+            "exomem.io/recovery-envelope": recovery_envelope,
+        }
+        helm_labels = {"app.kubernetes.io/managed-by": "Helm"}
+        helm_annotations = {
+            "meta.helm.sh/release-name": resource,
+            "meta.helm.sh/release-namespace": resource,
+        }
+        canonical_request = self._canonical_init_request(metadata, init_request)
+        data = value.get("data")
+        if (
+            identity.get("name") != resource + "-init-request"
+            or identity.get("namespace") != resource
+            or not metadata_matches(
+                identity,
+                {
+                    "labels": expected_labels,
+                    "annotations": expected_annotations,
+                },
+            )
+            or not _closed_values(identity.get("labels"), expected_labels, helm_labels)
+            or not _closed_values(annotations, expected_annotations, helm_annotations)
+            or envelope != recovery_envelope
+            or not isinstance(data, dict)
+            or set(data) != {"init.json"}
+            or data["init.json"] != canonical_request
+            or value.get("binaryData") not in (None, {})
+        ):
+            raise _refuse()
+        uid = _string(identity.get("uid"))
+        rv = _string(identity.get("resourceVersion"))
+        self._authenticate(
+            metadata,
+            envelope=recovery_envelope,
+            api_version="v1",
+            kind="ConfigMap",
+            name=resource + "-init-request",
+        )
+        return uid, rv
+
+    @staticmethod
+    def _canonical_init_request(
+        metadata: OpaqueProviderMetadata,
+        init_request: dict[str, Any],
+    ) -> str:
+        if not isinstance(init_request, dict) or set(init_request) != _INIT_REQUEST_KEYS:
+            raise _refuse()
+        request_id = init_request.get("request_id")
+        try:
+            parsed_request_id = uuid.UUID(request_id) if isinstance(request_id, str) else None
+        except ValueError as error:
+            raise _refuse() from error
+        release = init_request.get("expected_release")
+        if (
+            parsed_request_id is None
+            or parsed_request_id.version != 4
+            or str(parsed_request_id) != request_id
+            or init_request.get("operation_id") != metadata.operation_id
+            or _OPERATION_ID.fullmatch(str(init_request["operation_id"])) is None
+            or init_request.get("cell_id") != metadata.subject_id
+            or _OPAQUE_ID.fullmatch(str(init_request["cell_id"])) is None
+            or init_request.get("vault_id") != metadata.tenant_id
+            or _OPAQUE_ID.fullmatch(str(init_request["vault_id"])) is None
+            or init_request.get("vault_root") != "/var/lib/exomem/vault"
+            or init_request.get("state_root") != "/var/lib/exomem/state"
+            or init_request.get("log_root") != "/var/lib/exomem/logs"
+            or not isinstance(release, str)
+            or not 1 <= len(release.encode()) <= 64
+            or not isinstance(init_request.get("expected_protocol"), str)
+            or _PROTOCOL.fullmatch(init_request["expected_protocol"]) is None
+            or any(
+                type(init_request.get(key)) is not int
+                or not 1 <= init_request[key] <= 2_147_483_647
+                for key in ("runtime_uid", "runtime_gid")
+            )
+            or not isinstance(init_request.get("active_credential_version"), str)
+            or _CREDENTIAL_VERSION.fullmatch(init_request["active_credential_version"]) is None
+        ):
+            raise _refuse()
+        try:
+            return json.dumps(
+                init_request,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+        except (TypeError, ValueError) as error:
+            raise _refuse() from error
+
+    def _prove_job(
+        self,
+        job: dict[str, Any],
+        metadata: OpaqueProviderMetadata,
+        recovery_envelope: str,
+        *,
+        allow_deleting: bool,
+    ) -> tuple[str, str, bool]:
+        body = self._job_body(metadata, recovery_envelope)
+        identity = _mapping(job.get("metadata"))
+        annotations = _mapping(identity.get("annotations"))
+        uid = _string(identity.get("uid"))
+        rv = _string(identity.get("resourceVersion"))
+        helm_labels = {"app.kubernetes.io/managed-by": "Helm"}
+        helm_annotations = {
+            "meta.helm.sh/release-name": metadata.resource_name,
+            "meta.helm.sh/release-namespace": metadata.resource_name,
+        }
+        if (
+            identity.get("name") != self._name(metadata)
+            or identity.get("namespace") != metadata.resource_name
+            or (identity.get("deletionTimestamp") is not None and not allow_deleting)
+            or not metadata_matches(identity, body["metadata"])
+            or not _closed_values(identity.get("labels"), body["metadata"]["labels"], helm_labels)
+            or not _closed_values(annotations, body["metadata"]["annotations"], helm_annotations)
+            or annotations.get("exomem.io/recovery-envelope") != recovery_envelope
+        ):
+            raise _refuse()
+        self._authenticate(
+            metadata,
+            envelope=recovery_envelope,
+            api_version="batch/v1",
+            kind="Job",
+            name=self._name(metadata),
+        )
+        spec = _mapping(job.get("spec"))
+        for key, expected in body["spec"].items():
+            if key != "template" and (
+                type(spec.get(key)) is not type(expected) or spec[key] != expected
+            ):
+                raise _refuse()
+        defaults = {
+            "completionMode": "NonIndexed",
+            "completions": 1,
+            "parallelism": 1,
+            "suspend": False,
+            "manualSelector": False,
+        }
+        if set(spec) - set(body["spec"]) - set(defaults) - {"selector"}:
+            raise _refuse()
+        if any(key in spec and spec[key] != expected for key, expected in defaults.items()):
+            raise _refuse()
+        selector = spec.get("selector")
+        if selector is not None and selector != {
+            "matchLabels": {"batch.kubernetes.io/controller-uid": uid}
+        }:
+            raise _refuse()
+        template = _mapping(spec.get("template"))
+        template_identity = _mapping(template.get("metadata"))
+        controller_labels = {
+            "batch.kubernetes.io/controller-uid": uid,
+            "batch.kubernetes.io/job-name": self._name(metadata),
+            "controller-uid": uid,
+            "job-name": self._name(metadata),
+        }
+        if (
+            not metadata_matches(
+                template_identity,
+                body["spec"]["template"]["metadata"],
+            )
+            or not _closed_values(
+                template_identity.get("labels"),
+                body["spec"]["template"]["metadata"]["labels"],
+                controller_labels,
+            )
+            or template_identity.get("annotations") not in (None, {})
+            or not pod_spec_matches(
+                _mapping(template.get("spec")),
+                body["spec"]["template"]["spec"],
+            )
+        ):
+            raise _refuse()
+        return uid, rv, self._complete(job)
+
+    @staticmethod
+    def _complete(job: dict[str, Any]) -> bool:
+        status = _mapping(job.get("status", {}))
+        for key in ("failed", "succeeded", "active", "terminating"):
+            value = status.get(key, 0)
+            if type(value) is not int or value < 0:
+                raise _refuse()
+        conditions_value = status.get("conditions", [])
+        if not isinstance(conditions_value, list):
+            raise _refuse()
+        conditions: dict[str, str] = {}
+        for item in conditions_value:
+            condition = _mapping(item)
+            kind, state = condition.get("type"), condition.get("status")
+            if (
+                not isinstance(kind, str)
+                or not isinstance(state, str)
+                or state
+                not in {
+                    "True",
+                    "False",
+                    "Unknown",
+                }
+            ):
+                raise _refuse()
+            if kind in {"Complete", "Failed"}:
+                if kind in conditions:
+                    raise _refuse()
+                conditions[kind] = state
+        complete = conditions.get("Complete") == "True"
+        if conditions.get("Failed") == "True":
+            raise _refuse()
+        if complete and (
+            status.get("succeeded", 0) != 1
+            or status.get("active", 0) != 0
+            or status.get("terminating", 0) != 0
+        ):
+            raise _refuse()
+        return complete
+
+    async def _candidate_pods(
+        self,
+        metadata: OpaqueProviderMetadata,
+        uid: str | None,
+    ) -> list[dict[str, Any]]:
+        observed = _mapping(
+            self._wire(
+                await asyncio.to_thread(
+                    self._core.list_namespaced_pod,
+                    metadata.resource_name,
+                )
+            )
+        )
+        page_metadata = _mapping(observed.get("metadata", {}))
+        continuation = page_metadata.get("continue")
+        remaining = page_metadata.get("remainingItemCount")
+        if continuation is not None and not isinstance(continuation, str):
+            raise _refuse()
+        if remaining is not None and (type(remaining) is not int or remaining < 0):
+            raise _refuse()
+        if continuation or remaining:
+            raise _retry()
+        items = observed.get("items")
+        if not isinstance(items, list):
+            raise _refuse()
+        resource = metadata.resource_name
+        job_name = self._name(metadata)
+        candidates: list[dict[str, Any]] = []
+        for item in items:
+            pod = _mapping(item)
+            identity = _mapping(pod.get("metadata"))
+            if identity.get("namespace") != resource:
+                raise _refuse()
+            name = _string(identity.get("name"))
+            labels = _mapping(identity.get("labels", {}))
+            owners = identity.get("ownerReferences", [])
+            if not isinstance(owners, list):
+                raise _refuse()
+            owner_values = [_mapping(owner) for owner in owners]
+            spec = _mapping(pod.get("spec"))
+            volumes = spec.get("volumes", [])
+            if not isinstance(volumes, list):
+                raise _refuse()
+            uses_pvc = False
+            for volume_value in volumes:
+                volume = _mapping(volume_value)
+                claim = volume.get("persistentVolumeClaim")
+                if claim is not None and _mapping(claim).get("claimName") == resource + "-data":
+                    uses_pvc = True
+            job_signal = (
+                name.startswith(job_name + "-")
+                or any(
+                    labels.get(key) == job_name
+                    for key in ("job-name", "batch.kubernetes.io/job-name")
+                )
+                or any(
+                    owner.get("name") == job_name or (uid is not None and owner.get("uid") == uid)
+                    for owner in owner_values
+                )
+            )
+            runtime_signal = (
+                name == resource + "-0"
+                or any(
+                    owner.get("kind") == "StatefulSet" and owner.get("name") == resource
+                    for owner in owner_values
+                )
+                or (
+                    labels.get("app.kubernetes.io/name") == "exomem-cell"
+                    and labels.get("exomem.io/cell") == resource
+                    and not job_signal
+                )
+            )
+            if uses_pvc or job_signal or runtime_signal:
+                candidates.append(pod)
+        return candidates
+
+    def _prove_pod(
+        self,
+        pod: dict[str, Any],
+        metadata: OpaqueProviderMetadata,
+        uid: str,
+    ) -> tuple[bool, bool]:
+        identity = _mapping(pod.get("metadata"))
+        owners = identity.get("ownerReferences")
+        if not isinstance(owners, list) or len(owners) != 1:
+            raise _refuse()
+        owner = _mapping(owners[0])
+        expected_owner = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": self._name(metadata),
+            "uid": uid,
+            "controller": True,
+        }
+        if (
+            set(owner)
+            - {
+                "apiVersion",
+                "kind",
+                "name",
+                "uid",
+                "controller",
+                "blockOwnerDeletion",
+            }
+            or any(owner.get(key) != value for key, value in expected_owner.items())
+            or ("blockOwnerDeletion" in owner and type(owner["blockOwnerDeletion"]) is not bool)
+            or identity.get("namespace") != metadata.resource_name
+            or not _string(identity.get("uid"))
+        ):
+            raise _refuse()
+        if not identity["name"].startswith(self._name(metadata) + "-"):
+            raise _refuse()
+        expected_metadata = {
+            "labels": self._labels(
+                metadata,
+                template=True,
+                storage_init=True,
+            ),
+            "annotations": {},
+        }
+        controller_labels = {
+            "batch.kubernetes.io/controller-uid": uid,
+            "batch.kubernetes.io/job-name": self._name(metadata),
+            "controller-uid": uid,
+            "job-name": self._name(metadata),
+        }
+        if (
+            not metadata_matches(identity, expected_metadata)
+            or not _closed_values(
+                identity.get("labels"), expected_metadata["labels"], controller_labels
+            )
+            or identity.get("annotations") not in (None, {})
+            or not pod_spec_matches(
+                _mapping(pod.get("spec")),
+                self._pod_spec(metadata),
+                scheduled=True,
+            )
+        ):
+            raise _refuse()
+        status = _mapping(pod.get("status", {}))
+        phase = status.get("phase")
+        if phase not in {"Succeeded", "Failed"}:
+            return False, False
+        containers = status.get("containerStatuses")
+        if not isinstance(containers, list) or len(containers) != 1:
+            raise _refuse()
+        container = _mapping(containers[0])
+        terminated = _mapping(_mapping(container.get("state")).get("terminated"))
+        exit_code = terminated.get("exitCode")
+        if container.get("name") != "exomem" or type(exit_code) is not int:
+            raise _refuse()
+        successful = phase == "Succeeded" and exit_code == 0
+        failed = phase == "Failed" and exit_code != 0
+        if not successful and not failed:
+            raise _refuse()
+        return True, successful
+
+    async def _prove_pods(
+        self,
+        metadata: OpaqueProviderMetadata,
+        uid: str,
+        *,
+        complete: bool,
+    ) -> None:
+        candidates = await self._candidate_pods(metadata, uid)
+        terminal = successful = 0
+        for pod in candidates:
+            is_terminal, is_successful = self._prove_pod(pod, metadata, uid)
+            terminal += int(is_terminal)
+            successful += int(is_successful)
+        if complete:
+            if not candidates or terminal != len(candidates):
+                raise _retry()
+            if successful != 1:
+                raise _refuse()
+
+    async def _prove_absence(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        pvc_uid: str,
+    ) -> bool:
+        if await self._job(metadata) is not None:
+            return False
+        await self._stopped(metadata, pvc_uid)
+        candidates = await self._candidate_pods(metadata, None)
+        if not candidates:
+            return True
+        for pod in candidates:
+            identity = _mapping(pod.get("metadata"))
+            owners = identity.get("ownerReferences", [])
+            if not isinstance(owners, list) or len(owners) != 1:
+                raise _refuse()
+            uid = _string(_mapping(owners[0]).get("uid"))
+            terminal, _successful = self._prove_pod(pod, metadata, uid)
+            if not terminal:
+                raise _refuse()
+        raise _retry()
+
+    @staticmethod
+    def _same(actual: tuple[str, str], expected: tuple[str, str]) -> None:
+        if actual != expected:
+            raise _refuse()
+
+    async def completed(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        recovery_envelope: str,
+        init_request_recovery_envelope: str,
+        init_request: dict[str, Any],
+        pvc_uid: str,
+        effect_guard: Callable[[], Awaitable[None]],
+    ) -> bool:
+        try:
+            await effect_guard()
+            job = await self._job(metadata)
+            if job is None:
+                if await self._prove_absence(metadata, pvc_uid=pvc_uid):
+                    return False
+                raise _retry()
+            uid, rv, complete = self._prove_job(
+                job, metadata, recovery_envelope, allow_deleting=True
+            )
+            config_identity = self._prove_config_map(
+                await self._config_map(metadata),
+                metadata,
+                recovery_envelope=init_request_recovery_envelope,
+                init_request=init_request,
+            )
+            await self._stopped(metadata, pvc_uid)
+            await self._prove_pods(metadata, uid, complete=complete)
+            if not complete:
+                return False
+            await effect_guard()
+            current = await self._job(metadata)
+            if current is None:
+                raise _retry()
+            current_uid, current_rv, current_complete = self._prove_job(
+                current, metadata, recovery_envelope, allow_deleting=True
+            )
+            self._same((current_uid, current_rv), (uid, rv))
+            if not current_complete:
+                raise _refuse()
+            self._same(
+                self._prove_config_map(
+                    await self._config_map(metadata),
+                    metadata,
+                    recovery_envelope=init_request_recovery_envelope,
+                    init_request=init_request,
+                ),
+                config_identity,
+            )
+            await self._stopped(metadata, pvc_uid)
+            await self._prove_pods(metadata, uid, complete=True)
+            return True
+        except (ClaimConflict, StaleFence, MetadataConflict, DriverRetryable):
+            raise
+        except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+            if _retryable_kubernetes_error(error):
+                raise _retry() from None
+            raise _refuse() from None
+
+    async def cleanup(
+        self,
+        metadata: OpaqueProviderMetadata,
+        *,
+        recovery_envelope: str,
+        init_request_recovery_envelope: str,
+        init_request: dict[str, Any],
+        pvc_uid: str,
+        effect_guard: Callable[[], Awaitable[None]],
+    ) -> None:
+        try:
+            await effect_guard()
+            await self._stopped(metadata, pvc_uid)
+            job = await self._job(metadata)
+            if job is None:
+                if await self._prove_absence(metadata, pvc_uid=pvc_uid):
+                    return
+                raise _retry()
+            uid, rv, complete = self._prove_job(
+                job, metadata, recovery_envelope, allow_deleting=True
+            )
+            if not complete:
+                raise _refuse()
+            config_identity = self._prove_config_map(
+                await self._config_map(metadata),
+                metadata,
+                recovery_envelope=init_request_recovery_envelope,
+                init_request=init_request,
+            )
+            await self._prove_pods(metadata, uid, complete=True)
+            if _mapping(job["metadata"]).get("deletionTimestamp") is not None:
+                await effect_guard()
+                current = await self._job(metadata)
+                if current is None and await self._prove_absence(metadata, pvc_uid=pvc_uid):
+                    return
+                if current is None:
+                    raise _retry()
+                current_uid, current_rv, current_complete = self._prove_job(
+                    current, metadata, recovery_envelope, allow_deleting=True
+                )
+                self._same((current_uid, current_rv), (uid, rv))
+                if not current_complete or not _mapping(current["metadata"]).get(
+                    "deletionTimestamp"
+                ):
+                    raise _refuse()
+                await self._prove_pods(metadata, uid, complete=True)
+                raise _retry()
+            await effect_guard()
+            current = await self._job(metadata)
+            if current is None:
+                if await self._prove_absence(metadata, pvc_uid=pvc_uid):
+                    return
+                raise _retry()
+            current_uid, current_rv, current_complete = self._prove_job(
+                current, metadata, recovery_envelope, allow_deleting=False
+            )
+            self._same((current_uid, current_rv), (uid, rv))
+            if not current_complete:
+                raise _refuse()
+            self._same(
+                self._prove_config_map(
+                    await self._config_map(metadata),
+                    metadata,
+                    recovery_envelope=init_request_recovery_envelope,
+                    init_request=init_request,
+                ),
+                config_identity,
+            )
+            await self._stopped(metadata, pvc_uid)
+            await self._prove_pods(metadata, uid, complete=True)
+            await effect_guard()
+            try:
+                await asyncio.to_thread(
+                    self._batch.delete_namespaced_job,
+                    self._name(metadata),
+                    metadata.resource_name,
+                    body={
+                        "propagationPolicy": "Foreground",
+                        "preconditions": {"uid": uid, "resourceVersion": rv},
+                    },
+                )
+            except (ClaimConflict, StaleFence):
+                raise
+            except (LostAcknowledgement, OSError):
+                pass
+            except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+                if getattr(error, "status", None) != 404 and not _retryable_kubernetes_error(error):
+                    raise _refuse() from None
+            await effect_guard()
+            if not await self._prove_absence(metadata, pvc_uid=pvc_uid):
+                raise _retry()
+        except (ClaimConflict, StaleFence, MetadataConflict, DriverRetryable):
+            raise
+        except Exception as error:  # noqa: BLE001 - provider payloads must not escape
+            if _retryable_kubernetes_error(error):
+                raise _retry() from None
+            raise _refuse() from None

--- a/infra/provisioner/src/exomem_provisioner/governance_target_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/governance_target_recovery.py
@@ -65,6 +65,15 @@ def recover_expired_serving_bundle(
             reason=ConflictReason.AUTHORIZATION_MEMBERSHIP_TRANSITION_IS_INVALID,
         )
 
+    return membership.inspect_hosted_authorization_bundle(
+        _draining_successor_files(source, issued_at=issued_at), **identity
+    )
+
+
+def _draining_successor_files(
+    source: membership.HostedAuthorizationBundle, *, issued_at: int
+) -> dict[str, bytes]:
+    """Sign bytes only; each migration caller owns its distinct authorization checks."""
     # Parse only already authenticated canonical bytes, retaining key/attachment,
     # software/schema and the enrolled activation tuple. Reuse the wire signer.
     keyring = json.loads(source.keyring)
@@ -99,11 +108,8 @@ def recover_expired_serving_bundle(
         expires_at=expires_at,
     )
     control["mac"] = membership._mac(key, membership._control_mac_input(control))
-    return membership.inspect_hosted_authorization_bundle(
-        {
-            "keyring.json": source.keyring,
-            "control.json": membership._canonical(control),
-            "serving-membership.json": record_raw,
-        },
-        **identity,
-    )
+    return {
+        "keyring.json": source.keyring,
+        "control.json": membership._canonical(control),
+        "serving-membership.json": record_raw,
+    }

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -739,6 +739,13 @@ class LifecyclePlane(Protocol):
         self, metadata: OpaqueProviderMetadata, request: dict[str, Any], context: EffectContext
     ) -> DriverPending | DriverFinal: ...
 
+    async def governance_provision(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        context: EffectContext,
+    ) -> DriverPending | DriverFinal: ...
+
     """Provider composition required by the cell lifecycle reconciler."""
 
     async def observed_fence(self, tenant_id: str) -> int: ...
@@ -1836,7 +1843,12 @@ def _fixed_helm_values(
         ),
         "initOperationId": metadata.operation_id,
         "initRequestId": _deterministic_uuid4(metadata.operation_id + ":init"),
-        "migrationMode": config.migration_mode,
+        "migrationMode": (
+            "none"
+            if request["provisionMode"] == "restore-candidate"
+            and config.migration_mode == "governance-v3-to-v4"
+            else config.migration_mode
+        ),
         "pvcSize": "10Gi",
         "provisionMode": request["provisionMode"],
         "providerIdentity": {
@@ -1949,6 +1961,10 @@ class CellLifecycleDriver:
         context: EffectContext,
     ) -> DriverPending | DriverFinal:
         try:
+            if context.checkpoint.startswith("gpi1:") and (
+                action != "provision" or context.wire_protocol != WIRE_PROTOCOL_V2
+            ):
+                raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
             if context.checkpoint.startswith(CHECKPOINT_VERSION + ":") and (
                 action not in {"provision", "rollforward"}
                 or context.wire_protocol != WIRE_PROTOCOL_V2
@@ -1971,9 +1987,13 @@ class CellLifecycleDriver:
                 return observation
             if action == "provision":
                 if self._config.migration_mode == "governance-v3-to-v4":
-                    # Fresh-cell enrollment must use the same guarded sequence;
-                    # the legacy initializer is not governance admission.
-                    raise DriverTerminal("PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE")
+                    if request.get("provisionMode") == "restore-candidate":
+                        if context.checkpoint.startswith(("gpi1:", CHECKPOINT_VERSION + ":")):
+                            raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+                        return await self._provision(request, context)
+                    return await self._plane.governance_provision(
+                        _metadata_from_context(context), request, context
+                    )
                 return await self._provision(request, context)
             if action == "health":
                 return DriverFinal(

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -39,6 +39,7 @@ from .conflict_reason import ConflictReason
 from .driver import (
     DriverFinal,
     DriverPending,
+    DriverResource,
     DriverRetryable,
     DriverTerminal,
     EffectContext,
@@ -50,6 +51,8 @@ from .governance_migration_checkpoint import (
     migration_binding,
 )
 from .governance_migration_coordinator import HostedGovernanceMigrationCoordinator
+from .governance_provision_membership import drain_fresh_bootstrap_bundle
+from .governance_storage_init import KubernetesGovernanceStorageInitAdapter
 from .lifecycle import (
     HealthObservation,
     LifecycleConfig,
@@ -344,6 +347,8 @@ class KubernetesProviderRegistry:
         self,
         current: OpaqueProviderMetadata,
         owned: OpaqueProviderMetadata,
+        *,
+        allow_owned_job_cleanup: bool = False,
     ) -> KubernetesProviderSnapshot:
         namespace = None
         try:
@@ -414,7 +419,35 @@ class KubernetesProviderRegistry:
         )
         migration_job = self._governance_job_identity(init_job, current)
         if init_job is not None and migration_job == "absent":
-            self._require_not_terminating(init_job)
+            if allow_owned_job_cleanup:
+                identity = init_job.metadata
+                if (
+                    identity.name != current.resource_name + "-init"
+                    or identity.namespace != current.resource_name
+                    or not isinstance(identity.uid, str)
+                    or not identity.uid
+                    or not isinstance(identity.resource_version, str)
+                    or not identity.resource_version
+                ):
+                    raise MetadataConflict(
+                        "initialization Job identity is invalid",
+                        reason=ConflictReason.GOVERNANCE_MIGRATION_JOB_UNAVAILABLE,
+                    )
+                _require_annotations(identity.annotations, current)
+                self._authenticate_annotations(
+                    identity.annotations,
+                    current,
+                    provider="kubernetes",
+                    provider_reference=ProviderReference.kubernetes(
+                        provider="kubernetes",
+                        api_version="batch/v1",
+                        kind="Job",
+                        namespace=current.resource_name,
+                        name=current.resource_name + "-init",
+                    ),
+                )
+            else:
+                self._require_not_terminating(init_job)
         conditions = getattr(getattr(init_job, "status", None), "conditions", ()) or ()
         init_complete = migration_job == "absent" and any(
             getattr(item, "type", None) == "Complete" and getattr(item, "status", None) == "True"
@@ -505,6 +538,8 @@ class KubernetesProviderRegistry:
         recovery_envelope: str,
         provision_mode: str,
         helm_values: dict[str, Any],
+        *,
+        effect_guard: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         labels = dict(self._PSS_LABELS)
         labels.update(
@@ -546,6 +581,8 @@ class KubernetesProviderRegistry:
                 "annotations": annotations,
             },
         }
+        if effect_guard is not None:
+            await effect_guard()
         try:
             await asyncio.to_thread(self._core.create_namespace, body)
         except Exception as error:
@@ -698,6 +735,7 @@ class LiveLifecyclePlane:
         config: LifecycleConfig,
         fingerprint: KubernetesVaultFingerprintAdapter | None = None,
         governance_migration: HostedGovernanceMigrationCoordinator | None = None,
+        storage_init: KubernetesGovernanceStorageInitAdapter | None = None,
         now: Any = time.time,
     ) -> None:
         self._repository = repository
@@ -712,12 +750,14 @@ class LiveLifecyclePlane:
         self._config = config
         self._fingerprint = fingerprint
         self._governance_migration = governance_migration
+        self._storage_init = storage_init
         self._now = now
         self._owned: dict[str, OpaqueProviderMetadata] = {}
         self._snapshots: dict[str, KubernetesProviderSnapshot] = {}
         self._recovery_envelopes: dict[str, dict[str, str]] = {}
         self._helm_requests: dict[str, dict[str, Any]] = {}
         self._operation_ids: dict[str, str] = {}
+        self._initializing_recovery: set[str] = set()
 
     @staticmethod
     def _key(metadata: OpaqueProviderMetadata) -> str:
@@ -736,7 +776,15 @@ class LiveLifecyclePlane:
             ) from error
 
     async def _refresh(self, metadata: OpaqueProviderMetadata) -> KubernetesProviderSnapshot:
-        snapshot = await self._registry.inspect(metadata, self._owner(metadata))
+        snapshot = await self._registry.inspect(
+            metadata,
+            self._owner(metadata),
+            **(
+                {"allow_owned_job_cleanup": True}
+                if self._key(metadata) in self._initializing_recovery
+                else {}
+            ),
+        )
         self._snapshots[self._key(metadata)] = snapshot
         return snapshot
 
@@ -746,6 +794,7 @@ class LiveLifecyclePlane:
         request: dict[str, Any],
         *,
         require_fresh: bool = True,
+        effect_guard: Callable[[], Awaitable[None]] | None = None,
     ) -> str:
         """Ensure one authenticated bootstrap generation before Helm can start a pod."""
 
@@ -794,6 +843,11 @@ class LiveLifecyclePlane:
                 # committed since that read is clobbered and its epoch silently
                 # reset to genesis.
                 expected_revision=expected_revision,
+                **(
+                    {"create_only": expected_revision is None, "effect_guard": effect_guard}
+                    if effect_guard is not None
+                    else {}
+                ),
             )
             return minted
 
@@ -841,6 +895,10 @@ class LiveLifecyclePlane:
                     # anything still in date.
                     if bundle.expires_at > current:
                         raise
+                    if effect_guard is not None:
+                        # A governed bootstrap never discards its existing custody.
+                        # Expired pre-enrollment progress needs verified recovery.
+                        raise
                     # Enrollment is irreversible, including while a cell is
                     # stopped and unrouted. Expiry permits renewal, never a new
                     # unenrolled genesis that discards the activation tuple.
@@ -872,6 +930,26 @@ class LiveLifecyclePlane:
                             reason=(ConflictReason.AUTHORIZATION_SESSION_EXPIRED_ON_SERVING_CELL),
                         ) from error
                     bundle = await _mint(expected_revision=bundle.revision)
+        if effect_guard is not None:
+            bundle = inspect_hosted_authorization_bundle(
+                bundle.files,
+                expected_cell_id=owned.subject_id,
+                expected_logical_vault_id=owned.tenant_id,
+                expected_replica_id=replica_id,
+                expected_software_version=target["releaseVersion"],
+                expected_schema_version=AUTHORIZATION_BOOTSTRAP_SCHEMA_VERSION,
+                expected_recovery_envelope=recovery_envelope,
+                now=int(self._now()),
+                _require_fresh=require_fresh,
+            )
+            if (
+                bundle.governance_enrolled
+                or bundle.epoch != 1
+                or bundle.replica_state != "SERVING"
+                or json.loads(bundle.control)["issued_at"] > int(self._now())
+            ):
+                raise DriverTerminal("PROVISIONER_GOVERNANCE_CUSTODY_UNAVAILABLE")
+            await effect_guard()
         return bundle.revision
 
     async def _authorization_helm_values(
@@ -1097,6 +1175,15 @@ class LiveLifecyclePlane:
                 break
         self._owned[self._key(current)] = owned
         self._helm_requests[self._key(current)] = dict(helm_request)
+        self._initializing_recovery.discard(self._key(current))
+        if (
+            self._config.migration_mode == "governance-v3-to-v4"
+            and context.wire_protocol == WIRE_PROTOCOL_V2
+            and context.checkpoint.startswith("gpi1:")
+            and request.get("provisionMode") == "serve"
+            and owned == current
+        ):
+            self._initializing_recovery.add(self._key(current))
         snapshot = await self._refresh(current)
         migration_job = snapshot.governance_migration_job
         if migration_job != "absent":
@@ -1163,6 +1250,8 @@ class LiveLifecyclePlane:
         self,
         metadata: OpaqueProviderMetadata,
         request: dict[str, Any],
+        *,
+        effect_guard: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         reservation_class = await self._require_capacity_reservation(metadata, request)
         envelopes = self._recovery_envelopes[self._key(metadata)]
@@ -1176,9 +1265,14 @@ class LiveLifecyclePlane:
                 else "restore-candidate"
             ),
             helm_values,
+            **({"effect_guard": effect_guard} if effect_guard is not None else {}),
         )
         self._owned[self._key(metadata)] = metadata
-        await self._registry.record_operation(metadata, envelopes["providerOperationConfigMap"])
+        await self._registry.record_operation(
+            metadata,
+            envelopes["providerOperationConfigMap"],
+            **({"effect_guard": effect_guard} if effect_guard is not None else {}),
+        )
         await self._refresh(metadata)
 
     def has_release(self, metadata: OpaqueProviderMetadata) -> bool:
@@ -1189,10 +1283,20 @@ class LiveLifecyclePlane:
         metadata: OpaqueProviderMetadata,
         request: dict[str, Any],
         values: dict[str, Any],
+        *,
+        effect_guard: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         await self._require_capacity_reservation(metadata, request)
         owned = self._owner(metadata)
-        revision = await self._authorization_session_revision(metadata, request)
+        revision = await self._authorization_session_revision(
+            metadata,
+            request,
+            **(
+                {"effect_guard": effect_guard, "require_fresh": False}
+                if effect_guard is not None
+                else {}
+            ),
+        )
         await self._cell.write_credential_bundle(
             owned,
             {"1": str(request["serviceCredential"])},
@@ -1204,10 +1308,19 @@ class LiveLifecyclePlane:
                     "credentialSecret"
                 ],
             },
+            **({"effect_guard": effect_guard} if effect_guard is not None else {}),
         )
         desired = dict(values)
         desired["authorizationSessionRevision"] = revision
-        await self._helm.ensure_release(owned, desired)
+        await self._helm.ensure_release(
+            owned,
+            desired,
+            **(
+                {"rollback_on_failure": False, "effect_guard": effect_guard}
+                if effect_guard is not None
+                else {}
+            ),
+        )
         await self._refresh(metadata)
 
     async def provision_retarget_required(
@@ -1742,6 +1855,301 @@ class LiveLifecyclePlane:
                 metadata, context.provider_operation_id, retry_elapsed=True
             )
         await context.assert_effect_authority()
+
+    async def governance_provision(
+        self,
+        metadata: OpaqueProviderMetadata,
+        request: dict[str, Any],
+        context: EffectContext,
+    ) -> DriverPending | DriverFinal:
+        """Initialize offline, then enter the existing migration and admission path."""
+        try:
+            await context.assert_effect_authority()
+            if (
+                request.get("provisionMode") != "serve"
+                or context.wire_protocol != WIRE_PROTOCOL_V2
+                or self._config.migration_mode != "governance-v3-to-v4"
+                or (
+                    context.tenant_id,
+                    context.cell_id,
+                    context.provider_operation_id,
+                    context.fence_generation,
+                )
+                != (
+                    metadata.tenant_id,
+                    metadata.subject_id,
+                    metadata.operation_id,
+                    metadata.fence_generation,
+                )
+                or runtime_identity(request) != self._config.runtime_target_for(request, v2=True)
+            ):
+                raise DriverTerminal("PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE")
+            if context.checkpoint.startswith(CHECKPOINT_VERSION + ":"):
+                result = await self.governance_rollforward(metadata, request, context)
+                if isinstance(result, DriverFinal):
+                    return DriverFinal(
+                        {
+                            "providerRef": self.provider_reference(metadata),
+                            "privateEndpoint": (
+                                f"https://{self._config.control_hostname}/cells/{metadata.subject_id}"
+                            ),
+                        },
+                        resources=result.resources
+                        + (DriverResource(ResourceKind.ROUTE, metadata.resource_name + "-routes"),),
+                    )
+                return result
+            key = self._key(metadata)
+            owner = self._owned[key]
+            # A fresh provision cannot adopt another operation's initialized cell.
+            if owner != metadata:
+                raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+            if context.checkpoint.startswith("gpi1:"):
+                self._initializing_recovery.add(key)
+            original = self._helm_requests[key]
+            values = _fixed_helm_values(owner, original, self._config)
+            values["workloadMode"] = "initialize"
+            # The initializer only establishes storage. Governance is executed
+            # by the target-image coordinator after this Job is gone.
+            values["migrationMode"] = "none"
+
+            async def unstarted() -> None:
+                await context.assert_effect_authority()
+                snapshot = await self._refresh(metadata)
+                if (
+                    snapshot.serving
+                    or snapshot.runtime_admitted
+                    or snapshot.routes != (False, False)
+                ):
+                    raise DriverTerminal("PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE")
+                await context.assert_effect_authority()
+
+            if context.checkpoint in {
+                "effect-prepared",
+                "namespace-ready",
+                "release-applied",
+                "csi-binding",
+                "volume-registration-required",
+            }:
+                await unstarted()
+                snapshot = self._snapshot(metadata)
+                if not snapshot.namespace:
+                    if context.checkpoint not in {"effect-prepared", "namespace-ready"}:
+                        raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+                    await self.ensure_namespace(metadata, request, effect_guard=unstarted)
+                    return DriverPending(
+                        "namespace-ready",
+                        1,
+                        (
+                            DriverResource(
+                                ResourceKind.KUBERNETES_NAMESPACE, metadata.resource_name
+                            ),
+                        ),
+                    )
+                if context.checkpoint in {"effect-prepared", "namespace-ready"}:
+                    # Reuse the chart's offline storage shell: no Job or runtime
+                    # exists until a bound gpi1 denial marker has committed.
+                    await self.install_release(
+                        metadata,
+                        original,
+                        values | {"workloadMode": "restore"},
+                        effect_guard=unstarted,
+                    )
+                    return DriverPending(
+                        "release-applied",
+                        1,
+                        (
+                            DriverResource(ResourceKind.HELM_RELEASE, metadata.resource_name),
+                            DriverResource(ResourceKind.PVC, metadata.resource_name + "-data"),
+                        ),
+                    )
+                if not await self.volume_claim_bound(metadata):
+                    return DriverPending("csi-binding", 2)
+                return DriverPending("volume-registration-required", 1)
+            pvc_uid = await self._cell.authenticated_volume_uid(owner)
+            binding = migration_binding(context, pvc_uid=pvc_uid, runtime_image=self._config.image)
+            phase = None
+            if context.checkpoint.startswith("gpi1:"):
+                parts = context.checkpoint.split(":")
+                if (
+                    len(parts) != 3
+                    or parts[1] not in {"initializing", "complete", "drained"}
+                    or parts[2] != binding
+                ):
+                    raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+                phase = parts[1]
+            elif context.checkpoint != "volume-owned":
+                raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
+
+            async def bound() -> None:
+                await self._governance_authority(
+                    metadata, request, context, pvc_uid, maintenance=False
+                )
+                snapshot = await self._refresh(metadata)
+                if (
+                    snapshot.serving
+                    or snapshot.runtime_admitted
+                    or snapshot.routes != (False, False)
+                ):
+                    raise DriverTerminal("PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE")
+                await context.assert_effect_authority()
+
+            async def closed() -> None:
+                await bound()
+                await self._governance_authority(metadata, request, context, pvc_uid, closed=True)
+
+            async def stopped() -> None:
+                await closed()
+                await self._governance_authority(
+                    metadata, request, context, pvc_uid, closed=True, stopped=True
+                )
+
+            await bound()
+            if not await self._maintenance.acquire(
+                metadata, context.provider_operation_id, effect_guard=bound
+            ):
+                return DriverPending(context.checkpoint, 2)
+            await closed()
+            if phase is None:
+                return DriverPending("gpi1:initializing:" + binding, 1)
+            if self._storage_init is None:
+                raise DriverTerminal("PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE")
+            init_arguments = {
+                "pvc_uid": pvc_uid,
+                "recovery_envelope": self._recovery_envelopes[key]["initJob"],
+                "effect_guard": closed,
+                "init_request_recovery_envelope": self._recovery_envelopes[key][
+                    "initRequestConfigMap"
+                ],
+                "init_request": {
+                    "request_id": values["initRequestId"],
+                    "operation_id": values["initOperationId"],
+                    "cell_id": values["cellId"],
+                    "vault_id": values["vaultId"],
+                    "vault_root": "/var/lib/exomem/vault",
+                    "state_root": "/var/lib/exomem/state",
+                    "log_root": "/var/lib/exomem/logs",
+                    "expected_release": values["expectedRelease"],
+                    "expected_protocol": values["expectedProtocol"],
+                    "runtime_uid": values["runtimeUid"],
+                    "runtime_gid": values["runtimeGid"],
+                    "active_credential_version": values["activeCredentialVersion"],
+                },
+            }
+            if phase == "initializing":
+                if await self._storage_init.completed(owner, **init_arguments):
+                    return DriverPending("gpi1:complete:" + binding, 1)
+                if not (await self._refresh(metadata)).init_job_present:
+                    # TTL cleanup can beat worker observation. The runtime
+                    # initializer verifies its durable exact-request replay proof.
+                    await stopped()
+                    values[
+                        "authorizationSessionRevision"
+                    ] = await self._authorization_session_revision(
+                        metadata, original, require_fresh=False, effect_guard=stopped
+                    )
+                    await self._helm.ensure_release(
+                        owner, values, rollback_on_failure=False, effect_guard=stopped
+                    )
+                return DriverPending(context.checkpoint, 30)
+            if phase == "complete":
+                await self._storage_init.cleanup(owner, **init_arguments)
+                await stopped()
+                envelope = self._helm_requests[key]["_providerRecoveryEnvelopes"][
+                    "authorizationSessionSecret"
+                ]
+                files = await self._cell.read_authorization_session_bundle(owner)
+                if files is None:
+                    raise DriverTerminal("PROVISIONER_GOVERNANCE_CUSTODY_UNAVAILABLE")
+                identity = {
+                    "expected_cell_id": owner.subject_id,
+                    "expected_logical_vault_id": owner.tenant_id,
+                    "expected_replica_id": owner.resource_name + "-0",
+                    "expected_software_version": runtime_identity(request)["releaseVersion"],
+                    "expected_schema_version": AUTHORIZATION_BOOTSTRAP_SCHEMA_VERSION,
+                    "expected_recovery_envelope": envelope,
+                }
+                source = inspect_hosted_authorization_bundle(
+                    files, **identity, now=int(self._now()), _require_fresh=False
+                )
+                if source.governance_enrolled:
+                    raise DriverTerminal("PROVISIONER_GOVERNANCE_CUSTODY_UNAVAILABLE")
+                successor = drain_fresh_bootstrap_bundle(
+                    source.files,
+                    **{
+                        key: value
+                        for key, value in identity.items()
+                        if key != "expected_schema_version"
+                    },
+                    now=int(self._now()),
+                )
+
+                async def publish() -> None:
+                    await stopped()
+                    drain_fresh_bootstrap_bundle(
+                        source.files,
+                        **{
+                            key: value
+                            for key, value in identity.items()
+                            if key != "expected_schema_version"
+                        },
+                        now=int(self._now()),
+                    )
+                    inspect_hosted_authorization_bundle(
+                        successor.files, **identity, now=int(self._now())
+                    )
+
+                if source.revision != successor.revision:
+                    await self._cell.write_authorization_session_bundle(
+                        owner,
+                        successor.files,
+                        recovery_envelope=envelope,
+                        membership_epoch=successor.epoch,
+                        membership_digest=successor.membership_digest,
+                        revision=successor.revision,
+                        expected_revision=source.revision,
+                        effect_guard=publish,
+                    )
+                await stopped()
+                return DriverPending("gpi1:drained:" + binding, 1)
+            if self._fingerprint is None or self._governance_migration is None:
+                raise DriverTerminal("PROVISIONER_GOVERNANCE_MIGRATION_UNAVAILABLE")
+
+            async def fingerprint_authority() -> None:
+                await closed()
+                await self._fingerprint.prove_stopped_before_fingerprint(
+                    metadata,
+                    owner=owner,
+                    pvc_uid=pvc_uid,
+                    operation_id=context.provider_operation_id,
+                    recovery_envelope=self._recovery_envelopes[key]["initJob"],
+                )
+                await closed()
+
+            await fingerprint_authority()
+            before = await self._fingerprint.fingerprint(
+                metadata,
+                operation_id=context.provider_operation_id,
+                phase="before",
+                recovery_envelope=self._recovery_envelopes[key]["initJob"],
+                effect_guard=fingerprint_authority,
+            )
+            await stopped()
+            # Enter gm1 directly so no durable checkpoint loses the PVC binding.
+            return await self._governance_migration.advance(
+                context=replace(
+                    context, checkpoint="vault-fingerprinted-" + before, effect_guard=closed
+                ),
+                metadata=metadata,
+                owner=owner,
+                pvc_uid=pvc_uid,
+                runtime_image=self._config.image,
+                job_recovery_envelope=self._recovery_envelopes[key]["initJob"],
+                custody_recovery_envelope=self._helm_requests[key]["_providerRecoveryEnvelopes"][
+                    "authorizationSessionSecret"
+                ],
+            )
+        except (DriverRetryable, LostAcknowledgement):
+            return DriverPending(context.checkpoint, 30)
 
     async def governance_rollforward(
         self,

--- a/infra/provisioner/src/exomem_provisioner/production.py
+++ b/infra/provisioner/src/exomem_provisioner/production.py
@@ -28,6 +28,7 @@ from .durability_driver import DurabilityActionDriver
 from .entrypoint import help_requested
 from .governance_migration_coordinator import HostedGovernanceMigrationCoordinator
 from .governance_migration_job import KubernetesGovernanceMigrationAdapter
+from .governance_storage_init import KubernetesGovernanceStorageInitAdapter
 from .lifecycle import CellLifecycleDriver, LifecycleConfig
 from .live import (
     KubernetesProviderRegistry,
@@ -206,6 +207,13 @@ def build_live_provider_components(
         capacity=capacity,
         identity_verifier=identity_verifier,
         config=lifecycle_config,
+        storage_init=KubernetesGovernanceStorageInitAdapter(
+            core_v1=core_v1,
+            batch_v1=batch_v1,
+            apps_v1=apps_v1,
+            identity_verifier=identity_verifier,
+            runtime_image=lifecycle_config.image,
+        ),
         governance_migration=HostedGovernanceMigrationCoordinator(
             cell=cell,
             jobs=KubernetesGovernanceMigrationAdapter(
@@ -217,6 +225,7 @@ def build_live_provider_components(
         fingerprint=KubernetesVaultFingerprintAdapter(
             core_v1=core_v1,
             batch_v1=batch_v1,
+            apps_v1=apps_v1,
             image=lock.components.provisioner.image,
         ),
     )

--- a/infra/provisioner/src/exomem_provisioner/repository.py
+++ b/infra/provisioner/src/exomem_provisioner/repository.py
@@ -35,6 +35,8 @@ from .models import (
 from .provider_identity import cell_resource_name
 from .wire_protocol import WIRE_PROTOCOL_V1, WIRE_PROTOCOL_V2
 
+GOVERNANCE_PROVISION_CHECKPOINT_VERSION = "gpi1"
+
 
 class RepositoryConflict(RuntimeError):
     pass
@@ -61,10 +63,12 @@ class ClaimConflict(RepositoryConflict):
 
 
 def _holds_governance_checkpoint(operation: Operation, checkpoint: str) -> bool:
-    return (
-        operation.action in {OperationAction.PROVISION, OperationAction.ROLLFORWARD}
-        and operation.wire_protocol == WireProtocol.V2
-        and checkpoint.startswith(GOVERNANCE_CHECKPOINT_VERSION + ":")
+    if operation.wire_protocol != WireProtocol.V2:
+        return False
+    if checkpoint.startswith(GOVERNANCE_CHECKPOINT_VERSION + ":"):
+        return operation.action in {OperationAction.PROVISION, OperationAction.ROLLFORWARD}
+    return operation.action == OperationAction.PROVISION and checkpoint.startswith(
+        GOVERNANCE_PROVISION_CHECKPOINT_VERSION + ":"
     )
 
 
@@ -78,10 +82,20 @@ def _foreign_governance_barrier(operation: Any):
             barrier.id != operation.id,
             barrier.tenant_id == operation.tenant_id,
             or_(barrier.cell_id == operation.cell_id, operation.action == OperationAction.DESTROY),
-            barrier.action.in_({OperationAction.PROVISION, OperationAction.ROLLFORWARD}),
             barrier.wire_protocol == WireProtocol.V2,
-            barrier.checkpoint.startswith(GOVERNANCE_CHECKPOINT_VERSION + ":"),
-            barrier.state.in_({OperationState.PENDING, OperationState.CLAIMED, OperationState.ERROR}),
+            or_(
+                and_(
+                    barrier.action.in_({OperationAction.PROVISION, OperationAction.ROLLFORWARD}),
+                    barrier.checkpoint.startswith(GOVERNANCE_CHECKPOINT_VERSION + ":"),
+                ),
+                and_(
+                    barrier.action == OperationAction.PROVISION,
+                    barrier.checkpoint.startswith(GOVERNANCE_PROVISION_CHECKPOINT_VERSION + ":"),
+                ),
+            ),
+            barrier.state.in_(
+                {OperationState.PENDING, OperationState.CLAIMED, OperationState.ERROR}
+            ),
         )
         .exists()
     )
@@ -496,7 +510,11 @@ async def _release_completed_capacity(
         },
     }
     required = proof_fields.get(operation.action)
-    if required is None or set(result) != required or any(result[key] is not True for key in required):
+    if (
+        required is None
+        or set(result) != required
+        or any(result[key] is not True for key in required)
+    ):
         return
     if operation.action is OperationAction.DISCARD and operation.cell_id is None:
         raise ImmutableMetadataConflict("discard capacity release has no authenticated cell")
@@ -529,8 +547,7 @@ async def _release_completed_capacity(
             and not (
                 operation.action is OperationAction.DISCARD
                 and reservation.resource_name == cell_resource_name(operation.cell_id)
-                and reservation.reserving_provider_operation_id
-                == operation.external_operation_id
+                and reservation.reserving_provider_operation_id == operation.external_operation_id
             )
         )
         for reservation in reservations
@@ -677,7 +694,9 @@ class OperationRepository:
                         .with_for_update()
                     )
                     if existing is not None and str(existing.wire_protocol) != wire_protocol:
-                        raise IdempotencyConflict("idempotency key is bound to another wire protocol")
+                        raise IdempotencyConflict(
+                            "idempotency key is bound to another wire protocol"
+                        )
                     if existing is not None and existing.canonical_request_sha256 != digest:
                         raise IdempotencyConflict("idempotency key is bound to another request")
                     if fence is not None and fence_generation < fence.fence_generation:
@@ -766,8 +785,7 @@ class OperationRepository:
                 runtime_identity: dict[str, str] | None = None
                 target = request.get("runtimeTarget")
                 if isinstance(target, dict) and all(
-                    isinstance(key, str) and isinstance(value, str)
-                    for key, value in target.items()
+                    isinstance(key, str) and isinstance(value, str) for key, value in target.items()
                 ):
                     runtime_identity = dict(target)
                 elif isinstance(request.get("releaseVersion"), str) and isinstance(

--- a/infra/provisioner/tests/test_governance_fingerprint_stop.py
+++ b/infra/provisioner/tests/test_governance_fingerprint_stop.py
@@ -1,0 +1,76 @@
+"""A retry may observe its own read-only fingerprint, never an arbitrary PVC user."""
+
+from types import SimpleNamespace
+
+import pytest
+from test_governance_live_recovery import Missing
+from test_governance_stopped_cell import _pod as unrelated_pod
+from test_governance_stopped_cell import _pvc
+from test_vault_fingerprint_execution_proof import ENVELOPE, METADATA, OPERATION, Cluster, _adapter
+
+from exomem_provisioner.lifecycle import MetadataConflict
+
+
+def cluster(**kwargs):
+    adapter = _adapter()
+    result = Cluster(adapter, **kwargs)
+    adapter._core.read_namespaced_persistent_volume_claim = lambda *args: _pvc()
+
+    def missing(*args):
+        raise Missing
+
+    adapter._apps = SimpleNamespace(read_namespaced_stateful_set=missing)
+    return result
+
+
+async def prove(h):
+    await h.adapter.prove_stopped_before_fingerprint(
+        METADATA,
+        owner=METADATA,
+        pvc_uid="pvc-alpha",
+        operation_id=OPERATION,
+        recovery_envelope=ENVELOPE,
+    )
+
+
+async def test_exact_owned_fingerprint_pod_can_be_reconciled_after_interruption():
+    await prove(cluster())
+
+
+async def test_stopped_fingerprint_proof_refuses_unlabelled_pvc_user():
+    h = cluster()
+    h.pods.append(
+        unrelated_pod(
+            volumes=[
+                {
+                    "name": "vault",
+                    "persistentVolumeClaim": {"claimName": METADATA.resource_name + "-data"},
+                }
+            ]
+        )
+    )
+    with pytest.raises(MetadataConflict):
+        await prove(h)
+
+
+async def test_stopped_fingerprint_proof_requires_canonical_executable_job():
+    h = cluster(
+        job_mutate=lambda job: job["spec"]["template"]["spec"]["containers"][0].update(
+            command=["foreign"]
+        )
+    )
+    with pytest.raises(MetadataConflict):
+        await prove(h)
+
+
+async def test_stopped_fingerprint_proof_requires_canonical_executable_pod():
+    h = cluster(pod_mutate=lambda pod: pod["spec"]["containers"][0].update(command=["foreign"]))
+    with pytest.raises(MetadataConflict):
+        await prove(h)
+
+
+async def test_stopped_fingerprint_proof_refuses_two_owned_candidate_pods():
+    h = cluster()
+    h.pods = h.pods * 2
+    with pytest.raises(MetadataConflict):
+        await prove(h)

--- a/infra/provisioner/tests/test_governance_lifecycle_driver.py
+++ b/infra/provisioner/tests/test_governance_lifecycle_driver.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 import pytest
 from test_provider_lifecycle import _config, _context, _v2_request
 
-from exomem_provisioner.driver import DriverFinal, DriverPending, DriverTerminal
+from exomem_provisioner.driver import DriverFinal, DriverPending
 from exomem_provisioner.governance_migration_checkpoint import MigrationCheckpoint
 from exomem_provisioner.lifecycle import CellLifecycleDriver, HighFidelityProviderPlane
 from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V2
@@ -27,6 +27,10 @@ class MigrationPlane(HighFidelityProviderPlane):
         self.result = None
 
     async def governance_rollforward(self, metadata, request, context):
+        self.migration_calls.append(context)
+        return self.result or DriverPending(context.checkpoint, 30)
+
+    async def governance_provision(self, metadata, request, context):
         self.migration_calls.append(context)
         return self.result or DriverPending(context.checkpoint, 30)
 
@@ -55,8 +59,11 @@ async def test_dispatch_preserves_governance_checkpoint(phase):
 async def test_governance_provision_cannot_enter_legacy_admission():
     plane = MigrationPlane()
     driver = CellLifecycleDriver(plane=plane, config=config(), volume_worker=None)
-    with pytest.raises(DriverTerminal, match="PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE"):
-        await driver.execute("provision", _v2_request(), _context(wire_protocol=WIRE_PROTOCOL_V2))
+    context = _context(wire_protocol=WIRE_PROTOCOL_V2)
+    assert await driver.execute("provision", _v2_request(), context) == DriverPending(
+        context.checkpoint, 30
+    )
+    assert plane.migration_calls == [context]
 
 
 @pytest.mark.asyncio
@@ -72,3 +79,27 @@ async def test_governance_final_result_only_follows_plane_completion():
         )
         == plane.result
     )
+
+
+@pytest.mark.asyncio
+async def test_offline_restore_candidate_does_not_enter_fresh_governance_enrollment():
+    plane = MigrationPlane()
+    driver = CellLifecycleDriver(plane=plane, config=config(), volume_worker=None)
+    context = _context(wire_protocol=WIRE_PROTOCOL_V2)
+    request = _v2_request(provisionMode="restore-candidate")
+    result = await driver.execute("provision", request, context)
+    assert result.checkpoint == "namespace-ready"
+    assert not plane.migration_calls
+    context = replace(context, checkpoint=result.checkpoint)
+    result = await driver.execute("provision", request, context)
+    assert result.checkpoint == "release-applied"
+    assert not plane.migration_calls
+
+
+def test_offline_restore_chart_never_passes_governance_mode_to_storage_init():
+    from exomem_provisioner.lifecycle import _fixed_helm_values, _metadata_from_context
+
+    values = _fixed_helm_values(
+        _metadata_from_context(_context()), _v2_request(provisionMode="restore-candidate"), config()
+    )
+    assert values["workloadMode"] == "restore" and values["migrationMode"] == "none"

--- a/infra/provisioner/tests/test_governance_provision_barrier.py
+++ b/infra/provisioner/tests/test_governance_provision_barrier.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from test_governance_migration_barrier import postgresql17 as postgresql17
+from test_governance_migration_barrier import postgresql_repository as postgresql_repository
+from test_governance_migration_barrier import repository as repository
+from test_governance_migration_barrier import sqlite_repository as sqlite_repository
+from test_worker import _v2_request
+
+from exomem_provisioner.governance_migration_checkpoint import MigrationCheckpoint
+from exomem_provisioner.models import Operation, OperationAction, OperationState
+from exomem_provisioner.repository import ClaimConflict
+from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V1, WIRE_PROTOCOL_V2
+
+NOW = datetime(2030, 1, 1, tzinfo=UTC)
+GPI1 = "gpi1:initializing:" + "A" * 43
+GM1 = MigrationCheckpoint("inspect", "a" * 64, "A" * 43).encode()
+
+
+async def _submit(repository, action="provision", *, wire_protocol=WIRE_PROTOCOL_V2, **changes):
+    request = _v2_request(**changes)
+    return await repository.submit(
+        action,
+        action + str(request["operationId"]),
+        request,
+        wire_protocol=wire_protocol,
+    )
+
+
+async def _mark(repository, operation, *, state, checkpoint=GPI1):
+    async with repository.session_factory.begin() as session:
+        stored = await session.get(Operation, operation.id)
+        stored.checkpoint = checkpoint
+        stored.state = state
+        if state is OperationState.CLAIMED:
+            stored.claim_owner = "lost-worker"
+            stored.claim_token = "lost-claim"
+            stored.claim_expires_at = NOW
+
+
+@pytest.mark.parametrize(
+    "state", [OperationState.PENDING, OperationState.CLAIMED, OperationState.ERROR]
+)
+async def test_durable_provision_checkpoint_blocks_same_cell_successors(repository, state):
+    provision = await _submit(repository, operationId="provision")
+    await _mark(repository, provision, state=state)
+    await _submit(repository, "resume", operationId="successor")
+
+    assert (
+        await repository.claim_next(
+            "successor-worker",
+            now=NOW + timedelta(hours=1),
+            allowed_actions=frozenset({OperationAction.RESUME}),
+        )
+        is None
+    )
+
+
+async def test_provision_checkpoint_allows_unrelated_cell_and_its_own_retry(repository):
+    provision = await _submit(repository, operationId="provision")
+    await _mark(repository, provision, state=OperationState.PENDING)
+    await _submit(repository, "resume", operationId="blocked")
+    unrelated = await _submit(repository, "resume", operationId="unrelated", cellId="another-cell")
+
+    acquired = await repository.claim_next(
+        "other-worker",
+        now=NOW,
+        allowed_actions=frozenset({OperationAction.RESUME}),
+    )
+    assert acquired is not None and acquired.id == unrelated.id
+    retry = await repository.claim_next(
+        "provision-worker",
+        now=NOW,
+        allowed_actions=frozenset({OperationAction.PROVISION}),
+    )
+    assert retry is not None and retry.id == provision.id
+
+
+@pytest.mark.parametrize("action", ["resume", "destroy"])
+async def test_first_provision_checkpoint_refuses_overlapping_operation(repository, action):
+    provision = await _submit(repository, operationId="provision")
+    claim = await repository.claim_next(
+        "provision-worker", now=NOW, allowed_actions=frozenset({OperationAction.PROVISION})
+    )
+    assert claim is not None and claim.id == provision.id
+    overlap = await _submit(
+        repository,
+        action,
+        operationId="overlap",
+        **({"cellId": None} if action == "destroy" else {}),
+    )
+    if action == "resume":
+        await _mark(repository, overlap, state=OperationState.CLAIMED, checkpoint="effect-prepared")
+
+    with pytest.raises(ClaimConflict):
+        await repository.mark_pending(
+            provision.id,
+            "provision-worker",
+            claim_token=claim.claim_token,
+            claim_generation=claim.claim_generation,
+            checkpoint=GPI1,
+            retry_after_seconds=1,
+            now=NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    ("action", "wire_protocol"),
+    [
+        ("provision", WIRE_PROTOCOL_V1),
+        ("rollforward", WIRE_PROTOCOL_V2),
+        ("resume", WIRE_PROTOCOL_V2),
+    ],
+)
+async def test_gpi1_only_fences_v2_provision(repository, action, wire_protocol):
+    marker = await _submit(
+        repository,
+        action,
+        operationId="non-barrier",
+        wire_protocol=wire_protocol,
+    )
+    await _mark(repository, marker, state=OperationState.ERROR)
+    successor = await _submit(repository, "resume", operationId="successor")
+
+    claim = await repository.claim_next(
+        "successor-worker",
+        now=NOW,
+        allowed_actions=frozenset({OperationAction.RESUME}),
+    )
+    assert claim is not None and claim.id == successor.id
+
+
+async def test_gpi1_to_gm1_transition_and_terminal_failure_retain_barrier(repository):
+    provision = await _submit(repository, operationId="provision")
+    initial = await repository.claim_next(
+        "provision-worker", now=NOW, allowed_actions=frozenset({OperationAction.PROVISION})
+    )
+    await repository.mark_pending(
+        provision.id,
+        "provision-worker",
+        claim_token=initial.claim_token,
+        claim_generation=initial.claim_generation,
+        checkpoint=GPI1,
+        retry_after_seconds=1,
+        now=NOW,
+    )
+    retry = await repository.claim_next(
+        "provision-worker",
+        now=NOW + timedelta(seconds=2),
+        allowed_actions=frozenset({OperationAction.PROVISION}),
+    )
+    await repository.mark_pending(
+        provision.id,
+        "provision-worker",
+        claim_token=retry.claim_token,
+        claim_generation=retry.claim_generation,
+        checkpoint=GM1,
+        retry_after_seconds=1,
+        now=NOW + timedelta(seconds=2),
+    )
+    successor = await _submit(repository, "resume", operationId="successor")
+    assert (
+        await repository.claim_next(
+            "successor-worker",
+            now=NOW + timedelta(seconds=3),
+            allowed_actions=frozenset({OperationAction.RESUME}),
+        )
+        is None
+    )
+
+    terminal = await repository.claim_next(
+        "provision-worker",
+        now=NOW + timedelta(seconds=4),
+        allowed_actions=frozenset({OperationAction.PROVISION}),
+    )
+    failed = await repository.fail(
+        provision.id,
+        "provision-worker",
+        claim_token=terminal.claim_token,
+        claim_generation=terminal.claim_generation,
+        code="PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE",
+        now=NOW + timedelta(seconds=4),
+    )
+    assert failed.checkpoint == GM1
+    assert (
+        await repository.claim_next(
+            "successor-worker",
+            now=NOW + timedelta(days=1),
+            allowed_actions=frozenset({OperationAction.RESUME}),
+        )
+        is None
+    )
+    assert (await repository.get_by_id(successor.id)).state is OperationState.PENDING
+
+
+@pytest.mark.parametrize("failure", ["terminal", "exhausted"])
+async def test_terminal_provision_failure_retains_gpi1_barrier(repository, failure):
+    provision = await _submit(repository, operationId="provision")
+    initial = await repository.claim_next(
+        "provision-worker", now=NOW, allowed_actions=frozenset({OperationAction.PROVISION})
+    )
+    await repository.mark_pending(
+        provision.id,
+        "provision-worker",
+        claim_token=initial.claim_token,
+        claim_generation=initial.claim_generation,
+        checkpoint=GPI1,
+        retry_after_seconds=1,
+        now=NOW,
+    )
+    retry = await repository.claim_next(
+        "provision-worker",
+        now=NOW + timedelta(seconds=2),
+        allowed_actions=frozenset({OperationAction.PROVISION}),
+    )
+    if failure == "terminal":
+        failed = await repository.fail(
+            provision.id,
+            "provision-worker",
+            claim_token=retry.claim_token,
+            claim_generation=retry.claim_generation,
+            code="PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE",
+            now=NOW + timedelta(seconds=2),
+        )
+    else:
+        repository.max_failure_attempts = 1
+        failed = await repository.record_retryable_failure(
+            provision.id,
+            "provision-worker",
+            claim_token=retry.claim_token,
+            claim_generation=retry.claim_generation,
+            retry_after_seconds=1,
+            now=NOW + timedelta(seconds=2),
+        )
+    await _submit(repository, "resume", operationId="successor")
+
+    assert failed.state is OperationState.ERROR and failed.checkpoint == GPI1
+    assert (
+        await repository.claim_next(
+            "successor-worker",
+            now=NOW + timedelta(days=1),
+            allowed_actions=frozenset({OperationAction.RESUME}),
+        )
+        is None
+    )
+
+
+async def test_final_provision_clears_gpi1_barrier_atomically(repository):
+    provision = await _submit(repository, operationId="provision")
+    initial = await repository.claim_next(
+        "provision-worker", now=NOW, allowed_actions=frozenset({OperationAction.PROVISION})
+    )
+    await repository.mark_pending(
+        provision.id,
+        "provision-worker",
+        claim_token=initial.claim_token,
+        claim_generation=initial.claim_generation,
+        checkpoint=GPI1,
+        retry_after_seconds=1,
+        now=NOW,
+    )
+    successor = await _submit(repository, "resume", operationId="successor")
+    retry = await repository.claim_next(
+        "provision-worker",
+        now=NOW + timedelta(seconds=2),
+        allowed_actions=frozenset({OperationAction.PROVISION}),
+    )
+    await repository.checkpoint_effect_applied(
+        provision.id,
+        worker_id="provision-worker",
+        claim_token=retry.claim_token,
+        claim_generation=retry.claim_generation,
+        now=NOW + timedelta(seconds=2),
+    )
+    assert (await repository.get_by_id(provision.id)).checkpoint == GPI1
+    final = await repository.complete(
+        provision.id,
+        {},
+        worker_id="provision-worker",
+        claim_token=retry.claim_token,
+        claim_generation=retry.claim_generation,
+        now=NOW + timedelta(seconds=2),
+    )
+
+    assert final.state is OperationState.FINAL and final.checkpoint == "complete"
+    claim = await repository.claim_next("successor-worker", now=NOW + timedelta(seconds=2))
+    assert claim is not None and claim.id == successor.id

--- a/infra/provisioner/tests/test_governance_provision_effects.py
+++ b/infra/provisioner/tests/test_governance_provision_effects.py
@@ -1,0 +1,116 @@
+"""Bootstrap creates cannot overwrite custody or outlive their worker claim."""
+
+import base64
+
+import pytest
+from test_governance_live_recovery import Missing
+from test_governance_readiness import METADATA, NOW, SOFTWARE_VERSION
+
+from exomem_provisioner.adapters import KubernetesCellAdapter
+from exomem_provisioner.authorization_membership import build_initial_hosted_authorization_bundle
+from exomem_provisioner.driver import DriverRetryable
+from exomem_provisioner.repository import ClaimConflict
+
+
+async def allow():
+    pass
+
+
+async def lost():
+    raise ClaimConflict("claim lost")
+
+
+class Core:
+    def __init__(self):
+        self.secret = None
+        self.creates = []
+        self.patches = []
+
+    def read_namespaced_secret(self, *args):
+        if self.secret is None:
+            raise Missing
+        return self.secret
+
+    def create_namespaced_secret(self, namespace, body):
+        self.creates.append(body)
+
+    def patch_namespaced_secret(self, *args):
+        self.patches.append(args)
+        raise AssertionError("bootstrap must not patch an existing Secret")
+
+
+def bootstrap():
+    return build_initial_hosted_authorization_bundle(
+        cell_id=METADATA.subject_id,
+        logical_vault_id=METADATA.tenant_id,
+        replica_id=METADATA.resource_name + "-0",
+        software_version=SOFTWARE_VERSION,
+        schema_version=3,
+        recovery_envelope="original-envelope",
+        now=NOW,
+    )
+
+
+async def create_custody(adapter, guard):
+    bundle = bootstrap()
+    await adapter.write_authorization_session_bundle(
+        METADATA,
+        bundle.files,
+        recovery_envelope="original-envelope",
+        membership_epoch=bundle.epoch,
+        membership_digest=bundle.membership_digest,
+        revision=bundle.revision,
+        create_only=True,
+        effect_guard=guard,
+    )
+
+
+@pytest.mark.asyncio
+async def test_guarded_genesis_creates_without_patch():
+    core = Core()
+    await create_custody(KubernetesCellAdapter(core_v1=core, apps_v1=None), allow)
+    assert len(core.creates) == 1 and not core.patches
+
+
+@pytest.mark.asyncio
+async def test_guarded_genesis_claim_loss_prevents_create():
+    core = Core()
+    with pytest.raises(ClaimConflict):
+        await create_custody(KubernetesCellAdapter(core_v1=core, apps_v1=None), lost)
+    assert not core.creates and not core.patches
+
+
+@pytest.mark.asyncio
+async def test_guarded_genesis_conflict_is_uncertain_never_patch():
+    class Conflict(Exception):
+        status = 409
+
+    core = Core()
+
+    def conflict(*args):
+        raise Conflict
+
+    core.create_namespaced_secret = conflict
+    with pytest.raises(DriverRetryable):
+        await create_custody(KubernetesCellAdapter(core_v1=core, apps_v1=None), allow)
+    assert not core.patches
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guard", [allow, lost])
+async def test_guarded_bootstrap_credential_create_honors_authority(guard):
+    core = Core()
+    adapter = KubernetesCellAdapter(core_v1=core, apps_v1=None)
+    args = {
+        "lifecycle_annotations": {"exomem.io/recovery-envelope": "credential-envelope"},
+        "effect_guard": guard,
+    }
+    credential = base64.urlsafe_b64encode(bytes(range(32))).rstrip(b"=").decode()
+    if guard is lost:
+        with pytest.raises(ClaimConflict):
+            await adapter.write_credential_bundle(METADATA, {"1": credential}, **args)
+        assert not core.creates
+    else:
+        await adapter.write_credential_bundle(METADATA, {"1": credential}, **args)
+        assert len(core.creates) == 1
+    assert not core.patches

--- a/infra/provisioner/tests/test_governance_provision_live.py
+++ b/infra/provisioner/tests/test_governance_provision_live.py
@@ -1,0 +1,359 @@
+"""Fresh storage stays offline until the shared governance coordinator completes."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from test_governance_live_recovery import Missing
+from test_governance_readiness import METADATA, NOW, SOFTWARE_VERSION
+from test_governance_rollforward_live import RollforwardHarness
+
+from exomem_provisioner.authorization_membership import (
+    build_initial_hosted_authorization_bundle,
+    inspect_hosted_authorization_bundle,
+)
+from exomem_provisioner.driver import (
+    DriverFinal,
+    DriverPending,
+    DriverTerminal,
+    LostAcknowledgement,
+)
+from exomem_provisioner.governance_migration_checkpoint import (
+    MigrationCheckpoint,
+    migration_binding,
+)
+from exomem_provisioner.lifecycle import MetadataConflict
+from exomem_provisioner.repository import ClaimConflict
+
+
+class InitialEffects:
+    def __init__(self, h):
+        self.h = h
+
+    async def require_active(self, **kwargs):
+        self.h.effects.append("capacity")
+
+    async def ensure_release(self, metadata, values, *, rollback_on_failure, effect_guard):
+        await effect_guard()
+        assert rollback_on_failure is False
+        assert values["workloadMode"] in {"initialize", "restore"}
+        assert values["migrationMode"] == "none"
+        assert values["routes"]["enabled"] is False
+        self.h.helm_calls.append(values)
+        self.h.effects.append(
+            "initialize" if values["workloadMode"] == "initialize" else "storage-shell"
+        )
+
+
+class ProvisionHarness(RollforwardHarness):
+    def __init__(self):
+        super().__init__()
+        self.current = METADATA
+        self.now = NOW + 5
+        self.context = replace(
+            self.context,
+            provider_operation_id=METADATA.operation_id,
+            fence_generation=METADATA.fence_generation,
+            checkpoint="volume-owned",
+        )
+        self.request["provisionMode"] = "serve"
+        self.lease.metadata.annotations = METADATA.kubernetes_annotations
+        self.lease.spec.holder_identity = METADATA.operation_id
+        self.plane._recovery_envelopes[self.plane._key(self.current)] = self.envelopes
+        self.files = build_initial_hosted_authorization_bundle(
+            cell_id=METADATA.subject_id,
+            logical_vault_id=METADATA.tenant_id,
+            replica_id=METADATA.resource_name + "-0",
+            software_version=SOFTWARE_VERSION,
+            schema_version=3,
+            recovery_envelope=self.envelope,
+            now=NOW,
+        ).files
+        self.init_complete = False
+        self.cleanup_lost = False
+        self.plane._storage_init = SimpleNamespace(completed=self.completed, cleanup=self.cleanup)
+        initial = InitialEffects(self)
+        self.plane._capacity = initial
+        self.plane._operation_ids[self.plane._key(self.current)] = self.context.operation_id
+        self.plane._helm.ensure_release = initial.ensure_release
+        self.plane._fingerprint.prove_stopped_before_fingerprint = self.prove_fingerprint
+
+    def read_namespaced_stateful_set(self, *args):
+        if self.replicas:
+            return super().read_namespaced_stateful_set(*args)
+        raise Missing
+
+    async def prove_fingerprint(self, *args, pvc_uid, **kwargs):
+        await self.plane._cell.verify_governance_stopped(self.current, pvc_uid=pvc_uid)
+
+    async def completed(self, *args, effect_guard, **kwargs):
+        await effect_guard()
+        self.effects.append("init-observed")
+        return self.init_complete
+
+    async def cleanup(self, *args, effect_guard, **kwargs):
+        await effect_guard()
+        self.effects.append("init-cleanup")
+        if self.cleanup_lost:
+            raise LostAcknowledgement("cleanup outcome uncertain")
+
+    def custody(self):
+        return inspect_hosted_authorization_bundle(
+            self.files,
+            expected_cell_id=METADATA.subject_id,
+            expected_logical_vault_id=METADATA.tenant_id,
+            expected_replica_id=METADATA.resource_name + "-0",
+            expected_software_version=SOFTWARE_VERSION,
+            expected_schema_version=None,
+            expected_recovery_envelope=self.envelope,
+            now=self.now,
+            _require_fresh=False,
+        )
+
+    def bound_checkpoint(self, phase):
+        return (
+            "gpi1:"
+            + phase
+            + ":"
+            + migration_binding(self.context, pvc_uid=self.pvc_uid, runtime_image=self.config.image)
+        )
+
+    async def step(self):
+        return await self.plane.governance_provision(self.current, self.request, self.context)
+
+
+@pytest.mark.asyncio
+async def test_fresh_init_is_observed_without_starting_runtime_or_minting_custody():
+    h = ProvisionHarness()
+    result = await h.step()
+    assert isinstance(result, DriverPending)
+    assert result.checkpoint == h.bound_checkpoint("initializing")
+    assert not h.patches and not h.helm_calls
+    assert "start" not in h.effects
+
+
+@pytest.mark.asyncio
+async def test_successful_init_is_checkpointed_before_cleanup_or_draining_publication():
+    h = ProvisionHarness()
+    h.init_complete = True
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("initializing"))
+    result = await h.step()
+    assert result.checkpoint == h.bound_checkpoint("complete")
+    assert "init-cleanup" not in h.effects and not h.patches
+
+
+@pytest.mark.asyncio
+async def test_completed_init_is_cleaned_then_drained_without_starting_runtime():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    result = await h.step()
+    assert result.checkpoint == h.bound_checkpoint("drained")
+    assert h.custody().replica_state == "DRAINING"
+    assert h.custody().no_in_flight and not h.custody().governance_enrolled
+    assert h.custody().membership_schema_version == 3
+    assert len(h.patches) == 1 and "init-cleanup" in h.effects
+    assert not h.helm_calls and not h.admitted and not h.open_routes
+
+
+@pytest.mark.asyncio
+async def test_init_cleanup_uncertainty_retains_bound_checkpoint_and_custody():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    h.cleanup_lost = True
+    assert await h.step() == DriverPending(h.context.checkpoint, 30)
+    assert not h.patches and not h.helm_calls
+
+
+@pytest.mark.asyncio
+async def test_fresh_provision_replacement_pvc_refuses_before_any_effect():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    h.pvc_uid = "replacement"
+    with pytest.raises(DriverTerminal, match="PROVISIONER_CHECKPOINT_INVALID"):
+        await h.step()
+    assert not h.effects and not h.patches
+
+
+@pytest.mark.asyncio
+async def test_fresh_provision_claim_loss_prevents_every_effect():
+    h = ProvisionHarness()
+    h.claim_valid = False
+    with pytest.raises(ClaimConflict):
+        await h.step()
+    assert not h.effects and not h.patches
+
+
+@pytest.mark.asyncio
+async def test_expired_ttl_init_job_replays_only_original_offline_initializer():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("initializing"))
+    result = await h.step()
+    assert result == DriverPending(h.context.checkpoint, 30)
+    assert len(h.helm_calls) == 1 and h.effects[-1] == "initialize"
+    assert not h.patches and not h.admitted and not h.open_routes
+
+
+@pytest.mark.asyncio
+async def test_completed_checkpoint_never_replays_initializer():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    await h.step()
+    assert "initialize" not in h.effects
+
+
+@pytest.mark.asyncio
+async def test_prebinding_release_is_recorded_without_calling_legacy_initialize():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint="namespace-ready")
+
+    async def credentials(*args, effect_guard, **kwargs):
+        await effect_guard()
+        h.effects.append("credentials")
+
+    h.plane._cell.write_credential_bundle = credentials
+    result = await h.step()
+    assert result.checkpoint == "release-applied"
+    assert [resource.kind.value for resource in result.resources] == ["helm-release", "pvc"]
+    assert h.effects[-1] == "storage-shell" and not h.patches
+    assert h.helm_calls[0]["workloadMode"] == "restore"
+
+
+@pytest.mark.asyncio
+async def test_first_initializer_submission_has_a_durable_bound_denial_marker():
+    h = ProvisionHarness()
+    result = await h.step()
+    assert result.checkpoint == h.bound_checkpoint("initializing")
+    assert not h.helm_calls
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+    result = await h.step()
+    assert result.checkpoint == h.context.checkpoint
+    assert h.helm_calls[0]["workloadMode"] == "initialize"
+
+
+@pytest.mark.asyncio
+async def test_provision_rejects_foreign_owner_before_initializer_replay():
+    h = ProvisionHarness()
+    h.plane._owned[h.plane._key(h.current)] = replace(METADATA, operation_id="foreign")
+    with pytest.raises(DriverTerminal, match="PROVISIONER_CHECKPOINT_INVALID"):
+        await h.step()
+    assert not h.effects and not h.patches
+
+
+@pytest.mark.asyncio
+async def test_expired_bootstrap_drains_without_genesis_reset():
+    h = ProvisionHarness()
+    before = h.custody()
+    h.now = before.expires_at + 1
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    result = await h.step()
+    assert result.checkpoint == h.bound_checkpoint("drained")
+    after = h.custody()
+    assert after.keyring == before.keyring and after.epoch == before.epoch + 1
+    assert after.replica_state == "DRAINING" and not after.governance_enrolled
+
+
+@pytest.mark.asyncio
+async def test_lost_draining_ack_reconciles_same_revision_even_after_window_elapsed():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    await h.step()
+    successor = h.custody()
+    h.now = successor.expires_at + 1
+    result = await h.step()
+    assert result.checkpoint == h.bound_checkpoint("drained")
+    assert h.custody().files == successor.files and len(h.patches) == 1
+
+
+@pytest.mark.asyncio
+async def test_drained_provision_enters_same_coordinator_without_losing_volume_binding():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+    result = await h.step()
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+    result = await h.step()
+    checkpoint = MigrationCheckpoint.decode(result.checkpoint)
+    assert checkpoint.phase == "inspect"
+    assert checkpoint.binding == migration_binding(
+        h.context, pvc_uid=h.pvc_uid, runtime_image=h.config.image
+    )
+    assert checkpoint.vault_fingerprint == "a" * 64
+    assert "start" not in h.effects and not h.admitted and not h.open_routes
+
+
+@pytest.mark.asyncio
+async def test_fresh_final_uses_shared_readiness_admission_and_records_routes():
+    from test_governance_readiness import _serving_bundle
+
+    h = ProvisionHarness()
+    h.files = _serving_bundle(recovery_envelope=h.envelope).files
+    h.context = replace(
+        h.context,
+        checkpoint=MigrationCheckpoint(
+            "complete",
+            "a" * 64,
+            migration_binding(h.context, pvc_uid=h.pvc_uid, runtime_image=h.config.image),
+            "b" * 64,
+            "c" * 64,
+        ).encode(),
+    )
+    result = await h.step()
+    assert MigrationCheckpoint.decode(result.checkpoint).phase == "confirmed"
+    assert not h.admitted and not h.open_routes
+    h.context = replace(h.context, checkpoint=result.checkpoint)
+    final = await h.step()
+    assert isinstance(final, DriverFinal)
+    assert set(final.result) == {"providerRef", "privateEndpoint"}
+    assert [resource.kind.value for resource in final.resources] == ["route"]
+    assert h.admitted and h.open_routes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["claim", "pvc", "routes", "admission", "pod"])
+async def test_bootstrap_cas_rechecks_physical_authority_after_secret_reads(change):
+    from test_governance_stopped_cell import _pod
+
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("complete"))
+
+    def interfere():
+        if change == "claim":
+            h.claim_valid = False
+        elif change == "pvc":
+            h.pvc_uid = "replacement"
+        elif change == "routes":
+            h.open_routes = True
+        elif change == "admission":
+            h.admitted = True
+        else:
+            h.pods = [
+                _pod(
+                    volumes=[
+                        {
+                            "name": "data",
+                            "persistentVolumeClaim": {
+                                "claimName": METADATA.resource_name + "-data"
+                            },
+                        }
+                    ]
+                )
+            ]
+
+    h.after_secret_read = interfere
+    with pytest.raises((ClaimConflict, MetadataConflict, DriverTerminal)):
+        await h.step()
+    assert not h.patches and not h.helm_calls
+
+
+@pytest.mark.asyncio
+async def test_initializer_lost_ack_keeps_bound_marker_and_never_starts_service():
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("initializing"))
+    apply = h.plane._helm.ensure_release
+
+    async def lost(*args, **kwargs):
+        await apply(*args, **kwargs)
+        raise LostAcknowledgement("initializer applied")
+
+    h.plane._helm.ensure_release = lost
+    assert await h.step() == DriverPending(h.context.checkpoint, 30)
+    assert h.effects[-1] == "initialize" and not h.open_routes and not h.admitted

--- a/infra/provisioner/tests/test_governance_provision_membership.py
+++ b/infra/provisioner/tests/test_governance_provision_membership.py
@@ -1,0 +1,137 @@
+"""Never-served bootstrap expiry is not serving-renewal authority."""
+
+import importlib
+import json
+
+import pytest
+from test_governance_provision_effects import bootstrap
+from test_governance_readiness import METADATA, SOFTWARE_VERSION
+
+from exomem_provisioner.authorization_membership import (
+    enroll_hosted_governance_bundle,
+    transition_hosted_authorization_bundle,
+)
+from exomem_provisioner.lifecycle import MetadataConflict
+
+
+def drain(source, now):
+    helper = importlib.import_module("exomem_provisioner.governance_provision_membership")
+    return helper.drain_fresh_bootstrap_bundle(
+        source.files,
+        expected_cell_id=METADATA.subject_id,
+        expected_logical_vault_id=METADATA.tenant_id,
+        expected_replica_id=METADATA.resource_name + "-0",
+        expected_software_version=SOFTWARE_VERSION,
+        expected_recovery_envelope="original-envelope",
+        now=now,
+    )
+
+
+def test_expired_genesis_can_only_become_schema3_unenrolled_draining_successor():
+    source = bootstrap()
+    successor = drain(source, source.expires_at + 1)
+    assert successor.keyring == source.keyring
+    assert successor.membership_schema_version == 3
+    assert not successor.governance_enrolled
+    assert successor.replica_state == "DRAINING"
+    assert successor.no_in_flight and successor.issuance_stopped
+    assert successor.epoch == source.epoch + 1
+    assert json.loads(successor.membership)["previous_epoch_digest"] == source.membership_digest
+    assert drain(successor, source.expires_at + 2).files == successor.files
+
+
+def test_fresh_genesis_drain_preserves_existing_transition_bytes():
+    source = bootstrap()
+    now = json.loads(source.control)["issued_at"] + 5
+    actual = drain(source, now)
+    expected = transition_hosted_authorization_bundle(
+        source.files,
+        expected_cell_id=METADATA.subject_id,
+        expected_logical_vault_id=METADATA.tenant_id,
+        expected_replica_id=METADATA.resource_name + "-0",
+        expected_software_version=SOFTWARE_VERSION,
+        expected_recovery_envelope="original-envelope",
+        expected_schema_version=3,
+        target_state="DRAINING",
+        target_no_in_flight=True,
+        now=now,
+    )
+    assert actual.files == expected.files
+
+
+@pytest.mark.parametrize("offset", [-1, 100_000_000])
+def test_bootstrap_recovery_never_backdates_or_accepts_expired_keys(offset):
+    source = bootstrap()
+    with pytest.raises(MetadataConflict):
+        drain(source, json.loads(source.control)["issued_at"] + offset)
+
+
+def test_normal_transition_still_refuses_expired_bootstrap():
+    source = bootstrap()
+    with pytest.raises(MetadataConflict):
+        transition_hosted_authorization_bundle(
+            source.files,
+            expected_cell_id=METADATA.subject_id,
+            expected_logical_vault_id=METADATA.tenant_id,
+            expected_replica_id=METADATA.resource_name + "-0",
+            expected_software_version=SOFTWARE_VERSION,
+            expected_recovery_envelope="original-envelope",
+            expected_schema_version=3,
+            target_state="DRAINING",
+            target_no_in_flight=True,
+            now=source.expires_at + 1,
+        )
+
+
+def test_bootstrap_exception_cannot_recover_enrolled_custody():
+    initial = bootstrap()
+    source = drain(initial, initial.expires_at + 1)
+    enrolled = enroll_hosted_governance_bundle(
+        source.files,
+        expected_cell_id=METADATA.subject_id,
+        expected_logical_vault_id=METADATA.tenant_id,
+        expected_replica_id=METADATA.resource_name + "-0",
+        expected_software_version=SOFTWARE_VERSION,
+        expected_recovery_envelope="original-envelope",
+        expected_schema_version=3,
+        activation_store_id="activation-alpha",
+        activation_epoch=1,
+        activation_state_digest="a" * 64,
+        now=initial.expires_at + 2,
+    )
+    with pytest.raises(MetadataConflict):
+        drain(enrolled, initial.expires_at + 3)
+
+
+@pytest.mark.parametrize("redrain", [False, True])
+def test_bootstrap_exception_cannot_drain_a_resumed_serving_generation(redrain):
+    initial = bootstrap()
+    source = drain(initial, initial.expires_at + 1)
+    resumed = transition_hosted_authorization_bundle(
+        source.files,
+        expected_cell_id=METADATA.subject_id,
+        expected_logical_vault_id=METADATA.tenant_id,
+        expected_replica_id=METADATA.resource_name + "-0",
+        expected_software_version=SOFTWARE_VERSION,
+        expected_recovery_envelope="original-envelope",
+        expected_schema_version=3,
+        target_state="SERVING",
+        target_no_in_flight=False,
+        now=initial.expires_at + 2,
+    )
+    if redrain:
+        resumed = transition_hosted_authorization_bundle(
+            resumed.files,
+            expected_cell_id=METADATA.subject_id,
+            expected_logical_vault_id=METADATA.tenant_id,
+            expected_replica_id=METADATA.resource_name + "-0",
+            expected_software_version=SOFTWARE_VERSION,
+            expected_recovery_envelope="original-envelope",
+            expected_schema_version=3,
+            target_state="DRAINING",
+            target_no_in_flight=True,
+            now=initial.expires_at + 3,
+        )
+        assert resumed.epoch == 4
+    with pytest.raises(MetadataConflict):
+        drain(resumed, resumed.expires_at + 1)

--- a/infra/provisioner/tests/test_governance_provision_registry.py
+++ b/infra/provisioner/tests/test_governance_provision_registry.py
@@ -1,0 +1,49 @@
+"""Owned init cleanup can be observed without relaxing ordinary provider recovery."""
+
+import pytest
+from test_governance_migration_provider_barrier import _envelopes, _registry
+from test_live_provider import _metadata
+
+from exomem_provisioner.lifecycle import MetadataConflict
+
+
+def registry():
+    result, job = _registry(terminating=True)
+    metadata = _metadata()
+    job.metadata.annotations = metadata.kubernetes_annotations | {
+        "exomem.io/recovery-envelope": _envelopes(metadata)["initJob"],
+    }
+    job.metadata.labels = {
+        "app.kubernetes.io/name": "exomem-cell",
+        "exomem.io/cell": metadata.resource_name,
+        "exomem.io/storage-init": "true",
+    }
+    return result, job
+
+
+async def test_governed_read_can_observe_exact_owned_terminating_init_job():
+    adapter, _ = registry()
+    snapshot = await adapter.inspect(_metadata(), _metadata(), allow_owned_job_cleanup=True)
+    assert snapshot.init_job_present
+    assert not snapshot.init_complete and not snapshot.serving
+
+
+async def test_ordinary_observation_still_refuses_terminating_init_job():
+    adapter, _ = registry()
+    with pytest.raises(MetadataConflict):
+        await adapter.inspect(_metadata(), _metadata())
+
+
+@pytest.mark.parametrize(
+    "field", ["envelope", "owner", "name", "namespace", "uid", "resource_version"]
+)
+async def test_governed_read_refuses_unowned_or_malformed_job(field):
+    adapter, job = registry()
+    if field == "envelope":
+        job.metadata.annotations["exomem.io/recovery-envelope"] = "forged"
+    elif field == "owner":
+        job.metadata.annotations["exomem.io/operation-id"] = "foreign"
+    else:
+        setattr(job.metadata, field, None if field in {"uid", "resource_version"} else "foreign")
+    with pytest.raises(MetadataConflict):
+        await adapter.inspect(_metadata(), _metadata(), allow_owned_job_cleanup=True)

--- a/infra/provisioner/tests/test_governance_provision_render.py
+++ b/infra/provisioner/tests/test_governance_provision_render.py
@@ -1,0 +1,135 @@
+"""The pre-binding chart shell cannot execute storage or serve traffic."""
+
+import json
+import shutil
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from kubernetes.client import ApiClient
+from test_governance_provision_live import ProvisionHarness
+
+from exomem_provisioner.governance_storage_init import KubernetesGovernanceStorageInitAdapter
+
+
+async def test_actual_prebinding_helm_render_has_storage_but_no_workload_or_routes():
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("pinned Helm is required for rendered chart acceptance")
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint="namespace-ready")
+
+    async def credentials(*args, effect_guard, **kwargs):
+        await effect_guard()
+
+    h.plane._cell.write_credential_bundle = credentials
+    await h.step()
+    [values] = h.helm_calls
+    assert values["provisionMode"] == "serve"
+    rendered = subprocess.run(
+        [
+            helm,
+            "template",
+            h.current.resource_name,
+            str(Path(__file__).resolve().parents[3] / "infra/helm/cell"),
+            "--values",
+            "-",
+        ],
+        input=json.dumps(values),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert rendered.returncode == 0, rendered.stderr
+    documents = [doc for doc in yaml.safe_load_all(rendered.stdout) if isinstance(doc, dict)]
+    kinds = {doc["kind"] for doc in documents}
+    assert "PersistentVolumeClaim" in kinds
+    assert not kinds & {"Job", "Pod", "StatefulSet", "Deployment", "IngressRoute"}
+    assert not any(doc["metadata"]["name"].endswith("-init-request") for doc in documents)
+
+
+@pytest.mark.parametrize("installed_metadata", [False, True])
+async def test_actual_initializer_render_matches_closed_execution_and_request_proofs(
+    installed_metadata,
+):
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("pinned Helm is required for rendered chart acceptance")
+    h = ProvisionHarness()
+    h.context = replace(h.context, checkpoint=h.bound_checkpoint("initializing"))
+    await h.step()
+    [values] = h.helm_calls
+    rendered = subprocess.run(
+        [
+            helm,
+            "template",
+            h.current.resource_name,
+            str(Path(__file__).resolve().parents[3] / "infra/helm/cell"),
+            "--values",
+            "-",
+        ],
+        input=json.dumps(values),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert rendered.returncode == 0, rendered.stderr
+    documents = [doc for doc in yaml.safe_load_all(rendered.stdout) if isinstance(doc, dict)]
+    assert not {doc["kind"] for doc in documents} & {"StatefulSet", "Deployment", "IngressRoute"}
+    [job] = [doc for doc in documents if doc["kind"] == "Job"]
+    [request] = [doc for doc in documents if doc["kind"] == "ConfigMap"]
+    for document in (job, request):
+        document["metadata"].update(
+            namespace=h.current.resource_name, uid="api-assigned-uid", resourceVersion="1"
+        )
+        if installed_metadata:
+            # Helm 3.19.4 action.setMetadataVisitor adds only top-level tracking.
+            document["metadata"]["labels"]["app.kubernetes.io/managed-by"] = "Helm"
+            document["metadata"]["annotations"].update(
+                {
+                    "meta.helm.sh/release-name": h.current.resource_name,
+                    "meta.helm.sh/release-namespace": h.current.resource_name,
+                }
+            )
+    api = ApiClient()
+    job = api.sanitize_for_serialization(
+        api.deserialize(SimpleNamespace(data=json.dumps(job)), "V1Job")
+    )
+    authentications = []
+    adapter = KubernetesGovernanceStorageInitAdapter(
+        core_v1=None,
+        batch_v1=None,
+        apps_v1=None,
+        identity_verifier=SimpleNamespace(
+            authenticate=lambda *args, **kwargs: authentications.append((args, kwargs))
+        ),
+        runtime_image=h.config.image,
+    )
+    assert adapter._prove_job(job, h.current, h.envelopes["initJob"], allow_deleting=False) == (
+        "api-assigned-uid",
+        "1",
+        False,
+    )
+    assert adapter._prove_config_map(
+        request,
+        h.current,
+        recovery_envelope=h.envelopes["initRequestConfigMap"],
+        init_request={
+            "request_id": values["initRequestId"],
+            "operation_id": values["initOperationId"],
+            "cell_id": values["cellId"],
+            "vault_id": values["vaultId"],
+            "vault_root": "/var/lib/exomem/vault",
+            "state_root": "/var/lib/exomem/state",
+            "log_root": "/var/lib/exomem/logs",
+            "expected_release": values["expectedRelease"],
+            "expected_protocol": values["expectedProtocol"],
+            "runtime_uid": values["runtimeUid"],
+            "runtime_gid": values["runtimeGid"],
+            "active_credential_version": values["activeCredentialVersion"],
+        },
+    ) == ("api-assigned-uid", "1")
+    assert len(authentications) == 2

--- a/infra/provisioner/tests/test_governance_storage_init.py
+++ b/infra/provisioner/tests/test_governance_storage_init.py
@@ -1,0 +1,723 @@
+from __future__ import annotations
+
+import copy
+import json
+from types import SimpleNamespace
+
+import pytest
+from kubernetes.client import ApiClient, V1ListMeta, V1PodList
+
+from exomem_provisioner.driver import DriverRetryable, LostAcknowledgement
+from exomem_provisioner.governance_storage_init import (
+    KubernetesGovernanceStorageInitAdapter,
+)
+from exomem_provisioner.lifecycle import MetadataConflict, OpaqueProviderMetadata
+from exomem_provisioner.provider_identity import (
+    ProviderRecoveryIdentityCodec,
+    ProviderReference,
+)
+from exomem_provisioner.repository import ClaimConflict
+
+METADATA = OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "operation-alpha", 7)
+IMAGE = "registry.example/runtime@sha256:" + "a" * 64
+CODEC = ProviderRecoveryIdentityCodec.from_secret("storage-init-test-identity")
+
+
+class ApiMissing(Exception):
+    status = 404
+
+
+def _model(value: dict[str, object], kind: str):
+    return ApiClient().deserialize(SimpleNamespace(data=json.dumps(value)), kind)
+
+
+def _envelope(kind: str) -> str:
+    name = METADATA.resource_name + ("-init" if kind == "Job" else "-init-request")
+    return CODEC.seal(
+        provider="kubernetes",
+        provider_reference=ProviderReference.kubernetes(
+            provider="kubernetes",
+            api_version="batch/v1" if kind == "Job" else "v1",
+            kind=kind,
+            namespace=METADATA.resource_name,
+            name=name,
+        ),
+        tenant_id=METADATA.tenant_id,
+        cell_id=METADATA.subject_id,
+        operation_id=METADATA.operation_id,
+        fence_generation=METADATA.fence_generation,
+    )
+
+
+JOB_ENVELOPE = _envelope("Job")
+CONFIG_ENVELOPE = _envelope("ConfigMap")
+INIT_REQUEST = {
+    "request_id": "12345678-1234-4234-8234-123456789abc",
+    "operation_id": METADATA.operation_id,
+    "cell_id": METADATA.subject_id,
+    "vault_id": METADATA.tenant_id,
+    "vault_root": "/var/lib/exomem/vault",
+    "state_root": "/var/lib/exomem/state",
+    "log_root": "/var/lib/exomem/logs",
+    "expected_release": "0.75.0",
+    "expected_protocol": "1",
+    "runtime_uid": 10001,
+    "runtime_gid": 10001,
+    "active_credential_version": "credential-v1",
+}
+
+
+def _labels(*, template: bool = False, storage_init: bool = True) -> dict[str, str]:
+    values = {
+        "app.kubernetes.io/name": "exomem-cell",
+        "exomem.io/cell": METADATA.resource_name,
+    }
+    if not template:
+        values.update(
+            {
+                "app.kubernetes.io/instance": METADATA.resource_name,
+                "app.kubernetes.io/part-of": "exomem-hosted",
+            }
+        )
+    if storage_init:
+        values["exomem.io/storage-init"] = "true"
+    return values
+
+
+def _pod_spec() -> dict[str, object]:
+    return {
+        "runtimeClassName": "exomem-storage-init",
+        "serviceAccountName": METADATA.resource_name,
+        "automountServiceAccountToken": False,
+        "restartPolicy": "Never",
+        "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+        "containers": [
+            {
+                "name": "exomem",
+                "image": IMAGE,
+                "imagePullPolicy": "IfNotPresent",
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "args": [
+                    "hosted",
+                    "init",
+                    "--contract-version",
+                    "1",
+                    "--request-file",
+                    "/run/exomem/operator-requests/init.json",
+                ],
+                "env": [
+                    {"name": "EXOMEM_LOG_DIR", "value": "/dev"},
+                    {"name": "EXOMEM_HOSTED_OFFLINE_STATE_MIGRATION", "value": "1"},
+                ],
+                "resources": {
+                    "requests": {"cpu": "100m", "memory": "128Mi"},
+                    "limits": {"cpu": "1", "memory": "1Gi"},
+                },
+                "securityContext": {
+                    "runAsUser": 0,
+                    "runAsGroup": 0,
+                    "allowPrivilegeEscalation": False,
+                    "readOnlyRootFilesystem": True,
+                    "capabilities": {
+                        "drop": ["ALL"],
+                        "add": ["CHOWN", "DAC_OVERRIDE", "FOWNER"],
+                    },
+                },
+                "volumeMounts": [
+                    {"name": "data", "mountPath": "/var/lib/exomem"},
+                    {
+                        "name": "credentials",
+                        "mountPath": "/run/exomem/credentials",
+                        "readOnly": True,
+                    },
+                    {
+                        "name": "init-request",
+                        "mountPath": "/run/exomem/operator-requests/init.json",
+                        "subPath": "init.json",
+                        "readOnly": True,
+                    },
+                ],
+            }
+        ],
+        "volumes": [
+            {
+                "name": "data",
+                "persistentVolumeClaim": {"claimName": METADATA.resource_name + "-data"},
+            },
+            {
+                "name": "credentials",
+                "secret": {"secretName": "exomem-cell-credentials", "defaultMode": 292},
+            },
+            {
+                "name": "init-request",
+                "configMap": {
+                    "name": METADATA.resource_name + "-init-request",
+                    "defaultMode": 292,
+                },
+            },
+        ],
+    }
+
+
+def _job(*, state: str = "complete", deleting: bool = False):
+    if state == "complete":
+        status: dict[str, object] = {
+            "succeeded": 1,
+            "failed": 0,
+            "active": 0,
+            "terminating": 0,
+            "conditions": [{"type": "Complete", "status": "True"}],
+        }
+    elif state == "failed":
+        status = {
+            "succeeded": 0,
+            "failed": 1,
+            "active": 0,
+            "terminating": 0,
+            "conditions": [{"type": "Failed", "status": "True"}],
+        }
+    else:
+        status = {"succeeded": 0, "failed": 0, "active": 1, "terminating": 0}
+    metadata: dict[str, object] = {
+        "name": METADATA.resource_name + "-init",
+        "namespace": METADATA.resource_name,
+        "uid": "init-job-uid",
+        "resourceVersion": "17",
+        "labels": _labels(),
+        "annotations": {
+            **METADATA.kubernetes_annotations,
+            "exomem.io/recovery-envelope": JOB_ENVELOPE,
+        },
+    }
+    if deleting:
+        metadata["deletionTimestamp"] = "2026-09-08T12:00:00Z"
+    return _model(
+        {
+            "metadata": metadata,
+            "spec": {
+                "backoffLimit": 1,
+                "activeDeadlineSeconds": 120,
+                "ttlSecondsAfterFinished": 300,
+                "completionMode": "NonIndexed",
+                "completions": 1,
+                "parallelism": 1,
+                "suspend": False,
+                "manualSelector": False,
+                "template": {
+                    "metadata": {"labels": _labels(template=True)},
+                    "spec": _pod_spec(),
+                },
+            },
+            "status": status,
+        },
+        "V1Job",
+    )
+
+
+def _pod(
+    *,
+    name: str | None = None,
+    phase: str = "Succeeded",
+    exit_code: int = 0,
+    owner_uid: str = "init-job-uid",
+    labels: dict[str, str] | None = None,
+    spec: dict[str, object] | None = None,
+    deleting: bool = False,
+):
+    pod_name = name or METADATA.resource_name + "-init-abcde"
+    metadata: dict[str, object] = {
+        "name": pod_name,
+        "namespace": METADATA.resource_name,
+        "uid": "pod-uid-" + pod_name[-5:],
+        "labels": {
+            **_labels(template=True),
+            "batch.kubernetes.io/job-name": METADATA.resource_name + "-init",
+            "job-name": METADATA.resource_name + "-init",
+            **(labels or {}),
+        },
+        "ownerReferences": [
+            {
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "name": METADATA.resource_name + "-init",
+                "uid": owner_uid,
+                "controller": True,
+                "blockOwnerDeletion": True,
+            }
+        ],
+    }
+    if deleting:
+        metadata["deletionTimestamp"] = "2026-09-08T12:00:00Z"
+    scheduled = copy.deepcopy(spec or _pod_spec())
+    scheduled.update(
+        {
+            "nodeName": "worker-alpha",
+            "dnsPolicy": "ClusterFirst",
+            "schedulerName": "default-scheduler",
+            "terminationGracePeriodSeconds": 30,
+            "enableServiceLinks": True,
+            "serviceAccount": METADATA.resource_name,
+            "preemptionPolicy": "PreemptLowerPriority",
+            "priority": 0,
+        }
+    )
+    return _model(
+        {
+            "metadata": metadata,
+            "spec": scheduled,
+            "status": {
+                "phase": phase,
+                "containerStatuses": [
+                    {
+                        "name": "exomem",
+                        "image": IMAGE,
+                        "imageID": "registry.example/runtime@sha256:" + "b" * 64,
+                        "ready": False,
+                        "restartCount": 0,
+                        "state": {"terminated": {"exitCode": exit_code}},
+                    }
+                ]
+                if phase in {"Succeeded", "Failed"}
+                else [],
+            },
+        },
+        "V1Pod",
+    )
+
+
+def _config_map(*, request: dict[str, object] = INIT_REQUEST, envelope: str = CONFIG_ENVELOPE):
+    return _model(
+        {
+            "metadata": {
+                "name": METADATA.resource_name + "-init-request",
+                "namespace": METADATA.resource_name,
+                "uid": "init-request-uid",
+                "resourceVersion": "11",
+                "labels": _labels(storage_init=False),
+                "annotations": {
+                    **METADATA.kubernetes_annotations,
+                    "exomem.io/recovery-envelope": envelope,
+                },
+            },
+            "data": {"init.json": json.dumps(request, sort_keys=True, separators=(",", ":"))},
+        },
+        "V1ConfigMap",
+    )
+
+
+def _pvc(*, uid: str = "pvc-uid"):
+    return _model(
+        {
+            "metadata": {
+                "name": METADATA.resource_name + "-data",
+                "namespace": METADATA.resource_name,
+                "uid": uid,
+                "annotations": dict(METADATA.kubernetes_annotations),
+            },
+            "spec": {"volumeName": "pv-alpha"},
+            "status": {"phase": "Bound"},
+        },
+        "V1PersistentVolumeClaim",
+    )
+
+
+def _runtime(replicas: object = 0):
+    return _model(
+        {
+            "metadata": {"name": METADATA.resource_name, "namespace": METADATA.resource_name},
+            "spec": {
+                "replicas": replicas,
+                "serviceName": METADATA.resource_name,
+                "selector": {"matchLabels": {"app": "example"}},
+                "template": {
+                    "metadata": {"labels": {"app": "example"}},
+                    "spec": {"containers": [{"name": "exomem", "image": IMAGE}]},
+                },
+            },
+        },
+        "V1StatefulSet",
+    )
+
+
+class Cluster:
+    def __init__(self, *, state: str = "complete") -> None:
+        self.job = _job(state=state)
+        self.config_map = _config_map()
+        self.pvc = _pvc()
+        self.runtime: object = ApiMissing
+        self.pods = V1PodList(items=[_pod()], metadata=V1ListMeta())
+        self.deleted: list[dict[str, object]] = []
+        self.reads = 0
+        self.read_hook = lambda: None
+        self.delete_hook = lambda: None
+
+    def read_namespaced_job(self, name: str, namespace: str):
+        assert (name, namespace) == (METADATA.resource_name + "-init", METADATA.resource_name)
+        self.reads += 1
+        self.read_hook()
+        if self.job is None:
+            raise ApiMissing
+        return copy.deepcopy(self.job)
+
+    def read_namespaced_config_map(self, name: str, namespace: str):
+        assert (name, namespace) == (
+            METADATA.resource_name + "-init-request",
+            METADATA.resource_name,
+        )
+        return copy.deepcopy(self.config_map)
+
+    def read_namespaced_persistent_volume_claim(self, name: str, namespace: str):
+        assert (name, namespace) == (METADATA.resource_name + "-data", METADATA.resource_name)
+        return copy.deepcopy(self.pvc)
+
+    def read_namespaced_stateful_set(self, name: str, namespace: str):
+        assert name == namespace == METADATA.resource_name
+        if self.runtime is ApiMissing:
+            raise ApiMissing
+        return copy.deepcopy(self.runtime)
+
+    def list_namespaced_pod(self, namespace: str):
+        assert namespace == METADATA.resource_name
+        return copy.deepcopy(self.pods)
+
+    def delete_namespaced_job(self, name: str, namespace: str, body: dict[str, object]):
+        assert (name, namespace) == (METADATA.resource_name + "-init", METADATA.resource_name)
+        self.deleted.append(copy.deepcopy(body))
+        self.job = None
+        self.pods = V1PodList(items=[], metadata=V1ListMeta())
+        self.delete_hook()
+
+
+class Guard:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.fail_at: int | None = None
+
+    async def __call__(self) -> None:
+        self.calls += 1
+        if self.calls == self.fail_at:
+            raise ClaimConflict("AUTHORITY_LOST")
+
+
+def _adapter(cluster: Cluster) -> KubernetesGovernanceStorageInitAdapter:
+    return KubernetesGovernanceStorageInitAdapter(
+        core_v1=cluster,
+        batch_v1=cluster,
+        apps_v1=cluster,
+        identity_verifier=CODEC.verifier(),
+        runtime_image=IMAGE,
+    )
+
+
+def test_adapter_requires_a_digest_pinned_runtime_image() -> None:
+    cluster = Cluster()
+    with pytest.raises(MetadataConflict):
+        KubernetesGovernanceStorageInitAdapter(
+            core_v1=cluster,
+            batch_v1=cluster,
+            apps_v1=cluster,
+            identity_verifier=CODEC.verifier(),
+            runtime_image="registry.example/runtime:latest",
+        )
+
+
+def _arguments(guard: Guard | None = None) -> dict[str, object]:
+    return {
+        "recovery_envelope": JOB_ENVELOPE,
+        "init_request_recovery_envelope": CONFIG_ENVELOPE,
+        "init_request": INIT_REQUEST,
+        "pvc_uid": "pvc-uid",
+        "effect_guard": guard or Guard(),
+    }
+
+
+async def test_completed_proves_signed_job_config_input_pod_and_stopped_volume() -> None:
+    cluster = Cluster()
+    guard = Guard()
+    assert await _adapter(cluster).completed(METADATA, **_arguments(guard))
+    assert guard.calls >= 2
+
+
+@pytest.mark.parametrize("target", ["job", "template", "pod", "config_map"])
+async def test_completed_refuses_unexpected_execution_annotations(target: str) -> None:
+    cluster = Cluster()
+    if target == "job":
+        cluster.job.metadata.annotations["k8s.v1.cni.cncf.io/networks"] = "attacker-net"
+    elif target == "template":
+        cluster.job.spec.template.metadata.annotations = {
+            "k8s.v1.cni.cncf.io/networks": "attacker-net"
+        }
+    elif target == "pod":
+        cluster.pods.items[0].metadata.annotations = {"k8s.v1.cni.cncf.io/networks": "attacker-net"}
+    else:
+        cluster.config_map.metadata.annotations["k8s.v1.cni.cncf.io/networks"] = "attacker-net"
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+@pytest.mark.parametrize("target", ["template", "pod"])
+async def test_completed_refuses_network_policy_escape_label(target: str) -> None:
+    cluster = Cluster()
+    if target == "template":
+        cluster.job.spec.template.metadata.labels["network-access"] = "allowed"
+    else:
+        cluster.pods.items[0].metadata.labels["network-access"] = "allowed"
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_completed_accepts_bound_helm_ownership_metadata() -> None:
+    cluster = Cluster()
+    for resource in (cluster.job, cluster.config_map):
+        resource.metadata.labels["app.kubernetes.io/managed-by"] = "Helm"
+        resource.metadata.annotations.update(
+            {
+                "meta.helm.sh/release-name": METADATA.resource_name,
+                "meta.helm.sh/release-namespace": METADATA.resource_name,
+            }
+        )
+    assert await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_completed_accepts_bound_job_controller_labels() -> None:
+    cluster = Cluster()
+    controller_labels = {
+        "batch.kubernetes.io/controller-uid": "init-job-uid",
+        "batch.kubernetes.io/job-name": METADATA.resource_name + "-init",
+        "controller-uid": "init-job-uid",
+        "job-name": METADATA.resource_name + "-init",
+    }
+    cluster.job.spec.template.metadata.labels.update(controller_labels)
+    cluster.pods.items[0].metadata.labels.update(controller_labels)
+    assert await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+@pytest.mark.parametrize("state", ["absent", "active"])
+async def test_absent_or_active_initializer_remains_pending(state: str) -> None:
+    cluster = Cluster(state="active")
+    if state == "absent":
+        cluster.job = None
+        cluster.pods = V1PodList(items=[], metadata=V1ListMeta())
+    assert not await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_absent_initializer_requires_same_bound_pvc_and_empty_candidate_inventory() -> None:
+    cluster = Cluster()
+    cluster.job = None
+    cluster.pods = V1PodList(items=[], metadata=V1ListMeta())
+    cluster.pvc = _pvc(uid="replacement")
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda cluster: setattr(
+            cluster.job.spec.template.spec.containers[0], "image", "foreign/image:latest"
+        ),
+        lambda cluster: setattr(
+            cluster.job.spec.template.spec.containers[0], "args", ["hosted", "migrate"]
+        ),
+        lambda cluster: cluster.job.metadata.labels.update({"exomem.io/storage-init": "false"}),
+        lambda cluster: cluster.job.metadata.annotations.update(
+            {"exomem.io/recovery-envelope": CONFIG_ENVELOPE}
+        ),
+        lambda cluster: cluster.pods.items[0].metadata.labels.update(
+            {"exomem.io/storage-init": "false"}
+        ),
+    ],
+)
+async def test_changed_image_command_labels_or_envelope_is_terminal(mutation) -> None:
+    cluster = Cluster()
+    mutation(cluster)
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+@pytest.mark.parametrize("kind", ["request", "envelope"])
+async def test_config_map_executable_input_is_exact_and_separately_authenticated(kind: str) -> None:
+    cluster = Cluster()
+    if kind == "request":
+        cluster.config_map = _config_map(request={**INIT_REQUEST, "vault_id": "foreign"})
+    else:
+        cluster.config_map = _config_map(envelope=JOB_ENVELOPE)
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_expected_init_request_must_be_the_closed_initialize_shape() -> None:
+    cluster = Cluster()
+    request = {**INIT_REQUEST, "artifact_reference": "restore://foreign"}
+    cluster.config_map = _config_map(request=request)
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(
+            METADATA,
+            **({**_arguments(), "init_request": request}),
+        )
+
+
+@pytest.mark.parametrize("pod_kind", ["unlabelled-pvc", "runtime"])
+async def test_foreign_unlabelled_pvc_or_runtime_pod_is_terminal(pod_kind: str) -> None:
+    cluster = Cluster()
+    if pod_kind == "unlabelled-pvc":
+        pod = _pod(name="foreign")
+        pod.metadata.labels = {}
+        pod.metadata.owner_references = []
+    else:
+        pod = _pod(name=METADATA.resource_name + "-0")
+        pod.metadata.labels = {}
+        pod.metadata.owner_references = []
+        pod.spec.volumes = []
+    cluster.pods.items.append(pod)
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_incomplete_namespace_inventory_is_retryable_not_absence() -> None:
+    cluster = Cluster()
+    cluster.pods.metadata = V1ListMeta(_continue="next-page")
+    with pytest.raises(DriverRetryable):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+@pytest.mark.parametrize(
+    "conditions",
+    [
+        [{"type": "Complete", "status": True}],
+        [
+            {"type": "Complete", "status": "True"},
+            {"type": "Complete", "status": "True"},
+        ],
+        [
+            {"type": "Complete", "status": "True"},
+            {"type": "Failed", "status": "True"},
+        ],
+    ],
+)
+async def test_malformed_complete_condition_is_terminal(conditions) -> None:
+    cluster = Cluster()
+    cluster.job.status.conditions = conditions
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_cleanup_rereads_exact_job_then_deletes_with_uid_and_resource_version() -> None:
+    cluster = Cluster()
+    guard = Guard()
+    await _adapter(cluster).cleanup(METADATA, **_arguments(guard))
+    assert guard.calls >= 3
+    assert cluster.reads >= 3
+    assert cluster.deleted == [
+        {
+            "propagationPolicy": "Foreground",
+            "preconditions": {"uid": "init-job-uid", "resourceVersion": "17"},
+        }
+    ]
+
+
+@pytest.mark.parametrize("field", ["uid", "resource_version"])
+async def test_cleanup_refuses_job_replacement_between_proof_and_delete(field: str) -> None:
+    cluster = Cluster()
+
+    def replace_on_second_read() -> None:
+        if cluster.reads == 2:
+            setattr(cluster.job.metadata, field, "replacement")
+
+    cluster.read_hook = replace_on_second_read
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).cleanup(METADATA, **_arguments())
+    assert cluster.deleted == []
+
+
+async def test_cleanup_guard_loss_before_delete_propagates_without_effect() -> None:
+    cluster = Cluster()
+    guard = Guard()
+    guard.fail_at = 2
+    with pytest.raises(ClaimConflict):
+        await _adapter(cluster).cleanup(METADATA, **_arguments(guard))
+    assert cluster.deleted == []
+
+
+async def test_cleanup_rechecks_guard_immediately_after_final_provider_reads() -> None:
+    cluster = Cluster()
+    guard = Guard()
+    guard.fail_at = 3
+    with pytest.raises(ClaimConflict):
+        await _adapter(cluster).cleanup(METADATA, **_arguments(guard))
+    assert cluster.deleted == []
+
+
+async def test_terminating_exact_job_waits_without_repeating_delete() -> None:
+    cluster = Cluster()
+    cluster.job = _job(deleting=True)
+    cluster.pods = V1PodList(items=[_pod(deleting=True)], metadata=V1ListMeta())
+    with pytest.raises(DriverRetryable):
+        await _adapter(cluster).cleanup(METADATA, **_arguments())
+    assert cluster.deleted == []
+
+
+async def test_lost_delete_acknowledgement_succeeds_only_after_proven_absence() -> None:
+    cluster = Cluster()
+
+    def lost_after_delete() -> None:
+        raise LostAcknowledgement("private uncertain acknowledgement")
+
+    cluster.delete_hook = lost_after_delete
+    await _adapter(cluster).cleanup(METADATA, **_arguments())
+    assert len(cluster.deleted) == 1
+
+
+async def test_lost_delete_acknowledgement_with_remaining_job_is_retryable() -> None:
+    cluster = Cluster()
+
+    def uncertain_delete(name, namespace, body):
+        cluster.deleted.append(copy.deepcopy(body))
+        raise LostAcknowledgement("private uncertain acknowledgement")
+
+    cluster.delete_namespaced_job = uncertain_delete  # type: ignore[method-assign]
+    with pytest.raises(DriverRetryable) as raised:
+        await _adapter(cluster).cleanup(METADATA, **_arguments())
+    assert "private uncertain acknowledgement" not in str(raised.value)
+
+
+async def test_failed_job_is_never_cleaned_up() -> None:
+    cluster = Cluster(state="failed")
+    cluster.pods = V1PodList(items=[_pod(phase="Failed", exit_code=1)], metadata=V1ListMeta())
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).cleanup(METADATA, **_arguments())
+    assert cluster.deleted == []
+
+
+@pytest.mark.parametrize("kind", ["pvc", "runtime"])
+async def test_completion_refuses_changed_bound_pvc_or_nonzero_runtime(kind: str) -> None:
+    cluster = Cluster()
+    if kind == "pvc":
+        cluster.pvc = _pvc(uid="replacement")
+    else:
+        cluster.runtime = _runtime(1)
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).completed(METADATA, **_arguments())
+
+
+async def test_cleanup_rechecks_same_bound_pvc_after_deletion() -> None:
+    cluster = Cluster()
+
+    def replace_pvc() -> None:
+        cluster.pvc = _pvc(uid="replacement")
+
+    cluster.delete_hook = replace_pvc
+    with pytest.raises(MetadataConflict):
+        await _adapter(cluster).cleanup(METADATA, **_arguments())
+
+
+async def test_unrelated_namespace_pod_does_not_block_proof_or_cleanup() -> None:
+    cluster = Cluster()
+    unrelated = _pod(name="unrelated")
+    unrelated.metadata.labels = {}
+    unrelated.metadata.owner_references = []
+    unrelated.spec.volumes = []
+    cluster.pods.items.append(unrelated)
+    assert await _adapter(cluster).completed(METADATA, **_arguments())
+    await _adapter(cluster).cleanup(METADATA, **_arguments())


### PR DESCRIPTION
## Summary

Fresh cells now initialize storage offline and enter the existing governance migration coordinator before runtime admission. A durable operation/PVC/target-bound checkpoint is recorded before the initializer can run and remains a barrier through retries or terminal failure.

Initializer cleanup verifies the exact Job, request ConfigMap, execution metadata and bound storage, then rechecks worker authority immediately before UID/resource-version-guarded foreground deletion. Bootstrap custody is create-only and can advance only from never-served genesis into its draining successor.

Implements the fresh-provision portion of Task 6 in `simplify-hosted-launch-boundaries`. Deployment mode remains disabled; this PR does not activate live governance.

## Verification

- Full provisioner suite: 1,429 passed, 52 skipped.
- Fresh-checkpoint matrix: 13 PostgreSQL 17 and 13 SQLite checks passed; disposable resources cleaned up.
- Independent security review: 155 passed, 13 skipped; no unresolved findings.
- Actual Helm storage-shell and initializer render checks, including installed ownership metadata.
- Ruff, package build, public-artifact privacy gate and strict OpenSpec validation.
