### PR TITLE
fix(provisioner): harden Helm history absence and pinned-chart reads

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -16,7 +16,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, overload
 
 import httpx
 from kubernetes.client import ApiClient
@@ -2952,7 +2952,10 @@ class HelmCliAdapter:
         "secret",
     }
     _PENDING_RELEASE_STATUSES = ("pending-install", "pending-upgrade")
-    _RELEASE_ABSENT = "release: not found"
+    _RELEASE_ABSENT = "Error: release: not found"
+    # HELM_DEBUG makes Helm print a stack dump after the `Error:` line; pin
+    # it off so the pod environment cannot move the exact absence line.
+    _HELM_ENVIRONMENT = {"HELM_DRIVER": "configmap", "HELM_DEBUG": "false"}
     _CHART_NAME = re.compile(r"^name:[ \t]*([A-Za-z0-9][A-Za-z0-9._-]{0,62})[ \t]*$", re.M)
 
     def __init__(
@@ -3032,7 +3035,7 @@ class HelmCliAdapter:
                 "Helm values must not carry plaintext credentials",
                 reason=ConflictReason.HELM_VALUES_MUST_NOT_CARRY_PLAINTEXT_CREDENTIALS,
             )
-        environment = {"HELM_DRIVER": "configmap"}
+        environment = dict(self._HELM_ENVIRONMENT)
         await self._require_version(environment)
         if effect_guard is not None:
             await self._reconcile_own_pending_release(
@@ -3144,7 +3147,7 @@ class HelmCliAdapter:
         return value
 
     async def current_release_values(self, metadata: OpaqueProviderMetadata) -> dict[str, Any]:
-        environment = {"HELM_DRIVER": "configmap"}
+        environment = dict(self._HELM_ENVIRONMENT)
         await self._require_version(environment)
         return await self._current_values(metadata, environment)
 
@@ -3188,6 +3191,24 @@ class HelmCliAdapter:
             )
         return value
 
+    @overload
+    async def _release_history(
+        self,
+        metadata: OpaqueProviderMetadata,
+        environment: dict[str, str],
+        *,
+        absent_ok: Literal[False] = False,
+    ) -> tuple[dict[str, Any], ...]: ...
+
+    @overload
+    async def _release_history(
+        self,
+        metadata: OpaqueProviderMetadata,
+        environment: dict[str, str],
+        *,
+        absent_ok: Literal[True],
+    ) -> tuple[dict[str, Any], ...] | None: ...
+
     async def _release_history(
         self,
         metadata: OpaqueProviderMetadata,
@@ -3201,7 +3222,8 @@ class HelmCliAdapter:
         status: a release that was never recorded, which the caller may install
         (`None`), and a history read that did not answer, which is uncertain. A
         reconcile must never mistake the second for the first and walk into
-        Helm's own lock.
+        Helm's own lock. Absence is only the exact error line the pinned CLI
+        prints last; the same words inside any other error stay uncertain.
         """
         result = await self._runner(
             (
@@ -3223,7 +3245,12 @@ class HelmCliAdapter:
                     "Helm release history is unavailable",
                     reason=ConflictReason.HELM_RELEASE_HISTORY_IS_UNAVAILABLE,
                 )
-            if self._RELEASE_ABSENT in str(getattr(result, "stderr", "")):
+            lines = [
+                line.strip()
+                for line in str(getattr(result, "stderr", "")).splitlines()
+                if line.strip()
+            ]
+            if lines and lines[-1] == self._RELEASE_ABSENT:
                 return None
             raise self._pending_release_uncertain()
         if len(result.stdout.encode("utf-8")) > 262_144:
@@ -3307,8 +3334,10 @@ class HelmCliAdapter:
 
         The pinned CLI has no machine-readable output for `helm show chart`, so
         the one top-level `name:` line of the rendered `Chart.yaml` is read
-        exactly. An unreadable or ambiguous answer blocks the reconcile rather
-        than authenticating a record on a partial match.
+        exactly. The chart is baked into this image, so an unreadable or
+        ambiguous answer is a wiring defect: it fails terminally under its own
+        reason rather than authenticating a record on a partial match or
+        retrying with the routes closed until an operator notices.
         """
         if self._chart_reference_cache is None:
             result = await self._runner(
@@ -3328,7 +3357,10 @@ class HelmCliAdapter:
                 else []
             )
             if len(names) != 1:
-                raise self._pending_release_uncertain()
+                raise MetadataConflict(
+                    "pinned Helm chart is unreadable",
+                    reason=ConflictReason.HELM_PINNED_CHART_IS_UNREADABLE,
+                )
             self._chart_reference_cache = f"{names[0]}-{self._chart_version}"
         return self._chart_reference_cache
 
@@ -3520,7 +3552,7 @@ class HelmCliAdapter:
         *,
         operation_id: str,
     ) -> tuple[dict[str, Any], int]:
