### PR TITLE
fix(auth): name the reason a session was rejected

### DIFF
--- a/src/exomem/auth_sessions.py
+++ b/src/exomem/auth_sessions.py
@@ -1163,24 +1163,48 @@ class SessionAuthority:
         return record
 
     async def _validate_authoritatively(self, bearer: str) -> SessionRecord | None:
+        # Every rejection below reaches the client as an indistinguishable 401.
+        # Without a server-side reason, an operator seeing clients logged out
+        # cannot tell an expiry from a rotated signing key from a bumped
+        # generation, and the records are encrypted at rest so the files answer
+        # nothing either. These lines name the branch and nothing else: no
+        # bearer, no digest, no identity.
         record = await self._load_session_for_bearer(bearer)
         if record is None:
+            logger.info("event=session_rejected reason=no_matching_record")
             return None
-        if (
-            record.status != "active"
-            or record.issuer != self.issuer
-            or record.audience != self.audience
-        ):
+        if record.status != "active":
+            logger.info(
+                "event=session_rejected reason=status status=%s", record.status
+            )
+            return None
+        if record.issuer != self.issuer or record.audience != self.audience:
+            logger.info("event=session_rejected reason=issuer_or_audience_mismatch")
             return None
         if record.generation != await self.current_generation():
+            logger.info("event=session_rejected reason=generation_mismatch")
             return None
         if record.schema_version == _ACCESS_SCHEMA_VERSION:
             if record.expires_at is None or float(self.clock()) >= record.expires_at:
+                logger.info(
+                    "event=session_rejected reason=expired age_seconds=%s",
+                    None
+                    if record.expires_at is None
+                    else round(float(self.clock()) - record.expires_at, 1),
+                )
                 return None
             if record.family_id is None:
+                logger.info("event=session_rejected reason=missing_refresh_family")
                 return None
             family = await self._load_family(record.family_id)
-            if family is None or not await self._family_is_active(family):
+            if family is None:
+                logger.info("event=session_rejected reason=refresh_family_absent")
+                return None
+            if not await self._family_is_active(family):
+                logger.info(
+                    "event=session_rejected reason=refresh_family_inactive status=%s",
+                    family.status,
+                )
                 return None
         return record
 

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -745,3 +745,50 @@ async def test_swapped_ciphertext_fails_closed_during_session_listing() -> None:
 
     with pytest.raises(SessionStoreUnavailable, match="storage key"):
         await authority.list_sessions()
+
+
+@pytest.mark.anyio
+async def test_rejected_sessions_name_their_reason_without_leaking_material(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every rejection reaches the client as an identical 401.
+
+    Without a server-side reason an operator cannot tell an expiry from a
+    rotated signing key from a bumped generation, and the records are
+    encrypted at rest so the files answer nothing either.
+    """
+    store = AtomicMemoryStore()
+    moment = 1_800_000_000.0
+    authority = _authority(store, clock=lambda: moment)
+    bearer, record, _refresh = await authority.issue_offline(
+        client_id="client",
+        scopes=("offline_access", "exomem:read"),
+        identity=_identity(),
+    )
+
+    with caplog.at_level("INFO", logger="exomem.auth_sessions"):
+        assert await authority.validate(bearer) is not None
+        assert not [r for r in caplog.records if "session_rejected" in r.getMessage()]
+
+        expired = _authority(
+            store, clock=lambda: moment + ACCESS_TOKEN_TTL_SECONDS + 1
+        )
+        caplog.clear()
+        assert await expired.validate(bearer) is None
+        expiry_messages = [
+            r.getMessage() for r in caplog.records if "session_rejected" in r.getMessage()
+        ]
+
+        caplog.clear()
+        assert await authority.validate("exo_a2.notarealsession000000.x") is None
+        unknown_messages = [
+            r.getMessage() for r in caplog.records if "session_rejected" in r.getMessage()
+        ]
+
+    assert any("reason=expired" in message for message in expiry_messages)
+    assert any("reason=no_matching_record" in message for message in unknown_messages)
+    for message in expiry_messages + unknown_messages:
+        assert bearer not in message
+        assert record.token_digest not in message
+        assert str(record.github_user_id) not in message
+        assert record.github_login not in message


### PR DESCRIPTION
Every rejection in the session validator returns `None`, and every one reaches the client as an identical 401. An operator watching clients get logged out cannot tell an expiry from a rotated signing key from a bumped generation, and session records are encrypted at rest, so the files on disk answer nothing either.

Diagnosing one such outage today meant reading the validator to enumerate its branches and then reasoning about which could plausibly have fired, because the service itself said nothing. That is the gap this closes.

## The change

Each rejection branch now logs its reason: no matching record, wrong status, issuer or audience mismatch, generation mismatch, expired with the overshoot in seconds, missing refresh family, family absent, and family inactive with its status.

Info level, not debug. A rejection is low-frequency and operator-relevant, uvicorn already logs the resulting 401, and needing root-level debug logging to answer "why did every client log out" is the problem rather than the fix.

## Safety

The lines name the branch and nothing else. The test asserts the reason is present and that no bearer, token digest, GitHub user ID or login appears in any emitted message.

## Verification

- `tests/test_auth_sessions.py` and `tests/test_session_oauth.py`: 54 passed.
- New test covers a valid session logging nothing, an expired session naming `reason=expired`, and an unknown bearer naming `reason=no_matching_record`.
- `ruff check` clean.

Six fixture errors appear in the run. They are the state-root guard observing the two live services on this machine writing their own directories, which the guard's own message names as cross-process interference.

## Origin

This came out of a live investigation into MCP clients repeatedly losing authorization. The instrumented build is currently deployed on my own cell to capture a rejection in the wild; the change is worth having regardless of what that capture shows.

https://claude.ai/code/session_019TW4TVh414FuwX2Znigd3M
