### PR TITLE
fix(hosted): keep a reviewer-purpose cell out of the inventory refusal once its credential expires

### DIFF
--- a/docs/runbooks/hosted/runtime-upgrades.md
+++ b/docs/runbooks/hosted/runtime-upgrades.md
@@ -101,7 +101,10 @@ infra/scripts/hosted_fleet_inventory.py collect \
 ```
 
 Resolve every reported ghost, missing binding, divergent identity, stale capacity
-claim, active assignment, or unfinished operation before continuing. Then provide
+claim, active assignment, or unfinished operation before continuing. A
+reviewer-purpose tenant whose reviewer credential has expired is still a `reviewer`
+cell and rolls forward like any other; only live reviewer authority on a tenant that
+is not reviewer-purpose is reported as `reviewer_state_divergence`. Then provide
 immutable source commits and contract digests for exactly the inventory's
 `legacyRuntimes`. Missing, duplicate, mutable, or extra descriptor units are refused.
 An empty fleet uses an explicit empty `units` list rather than omitting the proof.

--- a/infra/scripts/hosted_fleet_inventory.py
+++ b/infra/scripts/hosted_fleet_inventory.py
@@ -1478,14 +1478,17 @@ def reconcile_inventory(
         ):
             current["issues"].add("runtime_identity_divergence")
 
-        reviewer_flags = {current["reviewerAuthority"], current["reviewerTenant"]}
-        if reviewer_flags == {False, True}:
+        # A reviewer-purpose tenant is a reviewer cell for its whole life: the purpose
+        # is immutable, while reviewer credentials are issued for bounded windows and
+        # expire between runs. Only live reviewer authority on a tenant that is not
+        # reviewer-purpose is a divergence.
+        if current["reviewerAuthority"] and not current["reviewerTenant"]:
             current["issues"].add("reviewer_state_divergence")
         for issue in current["issues"]:
             issues.add(issue)
 
         terminal = destroyed_binding and not live_other
-        reviewer = current["reviewerAuthority"] and current["reviewerTenant"]
+        reviewer = current["reviewerTenant"]
         if current["issues"]:
             classification = "inconsistent"
             inconsistent_count += 1

--- a/tests/test_hosted_fleet_inventory.py
+++ b/tests/test_hosted_fleet_inventory.py
@@ -92,6 +92,7 @@ def _add_live_cell(
     cell_id: str,
     runtime: dict[str, str],
     reviewer: bool = False,
+    reviewer_authority: bool | None = None,
 ) -> None:
     substrate = sources["substrate"]
     substrate["routableCells"].append({"cellId": cell_id, "runtime": _control_runtime(runtime)})
@@ -99,8 +100,9 @@ def _add_live_cell(
     substrate["capacityClaims"].append({"cellId": cell_id})
     substrate["capacityActiveCellCount"] += 1
     if reviewer:
-        substrate["reviewerAuthorities"].append({"cellId": cell_id})
         substrate["reviewerTenants"].append({"cellId": cell_id})
+    if reviewer if reviewer_authority is None else reviewer_authority:
+        substrate["reviewerAuthorities"].append({"cellId": cell_id})
 
     sources["provisioner"]["desiredCells"].append(
         {"cellId": cell_id, "runtime": dict(runtime), "state": "ready"}
@@ -189,6 +191,53 @@ def test_reconciles_ordinary_and_reviewer_cells(
     assert inventory["counts"]["targetCells"] == 1
     assert inventory["counts"]["legacyCells"] == 0
     assert module.zero_fleet_noop(inventory) is False
+
+
+def test_reviewer_purpose_outlives_its_expired_reviewer_credential() -> None:
+    """Reviewer credentials expire between runs; the tenant's purpose does not."""
+
+    module = _module()
+    target = _runtime("0.57.2", "a")
+    legacy = _runtime("0.57.1", "b")
+    sources = _empty_sources()
+    _add_live_cell(
+        sources, cell_id="cell_1809ce5c", runtime=legacy, reviewer=True, reviewer_authority=False
+    )
+
+    inventory = module.reconcile_inventory(sources, target=target)
+
+    assert inventory["status"] == "consistent"
+    assert inventory["issues"] == []
+    cell = inventory["cells"][0]
+    assert cell["classification"] == "reviewer"
+    assert cell["surfaces"]["reviewerPurpose"] is True
+    assert cell["surfaces"]["reviewerAuthority"] is False
+    assert inventory["counts"]["reviewerCells"] == 1
+    assert inventory["counts"]["ordinaryCells"] == 0
+    assert inventory["counts"]["legacyCells"] == 1
+    facts = module.execution_inventory_facts(inventory)
+    assert facts["cells"][0]["class"] == "reviewer"
+    assert facts["cells"][0]["status"] == "pending"
+
+
+def test_live_reviewer_authority_on_an_ordinary_tenant_is_a_divergence() -> None:
+    module = _module()
+    target = _runtime("0.57.2", "a")
+    sources = _empty_sources()
+    _add_live_cell(
+        sources, cell_id="cell_1809ce5c", runtime=target, reviewer=False, reviewer_authority=True
+    )
+
+    inventory = module.reconcile_inventory(sources, target=target)
+
+    assert inventory["status"] == "inconsistent"
+    assert inventory["issues"] == ["reviewer_state_divergence"]
+    cell = inventory["cells"][0]
+    assert cell["classification"] == "inconsistent"
+    assert cell["surfaces"]["reviewerPurpose"] is False
+    assert cell["surfaces"]["reviewerAuthority"] is True
+    with pytest.raises(module.InventoryError, match="inconsistent"):
+        module.execution_inventory_facts(inventory)
 
 
 def test_substrate_cannot_assert_or_be_required_to_know_the_runtime_image() -> None:


### PR DESCRIPTION
## What

`hosted_fleet_inventory.py` reported `reviewer_state_divergence` whenever Substrate's reviewer-purpose fact and its live-reviewer-authority fact disagreed for a cell, and classified a cell as `reviewer` only when both held. Reviewer purpose is immutable for a tenant; reviewer credentials are issued for bounded windows and expire between runs. So every reviewer canary cell turned the inventory `inconsistent` as soon as its credential lapsed, and the governed runtime upgrade was refused.

Reproduced on the live alpha fleet on 2026-09-10: the single live cell belongs to the reviewer-purpose canary tenant whose credential expired days ago, and `collect` refused with `inventory is inconsistent; rollforward is refused`.

## Change

- A reviewer-purpose tenant is a `reviewer` cell for its whole life, whatever its credential state.
- `reviewer_state_divergence` fires only for live reviewer authority on a tenant that is not reviewer-purpose.
- One runbook sentence under the inventory step says so.

Legacy counting, rollout selection, contract and promotion gating already treated reviewer cells exactly like ordinary cells, so the refusal was the old rule's only effect.

## Verification

- `uv run --frozen pytest -q tests/test_hosted_fleet_inventory.py`: 34 passed (two new tests; the positive one confirmed to fail against the previous code).
- `uvx ruff check` and `ruff format --check` clean on both Python files; privacy gate clean.
- Independent review: reviewer-purpose is now correctly treated as an immutable tenant property rather than conflated with the reviewer credential's bounded-window liveness, fixing a false-positive `reviewer_state_divergence` refusal (reproduced on the live alpha fleet) while leaving every other gating path unchanged and covered by tests that were confirmed to fail against the prior code. APPROVE.