-        environment = {"HELM_DRIVER": "configmap"}
+        environment = dict(self._HELM_ENVIRONMENT)
         await self._require_version(environment)
         current = await self._current_values(metadata, environment)
         marker = current.get("runtimeUpgrade")
@@ -3572,7 +3604,7 @@ class HelmCliAdapter:
         operation_id: str,
         require_marker: bool = False,
     ) -> None:
-        environment = {"HELM_DRIVER": "configmap"}
+        environment = dict(self._HELM_ENVIRONMENT)
         await self._require_version(environment)
         current = await self._current_values(metadata, environment)
         marker = current.get("runtimeUpgrade")

--- a/infra/provisioner/src/exomem_provisioner/conflict_reason.py
+++ b/infra/provisioner/src/exomem_provisioner/conflict_reason.py
@@ -183,6 +183,7 @@ class ConflictReason(StrEnum):
     HELM_DEPLOYED_REVISION_IS_AMBIGUOUS = "helm-deployed-revision-is-ambiguous"
     HELM_EFFECT_OPTIONS_INVALID = "helm-effect-options-invalid"
     HELM_PENDING_RELEASE_IS_FOREIGN = "helm-pending-release-is-foreign"
+    HELM_PINNED_CHART_IS_UNREADABLE = "helm-pinned-chart-is-unreadable"
     HELM_RELEASE_HISTORY_IS_INVALID = "helm-release-history-is-invalid"
     HELM_RELEASE_RECORD_CLIENT_IS_UNAVAILABLE = "helm-release-record-client-is-unavailable"
     HELM_RELEASE_HISTORY_IS_UNAVAILABLE = "helm-release-history-is-unavailable"

--- a/infra/provisioner/tests/test_helm_guarded_transition.py
+++ b/infra/provisioner/tests/test_helm_guarded_transition.py
@@ -96,6 +96,7 @@ class HelmTransport:
         self.history_failure: tuple[int, str] | None = None
         self.revision_values_failure: tuple[int, str] | None = None
         self.chart_yaml = CHART_YAML
