### PR TITLE
fix(auth): observe credential presentation and refresh outcomes

### DIFF
--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -148,9 +148,19 @@ class ExomemSessionOAuthProxy(OAuthProxy):
 
     @override
     async def load_access_token(self, token: str) -> AccessToken | None:
+        # This is the only place a presented credential reaches validation, so
+        # its absence from the log is what distinguishes "the client sent a
+        # token we rejected" from "the client sent no token at all". Both
+        # surface as an identical `POST /mcp 401` in the access log, and they
+        # are different problems with different fixes: the first is a session
+        # dying server-side, the second is a client that has stopped
+        # presenting one. Without this line, silence is ambiguous rather than
+        # reassuring.
         record = await self._session_authority.validate(token)
         if record is None:
+            logger.info("event=credential_presented outcome=rejected")
             return None
+        logger.debug("event=credential_presented outcome=accepted")
         return AccessToken(
             token=token,
             client_id=record.client_id,
@@ -177,12 +187,17 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         """Load only an Exomem-owned refresh grant, never FastMCP legacy state."""
         if client.client_id is None:
             return None
+        # Whether the client even attempts a refresh is the other half of the
+        # picture: a client that re-authorizes from scratch every hour looks
+        # the same from the access log as one whose refresh is being refused.
         grant = await self._session_authority.validate_refresh(
             refresh_token,
             client_id=client.client_id,
         )
         if grant is None:
+            logger.info("event=refresh_attempted outcome=rejected")
             return None
+        logger.info("event=refresh_attempted outcome=accepted")
         return RefreshToken(
             token=refresh_token,
             client_id=grant.client_id,
@@ -208,7 +223,12 @@ class ExomemSessionOAuthProxy(OAuthProxy):
                 scopes=normalized_scopes,
             )
         except InvalidRefreshToken as error:
+            # Rotation refusals name their own cause already; surfacing it here
+            # is what tells an operator a refresh loop is failing rather than
+            # never being tried.
+            logger.info("event=refresh_rotated outcome=refused reason=%s", error)
             raise TokenError("invalid_grant", str(error)) from error
+        logger.info("event=refresh_rotated outcome=ok")
         return OAuthToken(
             access_token=access,
             token_type="Bearer",

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -1252,3 +1252,30 @@ async def test_the_served_metadata_still_advertises_the_issuer_parameter() -> No
     metadata = response.json()
     assert metadata["authorization_response_iss_parameter_supported"] is True
     assert metadata["issuer"] == str(proxy.issuer_url)
+
+
+@pytest.mark.anyio
+async def test_a_rejected_credential_is_distinguishable_from_none_presented(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 401 with no credential and a 401 with a bad one look identical.
+
+    The access log shows `POST /mcp 401` either way, but one is a session
+    dying server-side and the other is a client that has stopped presenting a
+    token. Only the first reaches `load_access_token`, so its log line is what
+    makes silence mean something.
+    """
+    proxy = _proxy()
+    bogus = "exo_a2.notarealsession000000.x"
+
+    with caplog.at_level("INFO", logger="exomem.session_oauth"):
+        assert await proxy.load_access_token(bogus) is None
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "credential_presented" in record.getMessage()
+    ]
+    assert any("outcome=rejected" in message for message in messages)
+    for message in messages:
+        assert bogus not in message


### PR DESCRIPTION
Follow-up to #1170. Naming why a session was rejected only helps when a credential actually reaches validation.

## The gap

A client that stops presenting a token never reaches the validator at all: FastMCP returns 401 before it runs. Both cases look identical in the access log as `POST /mcp 401`, so an empty rejection log was ambiguous rather than reassuring. It could mean sessions are healthy, or it could mean the client is no longer sending a token. Those are different problems with different fixes, and after #1170 there was still no way to tell them apart.

## The change

Three observation points:

- **Credential presentation** records whether a presented token was accepted or rejected. Its absence now means no credential arrived, which is a fact rather than a silence.
- **Refresh attempts** record whether the client tries to refresh at all, distinguishing a client that re-authorizes from scratch every hour from one whose refresh is being refused.
- **Rotation outcome** records success, or refusal with the reason the session authority gave.

Rejections and refresh events are info. An accepted credential is debug, since that fires on every authorized request.

## Safety

No token, digest or identity is logged. The test asserts the rejection is recorded and that the presented bearer does not appear in the message.

## Verification

- `tests/test_session_oauth.py` and `tests/test_auth_sessions.py`: 55 passed.
- `ruff check` clean.

Six fixture errors appear in the run. They are the state-root guard observing the two live services on this machine writing their own directories, which the guard's own message names as cross-process interference.

## Origin

Live investigation into MCP clients repeatedly losing authorization. The proximate cause of the outage was found and fixed separately; this is about being able to answer the question next time without reading the validator to enumerate its branches.

https://claude.ai/code/session_019TW4TVh414FuwX2Znigd3M
