### PR TITLE
fix(install): retain replaced service config and refuse vault rebinding

### DIFF
--- a/openspec/changes/guard-live-service-config-rewrite/.openspec.yaml
+++ b/openspec/changes/guard-live-service-config-rewrite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/guard-live-service-config-rewrite/proposal.md
+++ b/openspec/changes/guard-live-service-config-rewrite/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The release installer renders the managed service environment file entirely from
+its selected dotenv and publishes it over the live file with `os.replace`. A
+running cell whose configuration has drifted away from that dotenv therefore
+loses its real settings with no retained copy, and the replacement can rebind the
+service to a different vault.
+
+This happened on 2026-09-09. An upgrade run through `scripts/install-service.sh`
+replaced a running cell's environment from a two-month-old checkout dotenv: the
+vault path moved from the live vault to an unrelated one, a Windows-only path
+returned on a Linux host, and three host-specific keys disappeared. The remote
+preflight failed closed on one of the missing keys and left the service stopped,
+which is the only reason the cell did not come up serving a different knowledge
+base. The prior configuration was unrecoverable.
+
+The installer already accepts that a live binding can outrank the dotenv: it
+reads `EXOMEM_STATE_ROOT` back out of the managed file and preserves it across a
+re-render. The vault path deserves the same treatment, because the state root,
+the index and the graph are all derived from it. Nothing else about the
+installer's purpose changes: the dotenv remains the source for reconfiguration.
+
+## What Changes
+
+- Retain the previous managed service environment file before publishing a new
+  one, so a rewrite is recoverable rather than destructive.
+- Refuse to rebind an existing service to a different vault during a re-render,
+  and require an explicit opt-in flag for a deliberate vault move.
+- Leave new installs, first-time renders and every other key unchanged, so the
+  dotenv stays authoritative for reconfiguration.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `install-readiness`: the release installer's environment render gains a
+  retained predecessor and a vault-rebinding refusal for services that already
+  exist.

--- a/openspec/changes/guard-live-service-config-rewrite/specs/install-readiness/spec.md
+++ b/openspec/changes/guard-live-service-config-rewrite/specs/install-readiness/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Profile-complete release environment
+
+The release installer SHALL map lean, hybrid, and media profiles to their published
+extras, load the selected dotenv file into preflight and service environments, and
+MUST NOT depend on the checkout working directory for runtime dotenv discovery.
+
+When it publishes a managed service environment file over an existing one, the
+installer SHALL first retain the previous file's contents under a distinct
+predecessor path readable only by the current user, and SHALL report that path.
+Retention SHALL happen before the replacement becomes visible, so an interrupted
+publish never leaves the previous configuration unrecoverable.
+
+For a service that already exists, the installer SHALL compare the vault path it
+is about to render against the vault path recorded in the managed environment
+file. When the two differ, the installer SHALL refuse the render, leave the
+existing configuration and the running service untouched, and name both paths and
+the explicit opt-in required to proceed. When the opt-in is supplied, the
+installer SHALL perform the rebinding normally. A first-time render, a service
+that does not yet exist, and a managed file recording no vault path SHALL be
+unaffected by this refusal.
+
+#### Scenario: Media profile on Apple Silicon
+- **WHEN** release mode selects the media profile on macOS arm64
+- **THEN** the PyPI requirement includes embeddings, media, vision, diarization,
+  and the macOS MLX media extra
+
+#### Scenario: Service receives dotenv values
+- **WHEN** the selected `.env` contains Exomem vault and OAuth settings
+- **THEN** those values are available to doctor and the installed service
+- **AND** generated files containing secrets are readable only by the current user
+
+#### Scenario: Previous managed environment is retained
+- **WHEN** the installer publishes a managed service environment file and one already exists
+- **THEN** the previous contents are retained under a distinct predecessor path before the
+  replacement becomes visible
+- **AND** that path is reported and is readable only by the current user
+
+#### Scenario: Vault rebinding is refused for an existing service
+- **WHEN** an existing service's managed environment records one vault path and the
+  installer is about to render a different one without the explicit opt-in
+- **THEN** the installer refuses, naming the recorded path, the rendered path and the opt-in
+- **AND** the managed environment file and the running service are left untouched
+
+#### Scenario: Deliberate vault move is permitted
+- **WHEN** the same mismatch occurs and the explicit opt-in is supplied
+- **THEN** the installer renders the new vault path and proceeds with the transition
+
+#### Scenario: First install is unaffected
+- **WHEN** no managed service environment file exists yet, or it records no vault path
+- **THEN** the installer renders the selected dotenv without a rebinding refusal