+        self.chart_failure: tuple[int, str] | None = None
         self.core = HelmReleaseConfigMaps(self.history)
         self.adapter = HelmCliAdapter(
             binary="helm",
@@ -129,11 +130,14 @@ class HelmTransport:
         return name
 
     async def run(self, argv, environment):
-        assert environment == {"HELM_DRIVER": "configmap"}
+        assert environment == {"HELM_DRIVER": "configmap", "HELM_DEBUG": "false"}
         self.calls.append(argv)
         if argv[1] == "version":
             stdout = "v3.19.4\n"
         elif argv[1:3] == ("show", "chart"):
+            if self.chart_failure is not None:
+                code, message = self.chart_failure
+                return SimpleNamespace(returncode=code, stdout="", stderr=message)
             stdout = self.chart_yaml
         elif argv[1:3] == ("get", "values"):
             if "--revision" in argv:
@@ -466,6 +470,69 @@ async def test_a_release_that_was_never_recorded_lets_the_governed_install_proce
 
 
 @pytest.mark.asyncio
+async def test_helm_debug_is_pinned_off_so_the_absent_line_stays_last(tmp_path):
+    # With HELM_DEBUG inherited from the pod environment, Helm appends a
+    # stack dump after the `Error:` line, so an absent release would read as
+    # uncertain forever. Every Helm call therefore pins the flag off.
+    class Recording(HelmTransport):
+        environments: list[dict[str, str]] = []
+
+        async def run(self, argv, environment):
+            self.environments.append(dict(environment))
+            return await super().run(argv, environment)
+
+    h = Recording(tmp_path)
+    h.history_failure = (1, "Error: release: not found\n")
+
+    await h.transition("ensure", rollback_on_failure=False, effect_guard=h.guard)
+
+    assert h.environments and all(
+        env["HELM_DEBUG"] == "false" and env["HELM_DRIVER"] == "configmap" for env in h.environments
+    )
+    assert _upgrades(h) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_absent_release_is_recognized_only_by_its_exact_error_line(tmp_path):
+    h = HelmTransport(tmp_path)
+    # Helm prints kubeconfig warnings ahead of the error on the same stream.
+    h.history_failure = (
+        1,
+        "WARNING: Kubernetes configuration file is group-readable. "
+        "This is insecure. Location: /tmp/kubeconfig\n"
+        "Error: release: not found\n",
+    )
+
+    await h.transition("ensure", rollback_on_failure=False, effect_guard=h.guard)
+
+    assert h.core.reads == [] and h.core.deletes == []
+    assert _upgrades(h) == 1
+    assert "--install" in h.calls[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Error: query: failed to query with labels: release: not found\n",
+        "Error: release: not found: context deadline exceeded\n",
+        "Error: release: not found\nError: Kubernetes cluster unreachable\n",
+        "error: release: not found\n",
+    ],
+)
+async def test_a_history_error_that_merely_mentions_absence_stays_uncertain(tmp_path, stderr):
+    h = HelmTransport(tmp_path)
+    h.leave_pending("pending-upgrade", revision=2)
+    h.history_failure = (1, stderr)
+
+    with pytest.raises(DriverRetryable):
+        await h.transition("ensure", rollback_on_failure=False, effect_guard=h.guard)
+
+    assert h.core.reads == [] and h.core.deletes == []
+    assert _upgrades(h) == 0
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("rollback", [True, False])
 async def test_an_unanswered_history_read_never_walks_into_the_helm_lock(tmp_path, rollback):
     h = HelmTransport(tmp_path)
