### PR TITLE
fix(hosted): accept the frozen rollback baseline when a live legacy cell is not that release

### DIFF
--- a/infra/scripts/verify_hosted_release.py
+++ b/infra/scripts/verify_hosted_release.py
@@ -751,24 +751,30 @@ def _evidence_file(
 
 
 def _validate_legacy_manifest(manifest: dict[str, Any], lock: dict[str, Any]) -> None:
-    """Validate rollback evidence and bind it when a live legacy unit remains."""
+    """Validate rollback evidence and keep it exact for any legacy unit it names.
+
+    The rollback tuple is the frozen D0 baseline carried from lock to lock; which
+    runtimes are still live is proven by the fleet inventory and the reviewed legacy
+    catalog, not by this manifest. A manifest naming a release the catalog carries
+    must agree with that unit's identity; one naming a release outside the catalog
+    is the baseline itself and is accepted.
+    """
 
     validate_release_manifest(manifest, manifest)
-    legacy_catalog = lock["composition"]["legacyCatalog"]
-    if not legacy_catalog:
-        return
-    matches = []
-    for unit in legacy_catalog:
+    for unit in lock["composition"]["legacyCatalog"]:
         contract = unit["contract"]
         if (
-            manifest["release"] == contract["releaseVersion"]
-            and manifest["hostedProtocol"] == contract["protocolVersion"]
-            and manifest["runtimeImage"] == contract["runtimeImage"]
-            and manifest["sourceCommit"] == contract["sourceCommit"]
+            manifest["release"] != contract["releaseVersion"]
+            or manifest["hostedProtocol"] != contract["protocolVersion"]
         ):
-            matches.append(unit)
-    if len(matches) != 1:
-        raise ValueError("rollback manifest does not equal one reviewed legacy runtime identity")
+            continue
+        if (
+            manifest["runtimeImage"] != contract["runtimeImage"]
+            or manifest["sourceCommit"] != contract["sourceCommit"]
+        ):
+            raise ValueError(
+                "rollback manifest contradicts the reviewed legacy runtime identity it names"
+            )
 
 
 def _substitute_v1_corpus_tokens(value: object) -> object:

--- a/tests/test_hosted_deployment_lock_consumption.py
+++ b/tests/test_hosted_deployment_lock_consumption.py
@@ -367,6 +367,41 @@ def test_empty_legacy_catalog_still_accepts_a_valid_rollback_manifest() -> None:
         verifier._validate_legacy_manifest(manifest, lock)
 
 
+def test_rollback_baseline_outside_the_legacy_catalog_is_accepted() -> None:
+    """The D0 rollback tuple outlives the legacy fleet it was first bound to."""
+
+    verifier = _module(VERIFIER)
+    lock = _member("expand")
+    catalog = lock["composition"]["legacyCatalog"]  # type: ignore[index]
+    assert catalog, "the fixture pair must carry a reviewed legacy unit"
+    manifest = json.loads(LEGACY_MANIFEST.read_text(encoding="utf-8"))
+    assert all(
+        (manifest["release"], manifest["hostedProtocol"])
+        != (unit["contract"]["releaseVersion"], unit["contract"]["protocolVersion"])
+        for unit in catalog
+    )
+
+    verifier._validate_legacy_manifest(manifest, lock)
+
+
+def test_rollback_manifest_must_agree_with_the_legacy_unit_it_names() -> None:
+    verifier = _module(VERIFIER)
+    lock = _member("expand")
+    contract = lock["composition"]["legacyCatalog"][0]["contract"]  # type: ignore[index]
+    manifest = json.loads(LEGACY_MANIFEST.read_text(encoding="utf-8"))
+    manifest["release"] = contract["releaseVersion"]
+    manifest["hostedProtocol"] = contract["protocolVersion"]
+    manifest["runtimeImage"] = contract["runtimeImage"]
+    manifest["sourceCommit"] = contract["sourceCommit"]
+    manifest["publishedTag"] = f"ghcr.io/artexis10/exomem:{contract['sourceCommit']}-hosted"
+
+    verifier._validate_legacy_manifest(manifest, lock)
+
+    manifest["runtimeImage"] = "ghcr.io/artexis10/exomem@sha256:" + "f" * 64
+    with pytest.raises(ValueError, match="contradicts the reviewed legacy runtime identity"):
+        verifier._validate_legacy_manifest(manifest, lock)
+
+
 def test_fixed_lock_evidence_rejects_substituted_runtime_trust(tmp_path: Path) -> None:
     verifier = _module(VERIFIER)
     lock = _member("expand")


### PR DESCRIPTION
## What

`verify_hosted_release.py` refused a lock whose `composition.legacyCatalog` was non-empty unless the rollback manifest equalled exactly one catalogued legacy runtime. The rollback tuple has been the frozen D0 baseline since the first v2 lock: the 0.39.2 release manifest, the v1 provisioner, the frozen v1 wire corpus and the v1 Substrate consumer commit, carried byte-for-byte through every later composition. Every earlier upgrade happened against an empty legacy catalog, so the binding never fired.

Reproduced 2026-09-10 composing the 0.77.0 lock over one live cell at 0.73.1: `derive-legacy` produced a one-unit catalog and `verify_hosted_release.py --phase expand` failed with `rollback manifest does not equal one reviewed legacy runtime identity`. No generator exists for v1-shaped `exomem-hosted-release` manifests of v2-era releases, so the rule could only be satisfied by hand-authoring rollback evidence.

## Change

`_validate_legacy_manifest` still validates the manifest in full. If the manifest names a release and protocol the catalog carries, that unit's runtime image and source commit must match exactly (`contradicts the reviewed legacy runtime identity it names`). A manifest naming a release outside the catalog is the baseline and is accepted. Which runtimes are live is proven by the fleet inventory and the reviewed legacy catalog. The Helm rollback selection path is driven by `recordsCompatibility.rollbackRuntime`, not by this tuple, so nothing deployed changes.

## Verification

- `uv run --frozen pytest -q tests/test_hosted_deployment_lock_consumption.py`: 30 passed (two new tests; the first confirmed to fail against the previous code, the second preserves the exact-match guard).
- `verify_hosted_release.py --phase expand` on the composed 0.77.0 pair with its evidence directory: `hosted deployment lock verified`.
- `ruff check`, `ruff format --check` and the privacy gate clean.
- Independent review: the verifier now binds the frozen rollback manifest to a legacy-catalog entry only when it names that entry's release, verified against the 0.73.1 reproduction, the pre-fix code, and the full evidence-consumer surface. APPROVE.