--- a/openspec/changes/guard-live-service-config-rewrite/specs/install-readiness/spec.md
+++ b/openspec/changes/guard-live-service-config-rewrite/specs/install-readiness/spec.md
@@ -10,7 +10,10 @@ When it publishes a managed service environment file over an existing one, the
 installer SHALL first retain the previous file's contents under a distinct
 predecessor path readable only by the current user, and SHALL report that path.
 Retention SHALL happen before the replacement becomes visible, so an interrupted
-publish never leaves the previous configuration unrecoverable.
+publish never leaves the previous configuration unrecoverable. Configuration
+written earlier by the same installer run SHALL NOT be retained, so a predecessor
+always holds configuration the run did not author rather than an intermediate
+render of its own.
 
 For a service that already exists, the installer SHALL compare the vault path it
 is about to render against the vault path recorded in the managed environment
@@ -50,3 +53,4 @@ unaffected by this refusal.
 #### Scenario: First install is unaffected
 - **WHEN** no managed service environment file exists yet, or it records no vault path
 - **THEN** the installer renders the selected dotenv without a rebinding refusal
+- **AND** no predecessor is left behind, because every file the run replaced was its own

--- a/openspec/changes/guard-live-service-config-rewrite/tasks.md
+++ b/openspec/changes/guard-live-service-config-rewrite/tasks.md
@@ -1,14 +1,15 @@
 ## 1. Retain the replaced configuration
 
-- [ ] 1.1 Add failing coverage proving that publishing a managed service environment over an existing one retains the predecessor with the previous contents and owner-only permissions.
-- [ ] 1.2 Retain the predecessor before the replacement becomes visible and report its path; keep the publish atomic and leave the first-render case unchanged.
+- [x] 1.1 Add failing coverage proving that publishing a managed service environment over an existing one retains the predecessor with the previous contents and owner-only permissions.
+- [x] 1.2 Retain the predecessor before the replacement becomes visible and report its path; keep the publish atomic, and skip retention for a file the same run wrote, so a fresh install's two-phase publish leaves no misleading one-line predecessor.
 
 ## 2. Refuse an unintended vault rebinding
 
-- [ ] 2.1 Add failing coverage for an existing service whose managed environment records a different vault path than the render produces, including the permitted opt-in case and the unaffected first-install case.
-- [ ] 2.2 Read the recorded vault path from the managed file, refuse a differing render without the opt-in, and name both paths and the flag; add the opt-in flag and document it in the usage text.
+- [x] 2.1 Add failing coverage for an existing service whose managed environment records a different vault path than the render produces, including the permitted opt-in case and the unaffected first-install case.
+- [x] 2.2 Read the recorded vault path from the managed file, refuse a differing render without the opt-in, and name both paths and the flag; add `--rebind-vault` and document it in the usage text.
 
 ## 3. Delivery verification
 
-- [ ] 3.1 Run the installer-scoped test suite and lint, then run strict OpenSpec validation.
-- [ ] 3.2 Commit the intended scope, push, and open a ready Conventional Commit PR carrying the reproduction and the verification evidence.
+- [x] 3.1 Run the installer-scoped suite and lint: 28 passed in `tests/test_service_installers.py`, ruff clean, `openspec validate guard-live-service-config-rewrite --strict` passes. The fixture errors are the state-root guard observing the two live services on this machine writing their own directories, which its message names as cross-process interference; the only flagged entries are those services' state roots.
+- [x] 3.2 Strengthen the test harness so this path is genuinely covered: the fake interpreter now executes the installer's real publisher instead of reimplementing it, so atomic replacement, permissions and retention are exercised rather than paraphrased.
+- [ ] 3.3 Commit the intended scope, push, and open a ready Conventional Commit PR carrying the reproduction and the verification evidence.

--- a/openspec/changes/guard-live-service-config-rewrite/tasks.md
+++ b/openspec/changes/guard-live-service-config-rewrite/tasks.md
@@ -1,0 +1,14 @@
+## 1. Retain the replaced configuration
+
+- [ ] 1.1 Add failing coverage proving that publishing a managed service environment over an existing one retains the predecessor with the previous contents and owner-only permissions.
+- [ ] 1.2 Retain the predecessor before the replacement becomes visible and report its path; keep the publish atomic and leave the first-render case unchanged.
+
+## 2. Refuse an unintended vault rebinding
+
+- [ ] 2.1 Add failing coverage for an existing service whose managed environment records a different vault path than the render produces, including the permitted opt-in case and the unaffected first-install case.
+- [ ] 2.2 Read the recorded vault path from the managed file, refuse a differing render without the opt-in, and name both paths and the flag; add the opt-in flag and document it in the usage text.
+
+## 3. Delivery verification
+
+- [ ] 3.1 Run the installer-scoped test suite and lint, then run strict OpenSpec validation.
+- [ ] 3.2 Commit the intended scope, push, and open a ready Conventional Commit PR carrying the reproduction and the verification evidence.

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -24,6 +24,7 @@ PACKAGE_VERSION=""
 ENV_FILE=""
 LEGACY_MCP_COMPAT=0
 RESUME_STOPPED_TRANSITION=0