@@ -543,14 +610,25 @@ async def test_a_pending_install_under_a_foreign_chart_name_is_refused(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_an_unreadable_pinned_chart_blocks_the_reconcile_without_a_delete(tmp_path):
+@pytest.mark.parametrize("shape", ["no-name", "two-names", "cli-failure", "oversized"])
+async def test_an_unreadable_pinned_chart_is_a_terminal_wiring_defect(tmp_path, shape):
     h = HelmTransport(tmp_path)
     h.leave_pending("pending-upgrade", revision=2)
-    h.chart_yaml = "apiVersion: v2\nversion: 0.1.0\n"
+    if shape == "no-name":
+        h.chart_yaml = "apiVersion: v2\nversion: 0.1.0\n"
+    elif shape == "two-names":
+        h.chart_yaml = CHART_YAML + "name: other\n"
+    elif shape == "cli-failure":
+        h.chart_failure = (1, 'Error: path "chart" not found\n')
+    else:
+        h.chart_yaml = CHART_YAML + "description: " + "x" * 70_000 + "\n"
 
-    with pytest.raises(DriverRetryable):
+    # The chart is baked into the provisioner image; it cannot become readable
+    # by waiting, so retrying with the routes closed only hides the defect.
+    with pytest.raises(MetadataConflict) as raised:
         await h.transition("ensure", rollback_on_failure=False, effect_guard=h.guard)
 
+    assert raised.value.reason is ConflictReason.HELM_PINNED_CHART_IS_UNREADABLE
     assert h.core.deletes == []
     assert _upgrades(h) == 0
 

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -565,7 +565,7 @@ async def test_helm_cli_checks_pinned_version_and_uses_private_values_file(tmp_p
 
     async def runner(argv: tuple[str, ...], environment: dict[str, str]) -> SimpleNamespace:
         calls.append(argv)
-        assert environment == {"HELM_DRIVER": "configmap"}
+        assert environment == {"HELM_DRIVER": "configmap", "HELM_DEBUG": "false"}
         if argv[1] == "version":
             return SimpleNamespace(returncode=0, stdout="v3.19.4\n", stderr="")
         values_path = Path(argv[argv.index("--values") + 1])
@@ -603,7 +603,7 @@ async def test_helm_cli_checks_pinned_version_and_uses_private_values_file(tmp_p
 @pytest.mark.asyncio
 async def test_helm_cli_rejects_secret_values_and_version_drift(tmp_path: Path) -> None:
     async def wrong_version(_argv: tuple[str, ...], environment: dict[str, str]) -> SimpleNamespace:
-        assert environment == {"HELM_DRIVER": "configmap"}
+        assert environment == {"HELM_DRIVER": "configmap", "HELM_DEBUG": "false"}
         return SimpleNamespace(returncode=0, stdout="v3.18.0\n", stderr="")
 
     adapter = HelmCliAdapter(
@@ -631,7 +631,7 @@ async def test_helm_runtime_transition_replays_and_rolls_back_the_original_revis
     async def runner(argv: tuple[str, ...], environment: dict[str, str]) -> SimpleNamespace:
         nonlocal current_revision, current_values
         calls.append(argv)
-        assert environment == {"HELM_DRIVER": "configmap"}
+        assert environment == {"HELM_DRIVER": "configmap", "HELM_DEBUG": "false"}
         if argv[1] == "version":
             return SimpleNamespace(returncode=0, stdout="v3.19.4\n", stderr="")
         if argv[1:3] == ("get", "values"):


### PR DESCRIPTION
## What

Three hardening follow-ups to the governed Helm transition in `HelmCliAdapter`, raised by the independent review of the pending-release reconciliation (#1174).

## Changes

- **Absence is the exact error line.** A release counts as never recorded only when the last non-empty stderr line of `helm history` is exactly `Error: release: not found`. Any other non-zero result that merely contains those words stays an uncertain, retryable outcome with no upgrade and no delete. Previously a bare substring match could let a governed transition proceed into Helm's own pending lock.
- **`HELM_DEBUG` is pinned off** in the adapter's Helm environment. Helm 3.19.4 with an inherited `HELM_DEBUG=true` prints a stack dump after the `Error:` line, which would have turned a genuinely absent release into a permanent retry.
- **An unreadable pinned chart is terminal.** `helm show chart` of the chart baked into the provisioner image failing, returning no `name:` line, two of them, or an oversized answer now raises `MetadataConflict` under the new `HELM_PINNED_CHART_IS_UNREADABLE` reason. It is a wiring defect, not an eventually consistent effect, so retrying with the routes closed only hid it.
- **Typed overloads** on the history reader so callers that do not allow absence see the non-optional return.

## Verification

- Red first: 8 failed in `test_helm_guarded_transition.py` (four substring cases installed through; four chart shapes retried), then green. The `HELM_DEBUG` pin was added red-first as well: 50 failed on the environment assertion across the two Helm test files, then 83 passed.
- Full provisioner suite: 1526 passed, 67 skipped.
- `ruff check` and `ruff format --check` clean on the changed files.
- Independent code review reproduced the exact Helm 3.19.4 stderr line against a minimal API server with and without `HELM_DEBUG`, traced the terminal reason through to the operation, and approved after one correction round.

Pre-existing and tracked separately: `_chart_reference` returns the configured `provisioner.cellChartVersion`, and Helm ignores `--version` for a directory chart, so nothing binds that value to `infra/helm/cell/Chart.yaml`.
