### PR TITLE
feat(hosted): make governance-v3-to-v4 a selectable migration mode

### DIFF
--- a/infra/contracts/exomem-hosted-deployment-lock-v2.schema.json
+++ b/infra/contracts/exomem-hosted-deployment-lock-v2.schema.json
@@ -54,7 +54,7 @@
       "required": ["compatibilityDigest", "migrationMode", "substrateConsumerCommit", "substrateTrustSha256"],
       "properties": {
         "compatibilityDigest": {"$ref": "#/$defs/sha256"},
-        "migrationMode": {"enum": ["none", "binding-v1-to-v2", "state-root-v1"]},
+        "migrationMode": {"enum": ["none", "binding-v1-to-v2", "state-root-v1", "governance-v3-to-v4"]},
         "substrateConsumerCommit": {"$ref": "#/$defs/commit"},
         "substrateTrustSha256": {"$ref": "#/$defs/sha256"}
       }

--- a/infra/helm/platform/templates/_runtime-release.tpl
+++ b/infra/helm/platform/templates/_runtime-release.tpl
@@ -57,7 +57,7 @@
 {{- end -}}
 {{- if hasKey $lock "runtimeUpgrade" -}}
 {{- $upgrade := $lock.runtimeUpgrade -}}
-{{- if or (not (kindIs "map" $upgrade)) (ne (len $upgrade) 4) (not (hasKey $upgrade "compatibilityDigest")) (not (hasKey $upgrade "migrationMode")) (not (hasKey $upgrade "substrateConsumerCommit")) (not (hasKey $upgrade "substrateTrustSha256")) (not (regexMatch "^[0-9a-f]{64}$" $upgrade.compatibilityDigest)) (not (has $upgrade.migrationMode (list "none" "binding-v1-to-v2" "state-root-v1"))) (not (regexMatch "^[0-9a-f]{40}$" $upgrade.substrateConsumerCommit)) (not (regexMatch "^[0-9a-f]{64}$" $upgrade.substrateTrustSha256)) -}}
+{{- if or (not (kindIs "map" $upgrade)) (ne (len $upgrade) 4) (not (hasKey $upgrade "compatibilityDigest")) (not (hasKey $upgrade "migrationMode")) (not (hasKey $upgrade "substrateConsumerCommit")) (not (hasKey $upgrade "substrateTrustSha256")) (not (regexMatch "^[0-9a-f]{64}$" $upgrade.compatibilityDigest)) (not (has $upgrade.migrationMode (list "none" "binding-v1-to-v2" "state-root-v1" "governance-v3-to-v4"))) (not (regexMatch "^[0-9a-f]{40}$" $upgrade.substrateConsumerCommit)) (not (regexMatch "^[0-9a-f]{64}$" $upgrade.substrateTrustSha256)) -}}
 {{- fail "deployment lock runtime upgrade is invalid" -}}
 {{- end -}}
 {{- end -}}

--- a/infra/provisioner/src/exomem_provisioner/config.py
+++ b/infra/provisioner/src/exomem_provisioner/config.py
@@ -300,14 +300,16 @@ class SelectedDeploymentRuntime(BaseModel):
     recordsReaderVersion: Literal[2] | None = None
     lifecycleActionsEnabled: bool = False
     compatibilityDigest: str | None = Field(default=None, pattern=_SHA256)
