### PR TITLE
test(provisioner): wait for the real PostgreSQL server before probing it

### DIFF
--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -112,6 +112,32 @@ def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProce
     return result
 
 
+_INIT_COMPLETE = "PostgreSQL init process complete; ready for start up."
+
+
+def _wait_until_serving(container: str) -> None:
+    """Block until the image's real server, not its init-time one, is serving.
+
+    The official image first runs a temporary server on the Unix socket to
+    apply its init scripts, and `pg_isready` answers from that server too.
+    It then stops it and starts the real one, so a probe that passed a
+    moment earlier can be followed by "connection to server on socket ...
+    failed". Require the entrypoint's init-complete line first, then a
+    successful readiness probe against the server that follows it.
+    """
+    for _ in range(120):
+        logs = _run(["docker", "logs", container], check=False)
+        if _INIT_COMPLETE in logs.stdout + logs.stderr:
+            ready = _run(
+                ["docker", "exec", container, "pg_isready", "--username", "postgres"],
+                check=False,
+            )
+            if ready.returncode == 0:
+                return
+        time.sleep(0.5)
+    raise AssertionError(_run(["docker", "logs", container], check=False).stdout)
+
+
 @pytest.fixture(scope="module")
 def postgresql17() -> Iterator[PostgreSQL17]:
     if shutil.which("docker") is None:
@@ -138,16 +164,7 @@ def postgresql17() -> Iterator[PostgreSQL17]:
         ]
     )
     try:
-        for _ in range(60):
-            ready = _run(
-                ["docker", "exec", container, "pg_isready", "--username", "postgres"],
-                check=False,
-            )
-            if ready.returncode == 0:
-                break
-            time.sleep(0.5)
-        else:
-            raise AssertionError(_run(["docker", "logs", container], check=False).stdout)
+        _wait_until_serving(container)
         port_output = _run(["docker", "port", container, "5432/tcp"]).stdout.strip()
         port_match = re.search(r":([0-9]+)$", port_output)
         assert port_match is not None, port_output
@@ -185,16 +202,7 @@ def other_postgresql17(postgresql17: PostgreSQL17) -> Iterator[PostgreSQL17]:
         ]
     )
     try:
-        for _ in range(60):
-            ready = _run(
-                ["docker", "exec", container, "pg_isready", "--username", "postgres"],
-                check=False,
-            )
-            if ready.returncode == 0:
-                break
-            time.sleep(0.5)
-        else:
-            raise AssertionError(_run(["docker", "logs", container], check=False).stdout)
+        _wait_until_serving(container)
         server = PostgreSQL17(
             container=container,
             network=postgresql17.network,


### PR DESCRIPTION
## What

The PostgreSQL 17 test fixtures wait for the image's real server, not its init-time one, before the first `psql` call.

## Why

The static validation job on #1177 errored in the fixture with:

```
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
```

The official image first runs a temporary server on the Unix socket to apply its init scripts, and `pg_isready` answers from that server too. It then stops it and starts the real one. A probe that passed a moment earlier can therefore be followed by the socket error on the very next command. The same race showed up as a one-off error in a local full-suite run during review of #1177.

## Changes

`infra/provisioner/tests/test_postgresql17.py`: both fixtures call a shared wait that requires the entrypoint's "PostgreSQL init process complete; ready for start up." line in the container log and then a successful `pg_isready`, with the same bounded budget and the same log dump on timeout.

## Verification

- `RUN_POSTGRESQL17_TEST=1` on `test_postgresql17.py` plus `test_governance_operation_recovery.py`, run twice locally against fresh containers: 59 passed, 7 skipped; then 58 passed, 1 failed, 7 skipped. The single failure was `test_postgresql17_capacity_ledger_serializes_two_sixth_slot_attempts`, a timing-window test that holds a ledger lock across a 1.3 second sleep while a receipt expires in 1 second. It passed three times in a row on main in isolation, so it is load-sensitive and unrelated to fixture startup.
- `ruff check` and `ruff format --check` clean.

Red-first does not apply: the defect is a startup race in a container entrypoint, not a behaviour a unit test can pin. The CI static job, which runs the gated PostgreSQL tests, is the proportional check.