+REBIND_VAULT=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -50,6 +51,10 @@ Options:
   --legacy-mcp-compat       Set EXOMEM_MCP_LEGACY_COMPAT=1 in the service
   --resume-stopped-transition
                             Continue a prior failed transition proven stopped
+  --rebind-vault            Allow an existing service's vault path to change.
+                            Refused by default: the state root, index and graph
+                            all derive from it, so a re-render that moves it
+                            points the service at a different knowledge base
   -h, --help                Show this help
 EOF
 }
@@ -113,6 +118,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --resume-stopped-transition)
             RESUME_STOPPED_TRANSITION=1
+            shift
+            ;;
+        --rebind-vault)
+            REBIND_VAULT=1
             shift
             ;;
         -h|--help)
@@ -252,6 +261,22 @@ fi
 OLD_PORT="$(exomem_service_port "$SERVICE_DEFINITION")"
 VAULT="$(exomem_dotenv_file_value "$ENV_FILE" EXOMEM_VAULT_PATH)"
 [[ -n "$VAULT" ]] || die "EXOMEM_VAULT_PATH is required in $ENV_FILE"
+
+# The vault path is the cell's identity: its state root, index and graph are
+# all derived from it. A re-render that moves it points a running service at a
+# different knowledge base, which is never what an upgrade means. A drifted
+# live config against a stale `--env-file` is exactly how that happens, so
+# require the move to be asked for rather than inferred.
+PERSISTED_VAULT="$(exomem_dotenv_file_value "$SERVICE_ENV_FILE" EXOMEM_VAULT_PATH)"
+if [[ "$EXISTING_SERVICE" == 1 && -n "$PERSISTED_VAULT" && "$PERSISTED_VAULT" != "$VAULT" ]]; then
+    if [[ "$REBIND_VAULT" != 1 ]]; then
+        die "refusing to rebind the existing service's vault:
+  currently serving: $PERSISTED_VAULT (from $SERVICE_ENV_FILE)
+  would render:      $VAULT (from $ENV_FILE)
+pass --rebind-vault to move it deliberately, or correct $ENV_FILE"
+    fi
+    echo "Rebinding the service vault from $PERSISTED_VAULT to $VAULT as requested."
+fi
 DOTENV_STATE_ROOT="$(exomem_dotenv_file_value "$ENV_FILE" EXOMEM_STATE_ROOT)"
 PREFERRED_STATE_ROOT="${EXOMEM_STATE_ROOT:-${DOTENV_STATE_ROOT:-$(exomem_platform_state_root)}}"
 [[ "$PREFERRED_STATE_ROOT" == /* ]] \
@@ -294,9 +319,18 @@ else
         || die "fresh install cannot prove its listener is unbound"
 fi
 
+SERVICE_ENV_PUBLISHED_THIS_RUN=0
+
 durable_publish_service_env() {
     local source="$1"
-    "$VENV_PYTHON" - "$source" "$SERVICE_ENV_FILE" <<'PY'
+    local retain="retain"
+    # Only the configuration this run did NOT write is worth keeping. A fresh
+    # install publishes the state-root binding before the full render, and a
+    # predecessor holding that one line would be a misleading thing to hand
+    # someone who is trying to recover their real configuration.
+    [[ "$SERVICE_ENV_PUBLISHED_THIS_RUN" == 1 ]] && retain="no-retain"
+    SERVICE_ENV_PUBLISHED_THIS_RUN=1
+    "$VENV_PYTHON" - "$source" "$SERVICE_ENV_FILE" "$retain" <<'PY'
 from __future__ import annotations
 
 import os
@@ -308,6 +342,30 @@ source = Path(sys.argv[1])
 destination = Path(sys.argv[2])
 payload = source.read_bytes()
 destination.parent.mkdir(parents=True, exist_ok=True)
+
+# Retain what we are about to destroy. `os.replace` below is atomic and
+# leaves no trace of the previous contents, so a stale `--env-file` can
+# silently take a drifted live configuration with it -- vault path, host
+# additions and all. Retention happens BEFORE the replacement becomes
+# visible, so an interrupted publish still leaves the predecessor behind.
+if destination.exists() and sys.argv[3] == "retain":
+    previous = destination.with_name(f"{destination.name}.previous")
+    keeper, keeper_name = tempfile.mkstemp(
+        prefix=f".{previous.name}.", dir=destination.parent
+    )
+    kept = Path(keeper_name)
+    try:
+        with os.fdopen(keeper, "wb") as handle:
+            handle.write(destination.read_bytes())
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(kept, 0o600)
+        os.replace(kept, previous)
+    except BaseException:
+        kept.unlink(missing_ok=True)
+        raise
+    print(f"retained the previous service environment at {previous}")
+
 descriptor, temporary_name = tempfile.mkstemp(
     prefix=f".{destination.name}.", dir=destination.parent
 )

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -1349,3 +1349,107 @@ def test_the_embedded_toolchain_stand_ins_are_valid_python() -> None:
     assert bodies, "no embedded Python stand-in found to check"
     for body in bodies:
         ast.parse(textwrap.dedent(body).lstrip())
+
+
+def test_publishing_over_an_existing_service_env_retains_the_predecessor(
+    tmp_path: Path,
+) -> None:
+    """A rewrite of a live cell's configuration must stay recoverable.
+
+    The publish replaces the managed file atomically, so without a retained
+    predecessor a stale dotenv silently destroys a drifted live configuration.
+    """
+    require_posix_executable_scripts()
+    env, service_root, env_file = _fixture(tmp_path)
+    first = _invoke(env, service_root, env_file, "--profile", "lean")
+    assert first.returncode == 0, first.stderr
+
+    service_env = Path(env["XDG_CONFIG_HOME"]) / "exomem" / "service.env"
+    original = service_env.read_text(encoding="utf-8")
+
+    env_file.write_text(
+        env_file.read_text(encoding="utf-8").replace(
+            "GITHUB_CLIENT_SECRET=secret&value",
+            "GITHUB_CLIENT_SECRET=rotated&value",
+        ),
+        encoding="utf-8",
+    )
+    second = _invoke(env, service_root, env_file, "--profile", "lean")
+    assert second.returncode == 0, second.stderr
+
+    assert "rotated&value" in service_env.read_text(encoding="utf-8")
+    retained = sorted(service_env.parent.glob("service.env.previous*"))
+    assert retained, "the replaced configuration was not retained"
+    assert retained[-1].read_text(encoding="utf-8") == original
+    assert stat.S_IMODE(retained[-1].stat().st_mode) == 0o600
+    assert str(retained[-1]) in second.stdout
+
+
+def test_existing_service_refuses_a_differing_vault_render(tmp_path: Path) -> None:
+    """A vault change during a re-render is never a benign upgrade.
+
+    The state root, index and graph all derive from the vault path, so a stale
+    dotenv must not rebind a running cell to a different knowledge base.
+    """
+    require_posix_executable_scripts()
+    env, service_root, env_file = _fixture(tmp_path)
+    first = _invoke(env, service_root, env_file, "--profile", "lean")
+    assert first.returncode == 0, first.stderr
+
+    service_env = Path(env["XDG_CONFIG_HOME"]) / "exomem" / "service.env"
+    before = service_env.read_text(encoding="utf-8")
+    original_vault = tmp_path / "vault"
+    other_vault = tmp_path / "other-vault"
+    other_vault.mkdir()
+    env_file.write_text(
+        env_file.read_text(encoding="utf-8").replace(
+            f"EXOMEM_VAULT_PATH={original_vault}",
+            f"EXOMEM_VAULT_PATH={other_vault}",
+        ),
+        encoding="utf-8",
+    )
+
+    refused = _invoke(env, service_root, env_file, "--profile", "lean")
+
+    assert refused.returncode != 0
+    assert str(original_vault) in refused.stderr
+    assert str(other_vault) in refused.stderr
+    assert "--rebind-vault" in refused.stderr
+    assert service_env.read_text(encoding="utf-8") == before
+
+
+def test_existing_service_rebinds_the_vault_when_opted_in(tmp_path: Path) -> None:
+    require_posix_executable_scripts()
+    env, service_root, env_file = _fixture(tmp_path)
+    first = _invoke(env, service_root, env_file, "--profile", "lean")
+    assert first.returncode == 0, first.stderr
+
+    other_vault = tmp_path / "other-vault"
+    other_vault.mkdir()
+    env_file.write_text(
+        env_file.read_text(encoding="utf-8").replace(
+            f"EXOMEM_VAULT_PATH={tmp_path / 'vault'}",
+            f"EXOMEM_VAULT_PATH={other_vault}",
+        ),
+        encoding="utf-8",
+    )
+
+    moved = _invoke(env, service_root, env_file, "--profile", "lean", "--rebind-vault")
+
+    assert moved.returncode == 0, moved.stderr
+    service_env = Path(env["XDG_CONFIG_HOME"]) / "exomem" / "service.env"
+    assert f'EXOMEM_VAULT_PATH="{other_vault}"' in service_env.read_text(encoding="utf-8")
+
+
+def test_fresh_install_is_unaffected_by_the_vault_rebinding_refusal(
+    tmp_path: Path,
+) -> None:
+    require_posix_executable_scripts()
+    result, _service_root, _trace, env = _run(tmp_path, "--profile", "lean")
+
+    assert result.returncode == 0, result.stderr
+    service_env = Path(env["XDG_CONFIG_HOME"]) / "exomem" / "service.env"
+    assert f'EXOMEM_VAULT_PATH="{tmp_path / "vault"}"' in service_env.read_text(
+        encoding="utf-8"
+    )
+    assert not sorted(service_env.parent.glob("service.env.previous*"))

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -53,16 +53,16 @@ def _fake_python(path: Path) -> None:
             sys.argv = sys.argv[1:]
             runpy.run_path(script, run_name="__main__")
 
-        if len(sys.argv) == 4 and sys.argv[1] == "-":
-            _, _, source_raw, destination_raw = sys.argv
-            source = Path(source_raw)
-            destination = Path(destination_raw)
-            temporary = destination.with_name(f".{destination.name}.fake-tmp")
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            temporary.write_bytes(source.read_bytes())
-            temporary.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            temporary.replace(destination)
+        if len(sys.argv) == 5 and sys.argv[1] == "-":
+            # Run the installer's real publisher rather than a paraphrase of
+            # it. This program is plain stdlib and it owns the invariants that
+            # matter here -- atomic replacement, owner-only permissions, and
+            # retaining the configuration it is about to destroy -- so a
+            # stand-in that reimplements it tests the stand-in instead.
+            program = sys.stdin.read()
+            sys.argv = sys.argv[1:]
             log("durably publish service env")
+            exec(compile(program, "<durable_publish_service_env>", "exec"), {"__name__": "__main__"})
             raise SystemExit(0)
 
         if len(sys.argv) == 6 and sys.argv[1] == "-":


### PR DESCRIPTION
An upgrade run through `scripts/install-service.sh` replaced a running cell's environment from a two-month-old checkout dotenv. The vault path moved from the live vault to an unrelated one, a Windows-only path returned on a Linux host, and three host-specific keys disappeared. The publish is atomic and kept no copy, so the real configuration was unrecoverable. The only thing that stopped the service coming up against a different knowledge base was the remote preflight failing closed on one of the missing keys.

## What changes

**The installer retains what it is about to destroy.** The previous file is copied to a predecessor path, owner-only, before the replacement becomes visible, and the path is reported. Configuration written earlier by the same run is skipped: a fresh install publishes the state-root binding before the full render, and a predecessor holding just that one line would mislead exactly the recovery it exists for.

**It refuses to move an existing service's vault path** without `--rebind-vault`, naming both paths and the flag. The state root, index and graph all derive from that path, so a re-render that changes it is never what an upgrade means. The script already preserved `EXOMEM_STATE_ROOT` across a re-render for this reason; this extends the same reasoning to the value the state root is derived from.

New installs, first-time renders and every other key are unchanged, so the dotenv stays authoritative for reconfiguration.

## Test harness

The fake interpreter in the installer tests reimplemented the publisher rather than running it, so nothing covered the real code's invariants. It now executes the actual program, which means atomic replacement, owner-only permissions and retention are exercised rather than paraphrased. This strengthens existing coverage as well as the new tests.

## Verification

- `tests/test_service_installers.py`: 28 passed. Four new tests cover retention, the refusal, the permitted opt-in, and a fresh install left unaffected. All four fail before the change.
- `ruff check` clean; `openspec validate guard-live-service-config-rewrite --strict` passes.
- `bash -n` clean on the installer.

Five fixture errors appear in the run. They are the state-root guard observing the two live services on this machine writing their own directories, which the guard's own message names as cross-process interference. The only flagged entries are those services' state roots, which no test creates.

## Note for reviewers

`scripts/upgrade.sh` was always the right tool for moving a running cell to a new release and never touched this file. This change makes the wrong tool safe rather than merely documented, because the failure mode is silent and unrecoverable.

https://claude.ai/code/session_019TW4TVh414FuwX2Znigd3M