-    migrationMode: Literal["none", "binding-v1-to-v2", "state-root-v1"] = "none"
+    migrationMode: Literal["none", "binding-v1-to-v2", "state-root-v1", "governance-v3-to-v4"] = (
+        "none"
+    )
 
 
 class DeploymentRuntimeUpgrade(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
     compatibilityDigest: str = Field(pattern=_SHA256)
-    migrationMode: Literal["none", "binding-v1-to-v2", "state-root-v1"]
+    migrationMode: Literal["none", "binding-v1-to-v2", "state-root-v1", "governance-v3-to-v4"]
     substrateConsumerCommit: str = Field(pattern=_COMMIT)
     substrateTrustSha256: str = Field(pattern=_SHA256)
 

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -1845,11 +1845,12 @@ def _fixed_helm_values(
         ),
         "initOperationId": metadata.operation_id,
         "initRequestId": _deterministic_uuid4(metadata.operation_id + ":init"),
+        # The cell chart has no governance behaviour: the v3-to-v4 migration runs in the
+        # coordinator's own Job against a stopped cell. Every chart apply on this path --
+        # restore shell, initializer, and the rollforward's serving values -- must therefore
+        # carry a mode the cell chart still admits, or the apply fails schema validation.
         "migrationMode": (
-            "none"
-            if request["provisionMode"] == "restore-candidate"
-            and config.migration_mode == "governance-v3-to-v4"
-            else config.migration_mode
+            "none" if config.migration_mode == "governance-v3-to-v4" else config.migration_mode
         ),
         "pvcSize": "10Gi",
         "provisionMode": request["provisionMode"],

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -258,7 +258,9 @@ class LifecycleConfig:
     records_reader_version: int | None = None
     lifecycle_actions_enabled: bool = False
     compatibility_digest: str | None = None
-    migration_mode: Literal["none", "binding-v1-to-v2", "state-root-v1"] = "none"
+    migration_mode: Literal["none", "binding-v1-to-v2", "state-root-v1", "governance-v3-to-v4"] = (
+        "none"
+    )
 
     def runtime_target_for(self, request: dict[str, Any], *, v2: bool) -> dict[str, str]:
         if v2:

--- a/infra/provisioner/tests/test_config.py
+++ b/infra/provisioner/tests/test_config.py
@@ -127,7 +127,9 @@ def test_selected_deployment_lock_is_strict_and_exposes_admission_inputs(tmp_pat
         load_deployment_lock(path)
 
 
-@pytest.mark.parametrize("migration_mode", ("binding-v1-to-v2", "state-root-v1"))
+@pytest.mark.parametrize(
+    "migration_mode", ("binding-v1-to-v2", "state-root-v1", "governance-v3-to-v4")
+)
 def test_selected_runtime_exposes_only_signed_forward_upgrade_metadata(
     tmp_path: Path, migration_mode: str
 ) -> None:
@@ -150,10 +152,11 @@ def test_selected_runtime_exposes_only_signed_forward_upgrade_metadata(
     assert lock.runtimeUpgrade.substrateConsumerCommit == "8" * 40
     assert lock.runtimeUpgrade.substrateTrustSha256 == "7" * 64
 
-    value["runtimeUpgrade"]["migrationMode"] = "arbitrary-script"  # type: ignore[index]
-    path.write_text(json.dumps(value), encoding="utf-8")
-    with pytest.raises(ValueError):
-        load_deployment_lock(path)
+    for unknown in ("arbitrary-script", "governance-v4-to-v5"):
+        value["runtimeUpgrade"]["migrationMode"] = unknown  # type: ignore[index]
+        path.write_text(json.dumps(value), encoding="utf-8")
+        with pytest.raises(ValueError):
+            load_deployment_lock(path)
 
 
 def test_selected_lock_accepts_an_authoritatively_empty_legacy_catalog(tmp_path: Path) -> None:

--- a/infra/provisioner/tests/test_governance_live_readiness.py
+++ b/infra/provisioner/tests/test_governance_live_readiness.py
@@ -97,7 +97,7 @@ class ReadinessHarness:
             location="fsn1",
             runtime_target=target,
             legacy_runtime_units={(SOFTWARE_VERSION, "1"): target},
-            migration_mode=mode,  # type: ignore[arg-type] # Not enabled by configuration yet.
+            migration_mode=mode,
         )
         worker_policy = {"workerCount": 2, "semantic": True, "media": False}
         self.request = {

--- a/infra/provisioner/tests/test_governance_rollforward_render.py
+++ b/infra/provisioner/tests/test_governance_rollforward_render.py
@@ -1,0 +1,40 @@
+"""The governance rollforward hands the cell chart only values that chart accepts."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from test_governance_rollforward_live import RollforwardHarness
+
+CELL_CHART = Path(__file__).resolve().parents[3] / "infra/helm/cell"
+
+
+async def test_actual_rollforward_serving_render_never_carries_the_governance_mode():
+    """The migration runs in the coordinator's Job; the cell chart has no governance branch."""
+
+    h = RollforwardHarness()
+    assert h.config.migration_mode == "governance-v3-to-v4"
+    await h.drained()
+    await h.step()
+
+    [values] = h.helm_calls
+    assert values["workloadMode"] == "serve"
+    assert values["migrationMode"] == "none"
+
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("pinned Helm is required for rendered chart acceptance")
+    rendered = subprocess.run(
+        [helm, "template", h.current.resource_name, str(CELL_CHART), "--values", "-"],
+        input=json.dumps(values),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert rendered.returncode == 0, rendered.stderr
+    documents = [doc for doc in yaml.safe_load_all(rendered.stdout) if isinstance(doc, dict)]
+    assert "StatefulSet" in {doc["kind"] for doc in documents}

--- a/infra/scripts/hosted_composition_lock.py
+++ b/infra/scripts/hosted_composition_lock.py
@@ -209,7 +209,12 @@ def _runtime_upgrade(value: object) -> dict[str, object]:
         },
     )
     _sha256(upgrade["compatibilityDigest"], label="runtime upgrade compatibility")
-    if upgrade["migrationMode"] not in {"none", "binding-v1-to-v2", "state-root-v1"}:
+    if upgrade["migrationMode"] not in {
+        "none",
+        "binding-v1-to-v2",
+        "state-root-v1",
+        "governance-v3-to-v4",
+    }:
         _error("runtime upgrade migration mode is invalid")
     _commit(upgrade["substrateConsumerCommit"], label="runtime upgrade Substrate consumer")
     _sha256(upgrade["substrateTrustSha256"], label="runtime upgrade Substrate trust")

--- a/tests/test_hosted_composition_lock.py
+++ b/tests/test_hosted_composition_lock.py
@@ -325,8 +325,9 @@ def test_lock_validation_accepts_runtime_source_anchor_independent_of_platform_c
     composer.validate_deployment_lock(lock)
 
 
+@pytest.mark.parametrize("migration_mode", ("none", "governance-v3-to-v4"))
 def test_composer_binds_runtime_upgrade_compatibility_and_migration(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, migration_mode: str
 ) -> None:
     composer = _module()
     request = _request(composer, tmp_path)
@@ -352,7 +353,7 @@ def test_composer_binds_runtime_upgrade_compatibility_and_migration(
         evidence,
         {
             "compatibilityDigest": "9" * 64,
-            "migrationMode": "none",
+            "migrationMode": migration_mode,
             "substrateConsumerCommit": consumer_commit,
             "substrateTrustSha256": trust_digest,
         },
@@ -378,13 +379,13 @@ def test_composer_binds_runtime_upgrade_compatibility_and_migration(
     assert [lock["runtimeUpgrade"] for lock in pair["locks"]] == [
         {
             "compatibilityDigest": "9" * 64,
-            "migrationMode": "none",
+            "migrationMode": migration_mode,
             "substrateConsumerCommit": consumer_commit,
             "substrateTrustSha256": trust_digest,
         },
         {
             "compatibilityDigest": "9" * 64,
-            "migrationMode": "none",
+            "migrationMode": migration_mode,
             "substrateConsumerCommit": consumer_commit,
             "substrateTrustSha256": trust_digest,
         },

--- a/tests/test_hosted_deployment_lock_consumption.py
+++ b/tests/test_hosted_deployment_lock_consumption.py
@@ -213,7 +213,9 @@ def test_lock_schema_admits_the_governance_migration_mode_and_still_refuses_unkn
     for member in members:
         member["runtimeUpgrade"]["migrationMode"] = "governance-v4-to-v5"
 
-    assert list(validator.iter_errors(pair))
+    errors = list(validator.iter_errors(pair))
+    assert errors
+    assert all(error.json_path.endswith("migrationMode") for error in errors)
 
 
 def _v3_member() -> dict[str, object]:

--- a/tests/test_hosted_deployment_lock_consumption.py
+++ b/tests/test_hosted_deployment_lock_consumption.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from jsonschema import Draft202012Validator
 
 ROOT = Path(__file__).resolve().parents[1]
 PREPARE = ROOT / "infra/scripts/prepare_hosted_release.py"
@@ -27,6 +28,7 @@ SUBSTRATE_TRUST = (
     ROOT / "infra/contracts/exomem-hosted-deployment-lock-evidence-v2/substrate-trust-0.57.2.json"
 )
 LOCK_PAIR = ROOT / "infra/contracts/exomem-hosted-deployment-lock-pair-v2.json"
+LOCK_SCHEMA = ROOT / "infra/contracts/exomem-hosted-deployment-lock-v2.schema.json"
 
 
 def _module(path: Path = PREPARE):
@@ -191,6 +193,27 @@ def _pair() -> dict[str, object]:
         "schemaVersion": 2,
         "locks": [expand, contract],
     }
+
+
+def test_lock_schema_admits_the_governance_migration_mode_and_still_refuses_unknown_ones() -> None:
+    validator = Draft202012Validator(json.loads(LOCK_SCHEMA.read_text(encoding="utf-8")))
+    pair = _pair()
+    members = pair["locks"]
+    assert isinstance(members, list)
+    for member in members:
+        member["runtimeUpgrade"] = {
+            "compatibilityDigest": "9" * 64,
+            "migrationMode": "governance-v3-to-v4",
+            "substrateConsumerCommit": "8" * 40,
+            "substrateTrustSha256": "7" * 64,
+        }
+
+    assert not list(validator.iter_errors(pair))
+
+    for member in members:
+        member["runtimeUpgrade"]["migrationMode"] = "governance-v4-to-v5"
+
+    assert list(validator.iter_errors(pair))
 
 
 def _v3_member() -> dict[str, object]:

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -238,6 +238,42 @@ def test_platform_requires_cross_repository_trust_in_runtime_upgrade_metadata(
     assert "runtime upgrade is invalid" in result.stderr
 
 
+def test_platform_admits_the_governance_migration_mode_but_no_other_new_one(
+    tmp_path: Path,
+) -> None:
+    """The coordinator's governance migration is selectable from a real deployment lock."""
+
+    if HELM is None:
+        pytest.skip("set HELM_BIN to run pinned Helm rendering")
+    values = yaml.safe_load((PLATFORM / "values.validation.yaml").read_text(encoding="utf-8"))
+    lock = json.loads(values["provisioner"]["deploymentLockJson"])
+    lock["runtimeUpgrade"] = {
+        "compatibilityDigest": "c" * 64,
+        "migrationMode": "governance-v3-to-v4",
+        "substrateConsumerCommit": "d" * 40,
+        "substrateTrustSha256": "e" * 64,
+    }
+    accepted = _lock_override(tmp_path / "governance", lock)
+    _render(
+        PLATFORM,
+        PLATFORM / "values.validation.yaml",
+        namespace="exomem-platform",
+        extra_args=("--values", str(accepted)),
+    )
+
+    lock["runtimeUpgrade"]["migrationMode"] = "governance-v4-to-v5"
+    rejected = _lock_override(tmp_path / "unknown", lock)
+    result = _render_process(
+        PLATFORM,
+        PLATFORM / "values.validation.yaml",
+        namespace="exomem-platform",
+        release_name="exomem-platform",
+        extra_args=("--values", str(rejected)),
+    )
+    assert result.returncode != 0
+    assert "runtime upgrade is invalid" in result.stderr
+
+
 def test_platform_accepts_an_authoritatively_empty_legacy_catalog(tmp_path: Path) -> None:
     if HELM is None:
         pytest.skip("set HELM_BIN to run pinned Helm rendering")
@@ -2885,6 +2921,25 @@ def test_cell_state_root_migration_mode_enables_only_the_offline_state_migrator(
     }
     assert env["EXOMEM_HOSTED_OFFLINE_STATE_MIGRATION"] == "1"
     assert not any(document.get("kind") == "StatefulSet" for document in documents)
+
+
+def test_cell_chart_refuses_the_governance_migration_mode() -> None:
+    """Governance migration runs in the coordinator's Job, never in an in-cell storage init."""
+
+    result = _render_process(
+        CELL,
+        CELL / "values.initialize.yaml",
+        namespace="cell-alpha-test",
+        extra_args=(
+            "--set",
+            "workloadMode=migrate",
+            "--set",
+            "migrationMode=governance-v3-to-v4",
+        ),
+    )
+
+    assert result.returncode != 0
+    assert "migrationMode" in result.stderr
 
 
 def test_cell_chart_rejects_mismatched_runtime_and_provider_cell_ids(tmp_path: Path) -> None:

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -2926,6 +2926,8 @@ def test_cell_state_root_migration_mode_enables_only_the_offline_state_migrator(
 def test_cell_chart_refuses_the_governance_migration_mode() -> None:
     """Governance migration runs in the coordinator's Job, never in an in-cell storage init."""
 
+    if HELM is None:
+        pytest.skip("set HELM_BIN to run pinned Helm rendering")
     result = _render_process(
         CELL,
         CELL / "values.initialize.yaml",

--- a/tests/test_hosted_migration_mode_consistency.py
+++ b/tests/test_hosted_migration_mode_consistency.py
@@ -1,0 +1,83 @@
+"""Every deployment-lock migration-mode enumeration agrees, and the cell chart deliberately does not.
+
+A hosted migration mode is selectable only if the lock schema, the composer, the platform
+template and the provisioner's own models all admit it. The cell chart is the one deliberate
+divergence: `governance-v3-to-v4` runs in the coordinator's Job against a stopped cell, and the
+cell chart has no governance behaviour at all, so it must keep refusing the mode.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import get_args, get_type_hints
+
+import pytest
+from exomem_provisioner.config import DeploymentRuntimeUpgrade, SelectedDeploymentRuntime
+from exomem_provisioner.lifecycle import LifecycleConfig
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_SCHEMA = ROOT / "infra/contracts/exomem-hosted-deployment-lock-v2.schema.json"
+COMPOSER = ROOT / "infra/scripts/hosted_composition_lock.py"
+PLATFORM_TEMPLATE = ROOT / "infra/helm/platform/templates/_runtime-release.tpl"
+CELL_SCHEMA = ROOT / "infra/helm/cell/values.schema.json"
+
+CELL_ONLY_EXCLUDES = "governance-v3-to-v4"
+
+
+def _composer():
+    spec = importlib.util.spec_from_file_location("hosted_composition_lock", COMPOSER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _template_modes() -> set[str]:
+    text = PLATFORM_TEMPLATE.read_text(encoding="utf-8")
+    match = re.search(r"has \$upgrade\.migrationMode \(list ([^)]*)\)", text)
+    assert match is not None, "the platform template must enumerate migration modes"
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def _upgrade(mode: str) -> dict[str, str]:
+    return {
+        "compatibilityDigest": "9" * 64,
+        "migrationMode": mode,
+        "substrateConsumerCommit": "8" * 40,
+        "substrateTrustSha256": "7" * 64,
+    }
+
+
+def test_every_deployment_lock_migration_mode_enumeration_is_the_same_set() -> None:
+    canonical = set(get_args(DeploymentRuntimeUpgrade.model_fields["migrationMode"].annotation))
+    assert CELL_ONLY_EXCLUDES in canonical
+
+    assert set(get_args(SelectedDeploymentRuntime.model_fields["migrationMode"].annotation)) == (
+        canonical
+    )
+    assert set(get_args(get_type_hints(LifecycleConfig)["migration_mode"])) == canonical
+
+    schema = json.loads(LOCK_SCHEMA.read_text(encoding="utf-8"))
+    assert set(schema["$defs"]["runtimeUpgrade"]["properties"]["migrationMode"]["enum"]) == (
+        canonical
+    )
+
+    assert _template_modes() == canonical
+
+    composer = _composer()
+    for mode in canonical:
+        assert composer._runtime_upgrade(_upgrade(mode))["migrationMode"] == mode
+    with pytest.raises(composer.CompositionError):
+        composer._runtime_upgrade(_upgrade("governance-v4-to-v5"))
+
+
+def test_the_cell_chart_admits_every_mode_except_the_coordinator_owned_migration() -> None:
+    canonical = set(get_args(DeploymentRuntimeUpgrade.model_fields["migrationMode"].annotation))
+    cell = json.loads(CELL_SCHEMA.read_text(encoding="utf-8"))
+
+    assert set(cell["properties"]["migrationMode"]["enum"]) == canonical - {CELL_ONLY_EXCLUDES}

--- a/tests/test_hosted_migration_mode_consistency.py
+++ b/tests/test_hosted_migration_mode_consistency.py
@@ -16,8 +16,14 @@ from pathlib import Path
 from typing import get_args, get_type_hints
 
 import pytest
-from exomem_provisioner.config import DeploymentRuntimeUpgrade, SelectedDeploymentRuntime
-from exomem_provisioner.lifecycle import LifecycleConfig
+
+# The core CI shards run without the provisioner package; the hosted-infrastructure
+# job installs it and exercises this invariant, as the sibling hosted tests do.
+_config = pytest.importorskip("exomem_provisioner.config")
+_lifecycle = pytest.importorskip("exomem_provisioner.lifecycle")
+DeploymentRuntimeUpgrade = _config.DeploymentRuntimeUpgrade
+SelectedDeploymentRuntime = _config.SelectedDeploymentRuntime
+LifecycleConfig = _lifecycle.LifecycleConfig
 
 ROOT = Path(__file__).resolve().parents[1]
 LOCK_SCHEMA = ROOT / "infra/contracts/exomem-hosted-deployment-lock-v2.schema.json"


### PR DESCRIPTION
## What

`governance-v3-to-v4` becomes a selectable hosted migration mode in every validator that governs deployment-lock runtime selection: the strict pydantic lock models in `config.py`, `LifecycleConfig.migration_mode`, the deployment-lock v2 JSON schema, `hosted_composition_lock.py`, and the platform chart's runtime-release template. Any other unknown mode is still refused.

The cell chart's own values schema deliberately keeps refusing the mode: governance mode always passes `migrationMode: none` to the initializer and serving chart, because the migration runs in the provisioner-owned target-image Job, and the legacy in-cell storage-init paths still exclude the new mode.

Until now no real deployment lock could select the mode, so the governance coordinator shipped in #1159 through #1165 was reachable only from tests. Published lock and candidate bytes are untouched.

## Verification

- Provisioner: `test_config.py`, `test_governance_live_recovery.py`, `test_live_provider.py`, `test_governance_lifecycle_driver.py`: 85 passed.
- Lock composition and consumption: 77 passed, including a schema test that a real lock pair validates with the mode and still refuses `governance-v4-to-v5`.
- Helm contract with the pinned helm: 64 passed, including the platform rendering the mode into the tenant admission policy and the cell chart refusing it.
- `ruff check` and `openspec validate --all --strict --no-interactive` clean.
- Independent review on a clean copy.
