### PR TITLE
fix(hosted): keep the outgoing legacy cell alive through an expand and route the rollforward paths

### DIFF
--- a/infra/contracts/platform-composition-v1.json
+++ b/infra/contracts/platform-composition-v1.json
@@ -24,7 +24,13 @@
       "commandRegistry"
     ],
     "command_registry_length": 21,
-    "command_exact_fields": ["name", "readOnly", "mode", "tier", "capability"],
+    "command_exact_fields": [
+      "name",
+      "readOnly",
+      "mode",
+      "tier",
+      "capability"
+    ],
     "command_types": {
       "name": "snake_case string",
       "readOnly": "boolean",
@@ -51,34 +57,96 @@
       "X-Exomem-Provisioner-Protocol"
     ],
     "actions": {
-      "provision": {"method": "POST", "path": "/cells/provision"},
-      "health": {"method": "POST", "path": "/cells/health"},
-      "rotate-credential": {"method": "POST", "path": "/cells/rotate-credential"},
-      "quiesce": {"method": "POST", "path": "/cells/quiesce"},
-      "renew-authorization": {"method": "POST", "path": "/cells/renew-authorization"},
-      "resume": {"method": "POST", "path": "/cells/resume"},
-      "stop": {"method": "POST", "path": "/cells/stop"},
-      "export": {"method": "POST", "path": "/cells/export"},
-      "export-release": {"method": "POST", "path": "/cells/export-release"},
-      "export-delete": {"method": "POST", "path": "/cells/export-delete"},
-      "restore": {"method": "POST", "path": "/cells/restore"},
-      "export-download": {"method": "POST", "path": "/cells/export-download"},
-      "seal": {"method": "POST", "path": "/cells/seal"},
-      "discard": {"method": "POST", "path": "/cells/discard"},
-      "destroy": {"method": "POST", "path": "/cells/destroy"}
+      "provision": {
+        "method": "POST",
+        "path": "/cells/provision"
+      },
+      "health": {
+        "method": "POST",
+        "path": "/cells/health"
+      },
+      "rotate-credential": {
+        "method": "POST",
+        "path": "/cells/rotate-credential"
+      },
+      "quiesce": {
+        "method": "POST",
+        "path": "/cells/quiesce"
+      },
+      "renew-authorization": {
+        "method": "POST",
+        "path": "/cells/renew-authorization"
+      },
+      "rollforward": {
+        "method": "POST",
+        "path": "/cells/rollforward"
+      },
+      "rollback-rollforward": {
+        "method": "POST",
+        "path": "/cells/rollback-rollforward"
+      },
+      "resume": {
+        "method": "POST",
+        "path": "/cells/resume"
+      },
+      "stop": {
+        "method": "POST",
+        "path": "/cells/stop"
+      },
+      "export": {
+        "method": "POST",
+        "path": "/cells/export"
+      },
+      "export-release": {
+        "method": "POST",
+        "path": "/cells/export-release"
+      },
+      "export-delete": {
+        "method": "POST",
+        "path": "/cells/export-delete"
+      },
+      "restore": {
+        "method": "POST",
+        "path": "/cells/restore"
+      },
+      "export-download": {
+        "method": "POST",
+        "path": "/cells/export-download"
+      },
+      "seal": {
+        "method": "POST",
+        "path": "/cells/seal"
+      },
+      "discard": {
+        "method": "POST",
+        "path": "/cells/discard"
+      },
+      "destroy": {
+        "method": "POST",
+        "path": "/cells/destroy"
+      }
     }
   },
   "capacity_gate": {
     "implementation": "SignedLiveReceiptPostgreSQLCapacityAuthority",
-    "invoked_before": ["routine-provider-effect", "volume-registration-provider-effect"],
-    "provider_defense_checks": ["namespace-create", "helm-install"],
+    "invoked_before": [
+      "routine-provider-effect",
+      "volume-registration-provider-effect"
+    ],
+    "provider_defense_checks": [
+      "namespace-create",
+      "helm-install"
+    ],
     "pending_retry_seconds": 300,
     "sources": [
       "signed-kubernetes-hcloud-receipt",
       "fresh-kubernetes-observation",
       "postgresql-capacity-reservations"
     ],
-    "public_material_consumers": ["exomem-provisioner-worker", "exomem-volume-worker"],
+    "public_material_consumers": [
+      "exomem-provisioner-worker",
+      "exomem-volume-worker"
+    ],
     "limits": {
       "active_user_cells": 4,
       "active_recovery_cells": 2,
@@ -89,7 +157,10 @@
   },
   "volume_rebind": {
     "public_endpoint": null,
-    "invoked_by": ["restore", "node-recovery"],
+    "invoked_by": [
+      "restore",
+      "node-recovery"
+    ],
     "worker_primitive": "VolumeLifecycleWorker.rebind_static"
   },
   "provider_recovery_identity": {
@@ -119,7 +190,9 @@
       "deletion_job_template": "exomem-deletion-job-template",
       "volume_lifecycle": "exomem-volume-worker"
     },
-    "private_signers": ["exomem-provider-recovery-signer/private-key"],
+    "private_signers": [
+      "exomem-provider-recovery-signer/private-key"
+    ],
     "public_verifier": "exomem-provider-recovery-verifier/public-key"
   }
 }

--- a/infra/helm/platform/templates/provisioner-route.yaml
+++ b/infra/helm/platform/templates/provisioner-route.yaml
@@ -17,6 +17,8 @@ spec:
         Path(`/cells/rotate-credential`) ||
         Path(`/cells/quiesce`) ||
         Path(`/cells/renew-authorization`) ||
+        Path(`/cells/rollforward`) ||
+        Path(`/cells/rollback-rollforward`) ||
         Path(`/cells/resume`) ||
         Path(`/cells/stop`) ||
         Path(`/cells/export`) ||

--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -12,7 +12,7 @@ import os
 import re
 import tempfile
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -2241,7 +2241,15 @@ class PrivateCellApiAdapter:
         expected_contract_digest: str | None = None,
         expected_governance: HostedAuthorizationBundle | None = None,
         retry_transport: bool = False,
+        expected_target: Mapping[str, str] | None = None,
     ) -> HealthObservation:
+        # The runtime identity a v2 request names for this cell. During an expand a
+        # cell still on a cataloged legacy release reports its own profile and
+        # compatibility digest, not the selected forward ones.
+        if expected_target is None and config.runtime_target is not None:
+            expected_target = config.runtime_target_for(
+                {"runtimeTarget": config.runtime_target}, v2=True
+            )
         live = await self._call(
             "GET",
             metadata,
@@ -2300,12 +2308,12 @@ class PrivateCellApiAdapter:
         records_reader_version: int | None = None
         lifecycle_actions_enabled: bool | None = None
         if require_runtime_identity:
-            if config.runtime_target is None:
+            if expected_target is None:
                 raise MetadataConflict(
                     "selected runtime identity is unavailable",
                     reason=ConflictReason.SELECTED_RUNTIME_IDENTITY_IS_UNAVAILABLE,
                 )
-            selected_profile = config.runtime_target["agentProfile"]
+            selected_profile = expected_target["agentProfile"]
             agent_response = await self._request_response(
                 "GET",
                 metadata,
@@ -2475,10 +2483,8 @@ class PrivateCellApiAdapter:
                 command_fingerprint=command_fingerprint,
                 schema_digest=schema_digest,
                 compatibility_digest=(
-                    config.runtime_target_for(
-                        {"runtimeTarget": config.runtime_target}, v2=True
-                    ).get("compatibilityDigest")
-                    if require_runtime_identity
+                    expected_target.get("compatibilityDigest")
+                    if require_runtime_identity and expected_target is not None
                     else None
                 ),
                 records_reader_version=records_reader_version,

--- a/infra/provisioner/src/exomem_provisioner/app.py
+++ b/infra/provisioner/src/exomem_provisioner/app.py
@@ -28,6 +28,7 @@ from .repository import (
     IdempotencyConflict,
     OperationRepository,
     StaleFence,
+    legacy_targets_from,
 )
 from .schemas import (
     FailureCode,
@@ -142,6 +143,7 @@ def create_app(
             mode=lock.admission_mode,
             legacy_catalog=lock.legacy_catalog,
             forward_target=forward_target,
+            legacy_targets=legacy_targets_from(lock.legacy_targets),
         )
 
     @app.exception_handler(RequestValidationError)

--- a/infra/provisioner/src/exomem_provisioner/config.py
+++ b/infra/provisioner/src/exomem_provisioner/config.py
@@ -407,6 +407,17 @@ class DeploymentLock(BaseModel):
         )
 
     @property
+    def legacy_targets(self) -> tuple[dict[str, str], ...]:
+        """The six-field runtime identity of every cataloged legacy contract."""
+
+        from .wire_protocol import RUNTIME_IDENTITY_FIELDS
+
+        return tuple(
+            {field: getattr(unit.contract, field) for field in RUNTIME_IDENTITY_FIELDS}
+            for unit in self.composition.legacyCatalog
+        )
+
+    @property
     def authoritative_legacy_release_set_sha256(self) -> str:
         return self.composition.authoritativeLegacyReleaseSetSha256
 
@@ -416,8 +427,14 @@ class DeploymentLock(BaseModel):
         *,
         wire_protocol: str,
         selection: Literal["active", "rollback"] | None = None,
+        action: str | None = None,
     ) -> bool:
-        from .wire_protocol import WIRE_PROTOCOL_V2, runtime_identity
+        from .wire_protocol import (
+            FORWARD_ONLY_ACTIONS,
+            RUNTIME_IDENTITY_FIELDS,
+            WIRE_PROTOCOL_V2,
+            runtime_identity,
+        )
 
         try:
             target = runtime_identity(request)
@@ -431,7 +448,14 @@ class DeploymentLock(BaseModel):
             expected = selected.runtimeTarget.model_dump(mode="json")
             if selected.compatibilityDigest is not None:
                 expected["compatibilityDigest"] = selected.compatibilityDigest
-            return target == expected
+            if target == expected:
+                return True
+            # A cell still on a cataloged legacy release matches by its exact six-field
+            # contract identity, except for the actions that place a runtime image.
+            if action in FORWARD_ONLY_ACTIONS:
+                return False
+            identity = {field: target.get(field) for field in RUNTIME_IDENTITY_FIELDS}
+            return identity in self.legacy_targets
         return (target["releaseVersion"], target["protocolVersion"]) in self.legacy_catalog
 
 

--- a/infra/provisioner/src/exomem_provisioner/durability_actions.py
+++ b/infra/provisioner/src/exomem_provisioner/durability_actions.py
@@ -713,8 +713,10 @@ class KubernetesRestoreCandidateResolver:
     async def resolve(self, candidate_cell_id: str, *, source_vault_id: str):
         context = await self._context(candidate_cell_id, source_vault_id=source_vault_id)
         metadata = context.metadata
+        # A restore recovers the cell on the release its stored provision named, so
+        # a cell that a later expand catalogs as legacy keeps its own image here.
         target = self._config.runtime_target_for(
-            context.request, v2=context.wire_protocol == WIRE_PROTOCOL_V2
+            context.request, v2=context.wire_protocol == WIRE_PROTOCOL_V2, action="restore"
         )
         controller = HelmRestoreCandidateController(
             metadata=metadata,
@@ -794,7 +796,7 @@ class KubernetesRestoreCandidateResolver:
             archive_stager=self._stager,
             binding=binding,
             image=self._config.runtime_image_for(
-                context.request, v2=context.wire_protocol == WIRE_PROTOCOL_V2
+                context.request, v2=context.wire_protocol == WIRE_PROTOCOL_V2, action="restore"
             ),
             staging_image=self._provisioner_image,
             release_version=target["releaseVersion"],
@@ -860,7 +862,7 @@ class KubernetesRestoreCandidateResolver:
             or request.get("cellId") != metadata.subject_id
             or request.get("fenceGeneration") != metadata.fence_generation
             or not self._config.matches_runtime_request(
-                request, v2=rows[0].wire_protocol == WIRE_PROTOCOL_V2
+                request, v2=rows[0].wire_protocol == WIRE_PROTOCOL_V2, action="restore"
             )
         ):
             raise RestoreJobFailed("restore candidate provision request differs")

--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -39,7 +39,12 @@ from .provider_identity import (
     decode_hcloud_identity_envelope,
     provider_operation_resource_name,
 )
-from .wire_protocol import WIRE_PROTOCOL_V2, runtime_identity
+from .wire_protocol import (
+    FORWARD_ONLY_ACTIONS,
+    RUNTIME_IDENTITY_FIELDS,
+    WIRE_PROTOCOL_V2,
+    runtime_identity,
+)
 
 
 class MetadataConflict(RuntimeError):
@@ -262,16 +267,58 @@ class LifecycleConfig:
         "none"
     )
 
-    def runtime_target_for(self, request: dict[str, Any], *, v2: bool) -> dict[str, str]:
+    def _forward_target(self) -> dict[str, str]:
+        if self.runtime_target is None:
+            raise MetadataConflict("selected runtime target is unavailable")
+        compatibility_digest = self.compatibility_digest or self.runtime_target.get(
+            "compatibilityDigest"
+        )
+        if compatibility_digest is None:
+            return dict(self.runtime_target)
+        return {**self.runtime_target, "compatibilityDigest": compatibility_digest}
+
+    def _legacy_unit_for(
+        self, request: dict[str, Any], *, action: str | None
+    ) -> dict[str, str] | None:
+        """The cataloged legacy contract a v2 request names by exact identity, if any.
+
+        A legacy match is by all six contract fields, never by release label alone,
+        and is never offered to an action that places a runtime image: those only
+        ever target the selected forward release.
+        """
+
+        if action in FORWARD_ONLY_ACTIONS:
+            return None
+        try:
+            identity = runtime_identity(request)
+        except (KeyError, ValueError):
+            return None
+        if self.runtime_target is not None and identity == self._forward_target():
+            return None
+        unit = (self.legacy_runtime_units or {}).get(
+            (identity.get("releaseVersion"), identity.get("protocolVersion"))
+        )
+        if unit is None or any(
+            unit.get(field) != identity.get(field) for field in RUNTIME_IDENTITY_FIELDS
+        ):
+            return None
+        return unit
+
+    def runtime_target_for(
+        self, request: dict[str, Any], *, v2: bool, action: str | None = None
+    ) -> dict[str, str]:
         if v2:
-            if self.runtime_target is None:
-                raise MetadataConflict("selected runtime target is unavailable")
-            compatibility_digest = self.compatibility_digest or self.runtime_target.get(
-                "compatibilityDigest"
-            )
-            if compatibility_digest is None:
-                return dict(self.runtime_target)
-            return {**self.runtime_target, "compatibilityDigest": compatibility_digest}
+            forward = self._forward_target()
+            legacy = self._legacy_unit_for(request, action=action)
+            if legacy is None:
+                return forward
+            target = {field: legacy[field] for field in RUNTIME_IDENTITY_FIELDS}
+            # The catalog records no compatibility digest: the request's own is the
+            # one Substrate bound this cell to, and the health probe reports it back.
+            compatibility_digest = runtime_identity(request).get("compatibilityDigest")
+            if compatibility_digest is not None:
+                target["compatibilityDigest"] = compatibility_digest
+            return target
         target = runtime_identity(request)
         try:
             return (self.legacy_runtime_units or {})[
@@ -280,15 +327,22 @@ class LifecycleConfig:
         except KeyError as error:
             raise MetadataConflict("legacy runtime unit is not selected") from error
 
-    def matches_runtime_request(self, request: dict[str, Any], *, v2: bool) -> bool:
+    def matches_runtime_request(
+        self, request: dict[str, Any], *, v2: bool, action: str | None = None
+    ) -> bool:
         try:
-            expected = self.runtime_target_for(request, v2=v2)
+            expected = self.runtime_target_for(request, v2=v2, action=action)
         except MetadataConflict:
             return False
         return runtime_identity(request) == expected if v2 else True
 
-    def runtime_image_for(self, request: dict[str, Any], *, v2: bool) -> str:
-        return self.image if v2 else self.runtime_target_for(request, v2=False)["runtimeImage"]
+    def runtime_image_for(
+        self, request: dict[str, Any], *, v2: bool, action: str | None = None
+    ) -> str:
+        if not v2:
+            return self.runtime_target_for(request, v2=False)["runtimeImage"]
+        legacy = self._legacy_unit_for(request, action=action)
+        return self.image if legacy is None else legacy["runtimeImage"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -1925,11 +1979,13 @@ class CellLifecycleDriver:
     async def observed_fence(self, tenant_id: str) -> int:
         return await self._plane.observed_fence(tenant_id)
 
-    def runtime_target_matches(self, request: dict[str, Any], context: EffectContext) -> bool:
+    def runtime_target_matches(
+        self, request: dict[str, Any], context: EffectContext, action: str | None = None
+    ) -> bool:
         if "runtimeTarget" not in request and "releaseVersion" not in request:
             return True
         return self._config.matches_runtime_request(
-            request, v2=context.wire_protocol == WIRE_PROTOCOL_V2
+            request, v2=context.wire_protocol == WIRE_PROTOCOL_V2, action=action
         )
 
     def rollforward_target_matches(self, request: dict[str, Any], context: EffectContext) -> bool:
@@ -1937,7 +1993,7 @@ class CellLifecycleDriver:
             context.wire_protocol == WIRE_PROTOCOL_V2
             and self._config.compatibility_digest is not None
             and request.get("compatibilityDigest") == self._config.compatibility_digest
-            and self.runtime_target_matches(request, context)
+            and self.runtime_target_matches(request, context, "rollforward")
         )
 
     async def _stop_failed_rollforward(self, metadata: OpaqueProviderMetadata) -> None:
@@ -1987,7 +2043,7 @@ class CellLifecycleDriver:
             if action not in {
                 "rollforward",
                 "rollback-rollforward",
-            } and not self.runtime_target_matches(request, context):
+            } and not self.runtime_target_matches(request, context, action):
                 raise DriverTerminal("PROVISIONER_RELEASE_UNIT_MISMATCH")
             if await self.observed_fence(context.tenant_id) > context.fence_generation:
                 raise DriverTerminal("PROVISIONER_STALE_FENCE")

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -1509,6 +1509,7 @@ class LiveLifecyclePlane:
             expected_worker_policy=dict(request["workerPolicy"]),
             require_runtime_identity=v2,
             expected_contract_digest=target["gatewayContractDigest"],
+            **({"expected_target": target} if v2 else {}),
             **({"expected_governance": bundle, "retry_transport": True} if governed else {}),
         )
         if governed:
@@ -1737,7 +1738,8 @@ class LiveLifecyclePlane:
             self._config.migration_mode != "governance-v3-to-v4"
             or context.wire_protocol != WIRE_PROTOCOL_V2
             or self._governance_migration is None
-            or runtime_identity(request) != self._config.runtime_target_for(request, v2=True)
+            or runtime_identity(request)
+            != self._config.runtime_target_for(request, v2=True, action="rollforward")
         ):
             raise unavailable()
         try:
@@ -1821,7 +1823,8 @@ class LiveLifecyclePlane:
                 metadata.operation_id,
                 metadata.fence_generation,
             )
-            or runtime_identity(request) != self._config.runtime_target_for(request, v2=True)
+            or runtime_identity(request)
+            != self._config.runtime_target_for(request, v2=True, action="provision")
         ):
             raise DriverTerminal("PROVISIONER_CHECKPOINT_INVALID")
         owner = self._owned[self._key(metadata)]
@@ -1881,7 +1884,8 @@ class LiveLifecyclePlane:
                     metadata.operation_id,
                     metadata.fence_generation,
                 )
-                or runtime_identity(request) != self._config.runtime_target_for(request, v2=True)
+                or runtime_identity(request)
+                != self._config.runtime_target_for(request, v2=True, action="provision")
             ):
                 raise DriverTerminal("PROVISIONER_GOVERNANCE_PROVISION_UNAVAILABLE")
             if context.checkpoint.startswith(CHECKPOINT_VERSION + ":"):

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -1629,6 +1629,7 @@ class RecoveryService:
                 request,
                 wire_protocol=operation.wire_protocol.value,
                 selection=self._runtime_selection,
+                action=operation.action.value,
             )
         ):
             raise RecoveryRefusal("retarget resume preflight failed")
@@ -1698,6 +1699,7 @@ class RecoveryService:
                 request,
                 wire_protocol=operation.wire_protocol.value,
                 selection=self._runtime_selection,
+                action=operation.action.value,
             )
         ):
             raise RecoveryRefusal("retarget retry preflight failed")
@@ -1782,6 +1784,7 @@ class RecoveryService:
                 request,
                 wire_protocol=operation.wire_protocol.value,
                 selection=self._runtime_selection,
+                action=operation.action.value,
             )
         ):
             raise RecoveryRefusal("successor retarget preflight failed")
@@ -1895,6 +1898,7 @@ class RecoveryService:
                 request,
                 wire_protocol=operation.wire_protocol.value,
                 selection=self._runtime_selection,
+                action=operation.action.value,
             )
         ):
             raise RecoveryRefusal("retarget preflight failed")
@@ -1987,6 +1991,7 @@ class RecoveryService:
                 request,
                 wire_protocol=operation.wire_protocol.value,
                 selection=self._runtime_selection,
+                action=operation.action.value,
             )
         ):
             raise RecoveryRefusal("recovery preflight failed")

--- a/infra/provisioner/src/exomem_provisioner/repository.py
+++ b/infra/provisioner/src/exomem_provisioner/repository.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import secrets
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -38,7 +39,12 @@ from .models import (
     WireProtocol,
 )
 from .provider_identity import cell_resource_name
-from .wire_protocol import WIRE_PROTOCOL_V1, WIRE_PROTOCOL_V2
+from .wire_protocol import (
+    FORWARD_ONLY_ACTIONS,
+    RUNTIME_IDENTITY_FIELDS,
+    WIRE_PROTOCOL_V1,
+    WIRE_PROTOCOL_V2,
+)
 
 GOVERNANCE_PROVISION_CHECKPOINT_VERSION = "gpi1"
 GOVERNANCE_PROVISION_CHECKPOINT_PHASES = frozenset({"initializing", "complete", "drained"})
@@ -202,6 +208,19 @@ def _governance_recovery_snapshot(
     return _governance_recovery_digest(operation, fence.fence_generation)
 
 
+LegacyTarget = tuple[tuple[str, str], ...]
+
+
+def legacy_target_key(target: Mapping[str, object]) -> LegacyTarget:
+    """Reduce a runtime target to the six identity fields a legacy contract carries."""
+
+    return tuple((field, str(target.get(field))) for field in RUNTIME_IDENTITY_FIELDS)
+
+
+def legacy_targets_from(contracts: Iterable[Mapping[str, object]]) -> frozenset[LegacyTarget]:
+    return frozenset(legacy_target_key(contract) for contract in contracts)
+
+
 @dataclass(frozen=True, slots=True)
 class AdmissionPolicy:
     """Immutable deployment admission inputs supplied by the selected lock."""
@@ -209,6 +228,10 @@ class AdmissionPolicy:
     mode: str
     legacy_catalog: frozenset[tuple[str, str]]
     forward_target: dict[str, str]
+    # Exact six-field identities of the cataloged legacy contracts. A v2 request
+    # names its runtime by these fields plus a compatibility digest, so a live
+    # legacy cell is admitted by identity, never by release label alone.
+    legacy_targets: frozenset[LegacyTarget] = frozenset()
 
 
 def _admit_submission(
@@ -217,6 +240,7 @@ def _admit_submission(
     wire_protocol: str,
     request: dict[str, Any],
     existing: Operation | None,
+    action: str | None = None,
 ) -> None:
     if wire_protocol not in {WIRE_PROTOCOL_V1, WIRE_PROTOCOL_V2}:
         raise AdmissionRejected("unsupported wire protocol")
@@ -234,8 +258,25 @@ def _admit_submission(
             if identity not in policy.legacy_catalog:
                 raise AdmissionRejected("legacy runtime is not cataloged")
         return
-    if "runtimeTarget" in request and request["runtimeTarget"] != policy.forward_target:
-        raise AdmissionRejected("runtime target does not match deployment lock")
+    if "runtimeTarget" not in request:
+        return
+    target = request["runtimeTarget"]
+    if target == policy.forward_target:
+        return
+    if (
+        action not in FORWARD_ONLY_ACTIONS
+        and isinstance(target, Mapping)
+        and legacy_target_key(target) in policy.legacy_targets
+    ):
+        # A cell still on a cataloged legacy release keeps renewing, checking and
+        # stopping through the expand window; only the actions that place a runtime
+        # image must name the forward target. Contract mode refuses only a fresh
+        # legacy submission, mirroring v1: an operation already accepted may be
+        # replayed for its acknowledgement until it settles.
+        if policy.mode == "expand" or existing is not None:
+            return
+        raise AdmissionRejected("fresh legacy runtime is not admitted in contract mode")
+    raise AdmissionRejected("runtime target does not match deployment lock")
 
 
 def canonical_request_bytes(request: dict[str, Any]) -> bytes:
@@ -798,6 +839,7 @@ class OperationRepository:
                         wire_protocol=wire_protocol,
                         request=request,
                         existing=existing,
+                        action=action_value.value,
                     )
                     if existing is not None:
                         return _operation_snapshot(existing)
@@ -1244,10 +1286,9 @@ class OperationRepository:
                 now=now,
             )
             if _holds_governance_checkpoint(operation, operation.checkpoint):
-                if (
-                    operation.checkpoint.startswith(GOVERNANCE_CHECKPOINT_VERSION + ":")
-                    and checkpoint.startswith(GOVERNANCE_PROVISION_CHECKPOINT_VERSION + ":")
-                ):
+                if operation.checkpoint.startswith(
+                    GOVERNANCE_CHECKPOINT_VERSION + ":"
+                ) and checkpoint.startswith(GOVERNANCE_PROVISION_CHECKPOINT_VERSION + ":"):
                     raise ClaimConflict("governance migration cannot return to initialization")
                 if not _holds_governance_checkpoint(operation, checkpoint):
                     # Capacity waits and other scheduling outcomes must not

--- a/infra/provisioner/src/exomem_provisioner/wire_protocol.py
+++ b/infra/provisioner/src/exomem_provisioner/wire_protocol.py
@@ -18,6 +18,23 @@ from .schemas import (
 WIRE_PROTOCOL_V1 = "exomem-cell-provisioner.v1"
 WIRE_PROTOCOL_V2 = "exomem-cell-provisioner.v2"
 
+# The fields a reviewed runtime contract carries. A v2 request names its runtime
+# by these plus a compatibility digest that the legacy catalog never records.
+RUNTIME_IDENTITY_FIELDS = (
+    "releaseVersion",
+    "protocolVersion",
+    "agentProfile",
+    "gatewayContractDigest",
+    "commandFingerprint",
+    "schemaDigest",
+)
+
+# Actions that place or replace a runtime image only ever target the selected
+# forward release. Every other action operates on a cell as it already stands, so
+# a cell still on a cataloged legacy release keeps renewing, checking, stopping
+# and resuming through an expand window instead of lapsing.
+FORWARD_ONLY_ACTIONS = frozenset({"provision", "rollforward", "rollback-rollforward"})
+
 REQUEST_MODELS_BY_PROTOCOL: Mapping[str, Mapping[str, type[StrictSchema]]] = MappingProxyType(
     {
         WIRE_PROTOCOL_V1: V1_REQUEST_MODELS,

--- a/infra/provisioner/tests/test_api.py
+++ b/infra/provisioner/tests/test_api.py
@@ -78,22 +78,84 @@ def _settings(path: Path) -> ProvisionerSettings:
     digest = "a" * 64
     commit = "b" * 40
     target = {
-        "releaseVersion": "0.35.1", "protocolVersion": "1", "agentProfile": "hosted-alpha-agent-v1",
-        "gatewayContractDigest": digest, "commandFingerprint": "c" * 64, "schemaDigest": "d" * 64,
+        "releaseVersion": "0.35.1",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v1",
+        "gatewayContractDigest": digest,
+        "commandFingerprint": "c" * 64,
+        "schemaDigest": "d" * 64,
     }
     legacy_contract = {
-        **target, "releaseVersion": "0.22.0", "protocolVersion": "exomem-hosted.v1",
-        "runtimeImage": f"ghcr.io/artexis10/exomem@sha256:{digest}", "sourceCommit": commit,
+        **target,
+        "releaseVersion": "0.22.0",
+        "protocolVersion": "exomem-hosted.v1",
+        "runtimeImage": f"ghcr.io/artexis10/exomem@sha256:{digest}",
+        "sourceCommit": commit,
     }
     lock_path = path.with_suffix(".lock.json")
-    lock_path.write_text(json.dumps({
-        "artifact": "exomem-hosted-deployment-lock", "schemaVersion": 2, "admissionMode": "expand",
-        "components": {"runtime": {"image": f"ghcr.io/artexis10/exomem@sha256:{digest}", "sourceCommit": commit, "candidateSha256": digest}, "provisioner": {"image": f"ghcr.io/artexis10/exomem-provisioner@sha256:{'e' * 64}", "sourceCommit": commit, "candidateSha256": "e" * 64, "wireProtocol": "exomem-cell-provisioner.v2"}},
-        "runtimeTarget": target,
-        "runtimeUpgrade": {"compatibilityDigest": "e" * 64, "migrationMode": "none", "substrateConsumerCommit": commit, "substrateTrustSha256": "e" * 64},
-        "composition": {"commit": commit, "sourceClosure": {name: {"candidateCommit": commit, "compositionCommit": commit, "paths": ["src/**"]} for name in ("runtime", "provisioner")}, "forwardContractSha256": digest, "authoritativeLegacyReleaseSetSha256": "f" * 64, "legacyCatalog": [{"releaseVersion": "0.22.0", "protocolVersion": "exomem-hosted.v1", "runtimeImage": f"ghcr.io/artexis10/exomem@sha256:{digest}", "sourceCommit": commit, "contractSha256": _canonical_sha256(legacy_contract), "contract": legacy_contract}], "legacyReleaseSetSha256": _canonical_sha256([{"releaseVersion": "0.22.0", "protocolVersion": "exomem-hosted.v1"}])},
-        "rollback": {"provisionerImage": f"ghcr.io/artexis10/exomem-provisioner@sha256:{'e' * 64}", "provisionerSourceCommit": commit, "v1CorpusSha256": digest, "legacyManifestSha256": digest, "substrateV1ConsumerCommit": commit},
-    }), encoding="utf-8")
+    lock_path.write_text(
+        json.dumps(
+            {
+                "artifact": "exomem-hosted-deployment-lock",
+                "schemaVersion": 2,
+                "admissionMode": "expand",
+                "components": {
+                    "runtime": {
+                        "image": f"ghcr.io/artexis10/exomem@sha256:{digest}",
+                        "sourceCommit": commit,
+                        "candidateSha256": digest,
+                    },
+                    "provisioner": {
+                        "image": f"ghcr.io/artexis10/exomem-provisioner@sha256:{'e' * 64}",
+                        "sourceCommit": commit,
+                        "candidateSha256": "e" * 64,
+                        "wireProtocol": "exomem-cell-provisioner.v2",
+                    },
+                },
+                "runtimeTarget": target,
+                "runtimeUpgrade": {
+                    "compatibilityDigest": "e" * 64,
+                    "migrationMode": "none",
+                    "substrateConsumerCommit": commit,
+                    "substrateTrustSha256": "e" * 64,
+                },
+                "composition": {
+                    "commit": commit,
+                    "sourceClosure": {
+                        name: {
+                            "candidateCommit": commit,
+                            "compositionCommit": commit,
+                            "paths": ["src/**"],
+                        }
+                        for name in ("runtime", "provisioner")
+                    },
+                    "forwardContractSha256": digest,
+                    "authoritativeLegacyReleaseSetSha256": "f" * 64,
+                    "legacyCatalog": [
+                        {
+                            "releaseVersion": "0.22.0",
+                            "protocolVersion": "exomem-hosted.v1",
+                            "runtimeImage": f"ghcr.io/artexis10/exomem@sha256:{digest}",
+                            "sourceCommit": commit,
+                            "contractSha256": _canonical_sha256(legacy_contract),
+                            "contract": legacy_contract,
+                        }
+                    ],
+                    "legacyReleaseSetSha256": _canonical_sha256(
+                        [{"releaseVersion": "0.22.0", "protocolVersion": "exomem-hosted.v1"}]
+                    ),
+                },
+                "rollback": {
+                    "provisionerImage": f"ghcr.io/artexis10/exomem-provisioner@sha256:{'e' * 64}",
+                    "provisionerSourceCommit": commit,
+                    "v1CorpusSha256": digest,
+                    "legacyManifestSha256": digest,
+                    "substrateV1ConsumerCommit": commit,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
     return ProvisionerSettings(
         bearer=_BEARER,
         envelope_key="envelope-key-sentinel-00000000000000",
@@ -493,7 +555,9 @@ async def test_rollforward_is_v2_only_strict_and_idempotently_persisted(
 
 
 @pytest.mark.asyncio
-async def test_serving_requires_a_selected_lock_and_locked_health_advertises_v2(tmp_path: Path) -> None:
+async def test_serving_requires_a_selected_lock_and_locked_health_advertises_v2(
+    tmp_path: Path,
+) -> None:
     no_lock = ProvisionerSettings(
         bearer=_BEARER,
         envelope_key="envelope-key-sentinel-00000000000000",
@@ -511,8 +575,14 @@ async def test_serving_requires_a_selected_lock_and_locked_health_advertises_v2(
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="https://provisioner.test"
     ) as client:
-        assert (await client.get("/health/live")).json() == {"protocol": WIRE_PROTOCOL_V2, "status": "live"}
-        assert (await client.get("/health/ready")).json() == {"protocol": WIRE_PROTOCOL_V2, "status": "ready"}
+        assert (await client.get("/health/live")).json() == {
+            "protocol": WIRE_PROTOCOL_V2,
+            "status": "live",
+        }
+        assert (await client.get("/health/ready")).json() == {
+            "protocol": WIRE_PROTOCOL_V2,
+            "status": "ready",
+        }
 
 
 async def _ready(value: bool) -> bool:
@@ -619,6 +689,94 @@ async def test_api_exposes_exact_seventeen_post_paths_and_strict_pending_union(
             "checkpoint": "requested",
             "retryAfterSeconds": 2,
         }
+
+
+@pytest.mark.asyncio
+async def test_expand_lock_renews_a_live_legacy_v2_cell(tmp_path: Path) -> None:
+    """A cell still on the outgoing v2 release keeps its authorization during an expand."""
+
+    path = tmp_path / "legacy-v2.sqlite"
+    settings = _settings(path)
+    lock_path = path.with_suffix(".lock.json")
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    legacy_identity = {
+        "releaseVersion": "0.34.0",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v1",
+        "gatewayContractDigest": "1" * 64,
+        "commandFingerprint": "c" * 64,
+        "schemaDigest": "d" * 64,
+    }
+    contract = {
+        **legacy_identity,
+        "runtimeImage": f"ghcr.io/artexis10/exomem@sha256:{'2' * 64}",
+        "sourceCommit": "3" * 40,
+    }
+    contract_sha256 = hashlib.sha256(
+        (json.dumps(contract, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    ).hexdigest()
+    lock["composition"]["legacyCatalog"].append(
+        {
+            "releaseVersion": "0.34.0",
+            "protocolVersion": "1",
+            "runtimeImage": contract["runtimeImage"],
+            "sourceCommit": contract["sourceCommit"],
+            "contractSha256": contract_sha256,
+            "contract": contract,
+        }
+    )
+    catalog = sorted(
+        lock["composition"]["legacyCatalog"],
+        key=lambda unit: (unit["releaseVersion"], unit["protocolVersion"]),
+    )
+    lock["composition"]["legacyCatalog"] = catalog
+    release_set = [
+        {"releaseVersion": unit["releaseVersion"], "protocolVersion": unit["protocolVersion"]}
+        for unit in catalog
+    ]
+    lock["composition"]["legacyReleaseSetSha256"] = hashlib.sha256(
+        (json.dumps(release_set, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    ).hexdigest()
+    # Settings load the lock on every access, so rewriting the file is enough.
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    database = ProvisionerDatabase(settings)
+    await database.create_for_tests()
+    repository = OperationRepository(
+        database.session_factory,
+        codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
+        claim_seconds=settings.claim_seconds,
+    )
+    app = create_app(
+        settings=settings,
+        readiness_probe=database.ready,
+        repository=repository,
+        provider_identity_codec=ProviderRecoveryIdentityCodec.from_secret("provider-recovery-root"),
+    )
+    body = _body_for("renew-authorization")
+    body["runtimeTarget"] = {**legacy_identity, "compatibilityDigest": "9" * 64}
+    drifted = {
+        **body,
+        "operationId": "legacy-drift",
+        "runtimeTarget": {**body["runtimeTarget"], "gatewayContractDigest": "5" * 64},
+    }
+    headers = _headers("legacy-v2-renew")
+    headers["X-Exomem-Provisioner-Protocol"] = WIRE_PROTOCOL_V2
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="https://provisioner.test"
+        ) as client:
+            admitted = await client.post("/cells/renew-authorization", headers=headers, json=body)
+            rejected = await client.post(
+                "/cells/renew-authorization",
+                headers=_headers("legacy-drift")
+                | {"X-Exomem-Provisioner-Protocol": WIRE_PROTOCOL_V2},
+                json=drifted,
+            )
+    finally:
+        await database.dispose()
+    assert admitted.status_code == 202, admitted.text
+    assert rejected.status_code == 422
+    assert rejected.json() == {"code": "PROVISIONER_REJECTED", "retryable": False}
 
 
 @pytest.mark.asyncio

--- a/infra/provisioner/tests/test_config.py
+++ b/infra/provisioner/tests/test_config.py
@@ -159,6 +159,45 @@ def test_selected_runtime_exposes_only_signed_forward_upgrade_metadata(
             load_deployment_lock(path)
 
 
+def test_expand_lock_matches_a_cataloged_legacy_v2_identity_except_to_place_an_image(
+    tmp_path: Path,
+) -> None:
+    value = _deployment_lock()
+    composition = value["composition"]
+    assert isinstance(composition, dict)
+    legacy_contract = dict(composition["legacyCatalog"][0]["contract"])
+    path = tmp_path / "selected-lock.json"
+    path.write_text(json.dumps(value), encoding="utf-8")
+    lock = load_deployment_lock(path)
+    legacy_target = {
+        field: legacy_contract[field]
+        for field in (
+            "releaseVersion",
+            "protocolVersion",
+            "agentProfile",
+            "gatewayContractDigest",
+            "commandFingerprint",
+            "schemaDigest",
+        )
+    }
+    legacy_request = {"runtimeTarget": {**legacy_target, "compatibilityDigest": "9" * 64}}
+    v2 = "exomem-cell-provisioner.v2"
+
+    assert lock.matches_runtime_request(legacy_request, wire_protocol=v2)
+    assert lock.matches_runtime_request(
+        legacy_request, wire_protocol=v2, action="renew-authorization"
+    )
+    for placing in ("provision", "rollforward", "rollback-rollforward"):
+        assert not lock.matches_runtime_request(legacy_request, wire_protocol=v2, action=placing)
+    assert not lock.matches_runtime_request(
+        {"runtimeTarget": {**legacy_request["runtimeTarget"], "schemaDigest": "1" * 64}},
+        wire_protocol=v2,
+    )
+    assert lock.matches_runtime_request(
+        {"runtimeTarget": dict(value["runtimeTarget"])}, wire_protocol=v2, action="provision"
+    )
+
+
 def test_selected_lock_accepts_an_authoritatively_empty_legacy_catalog(tmp_path: Path) -> None:
     value = _deployment_lock()
     composition = value["composition"]

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -1482,6 +1482,119 @@ async def test_private_cell_api_uses_fresh_identity_and_exact_lifecycle_routes()
 
 
 @pytest.mark.asyncio
+async def test_private_cell_api_health_reports_the_identity_the_request_names() -> None:
+    """A legacy cell under an expand lock is probed by its own profile and compatibility digest."""
+
+    calls: list[str] = []
+    agent_contract_base = {
+        "schema_version": 1,
+        "protocol_version": "1",
+        "exomem_release": "0.22.0",
+        "agent_profile": {
+            "profile": "hosted-alpha-agent-v1",
+            "active_capability_sha256": "c" * 64,
+        },
+        "commands": [],
+    }
+    runtime_digest = hashlib.sha256(
+        json.dumps(agent_contract_base, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    async def request(
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: object = None,
+    ) -> _Response:
+        del method, headers, json
+        calls.append(url)
+        if url.endswith("/agent/hosted-alpha-agent-v1/contract"):
+            return _Response(
+                200,
+                {
+                    **agent_contract_base,
+                    "digest": {"algorithm": "sha256", "value": runtime_digest},
+                },
+                raw=True,
+            )
+        if url.endswith("/contract"):
+            return _Response(200, {"digest": {"algorithm": "sha256", "value": "b" * 64}}, raw=True)
+        if url.endswith("/ready"):
+            return _Response(
+                200,
+                {
+                    "cell_id": "cell-alpha",
+                    "vault_id": "tenant-alpha",
+                    "exomem_release": "0.22.0",
+                    "hosted_protocol": "1",
+                    "authenticated_credential_version": "1",
+                    "security_revision": 1,
+                    "service_authenticated": True,
+                    "mutation_authority": True,
+                    "admission_phase": "active",
+                    "read_admission": True,
+                    "write_admission": True,
+                    "worker_policy_digest": hashlib.sha256(
+                        b'{"media":false,"semantic":true,"workerCount":2}'
+                    ).hexdigest(),
+                },
+            )
+        return _Response(200, {"live": True, "cell_id": "cell-alpha", "protocol_version": "1"})
+
+    config = LifecycleConfig(
+        image="repo@sha256:" + "f" * 64,
+        chart_path="chart",
+        chart_version="0.1.0",
+        helm_version="3.19.4",
+        control_hostname="control.example.invalid",
+        transfer_hostname="transfer.example.invalid",
+        browser_origin="https://substratesystems.io",
+        release_version="0.23.0",
+        protocol_version="1",
+        contract_digest="f" * 64,
+        location="fsn1",
+        runtime_target={
+            "releaseVersion": "0.23.0",
+            "protocolVersion": "1",
+            "agentProfile": "hosted-alpha-agent-v2",
+            "gatewayContractDigest": "f" * 64,
+            "commandFingerprint": "c" * 64,
+            "schemaDigest": "d" * 64,
+        },
+        compatibility_digest="8" * 64,
+    )
+    legacy_target = {
+        "releaseVersion": "0.22.0",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v1",
+        "gatewayContractDigest": "b" * 64,
+        "commandFingerprint": "c" * 64,
+        "schemaDigest": "d" * 64,
+        "compatibilityDigest": "9" * 64,
+    }
+    adapter = PrivateCellApiAdapter(request=request, internal_origin="http://cells.invalid")
+
+    health = await adapter.health(
+        _metadata(),
+        credential=_credential(),
+        protocol_version="1",
+        config=config,
+        expected_release="0.22.0",
+        expected_worker_policy={"workerCount": 2, "semantic": True, "media": False},
+        require_runtime_identity=True,
+        expected_contract_digest="b" * 64,
+        expected_target=legacy_target,
+    )
+
+    assert health.ready is True
+    assert health.agent_profile == "hosted-alpha-agent-v1"
+    assert health.compatibility_digest == "9" * 64
+    assert "http://cells.invalid/private/exomem/v1/agent/hosted-alpha-agent-v1/contract" in calls
+    assert not any("hosted-alpha-agent-v2" in url for url in calls)
+
+
+@pytest.mark.asyncio
 async def test_private_cell_api_derives_release_independent_schema_digest_from_agent_contract() -> (
     None
 ):

--- a/infra/provisioner/tests/test_provider_lifecycle.py
+++ b/infra/provisioner/tests/test_provider_lifecycle.py
@@ -47,7 +47,7 @@ from exomem_provisioner.provider_identity import (
     provider_operation_resource_name,
 )
 from exomem_provisioner.repository import OperationRepository
-from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V2
+from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V2, runtime_identity
 from exomem_provisioner.worker import ProvisionerWorker
 
 
@@ -1513,6 +1513,148 @@ async def test_v2_health_preserves_pre_upgrade_runtime_identity_without_compatib
 
     assert isinstance(healthy, DriverFinal)
     assert healthy.result["runtimeIdentity"] == target
+
+
+_LEGACY_IMAGE = "registry.invalid/exomem@sha256:" + "a" * 64
+_FORWARD_IMAGE = "registry.invalid/exomem@sha256:" + "f" * 64
+
+
+def _expand_configs() -> tuple[LifecycleConfig, LifecycleConfig]:
+    """The outgoing 0.22.0 worker config and the 0.23.0 expand config that catalogs it."""
+
+    legacy_target = _runtime_target()
+    legacy_unit = {
+        field: legacy_target[field]
+        for field in (
+            "releaseVersion",
+            "protocolVersion",
+            "agentProfile",
+            "gatewayContractDigest",
+            "commandFingerprint",
+            "schemaDigest",
+        )
+    }
+    legacy = replace(_config(), runtime_target=legacy_target)
+    forward = replace(
+        _config(),
+        image=_FORWARD_IMAGE,
+        release_version="0.23.0",
+        contract_digest="f" * 64,
+        runtime_target=_runtime_target(
+            releaseVersion="0.23.0",
+            gatewayContractDigest="f" * 64,
+            compatibilityDigest="8" * 64,
+        ),
+        compatibility_digest="8" * 64,
+        legacy_runtime_units={
+            ("0.22.0", "1"): {
+                **legacy_unit,
+                "runtimeImage": _LEGACY_IMAGE,
+                "sourceCommit": "a" * 40,
+            }
+        },
+    )
+    return legacy, forward
+
+
+class _RenewingPlane(HighFidelityProviderPlane):
+    def __init__(self, *, location: str) -> None:
+        super().__init__(location=location)
+        self.renewals: list[tuple[str, str]] = []
+
+    async def renew_authorization_session(
+        self, metadata: OpaqueProviderMetadata, request: dict[str, object]
+    ) -> str:
+        self.renewals.append((metadata.subject_id, runtime_identity(request)["releaseVersion"]))
+        return f"revision-{len(self.renewals)}"
+
+
+@pytest.mark.asyncio
+async def test_legacy_v2_cell_keeps_renewing_and_checking_under_the_expand_lock() -> None:
+    """The worker gate admits a cataloged legacy identity for the actions that keep a cell alive."""
+
+    plane = _RenewingPlane(location="fsn1")
+    legacy, forward = _expand_configs()
+    request = _v2_request()
+    await plane.seed_ready_cell(_metadata(), request, legacy)
+    driver = CellLifecycleDriver(plane=plane, volume_worker=None, config=forward)
+    context = _context(wire_protocol=WIRE_PROTOCOL_V2)
+
+    renewed = await driver.execute("renew-authorization", request, context)
+    healthy = await driver.execute("health", request, context)
+
+    assert isinstance(renewed, DriverFinal)
+    assert plane.renewals == [("cell-alpha", "0.22.0")]
+    assert isinstance(healthy, DriverFinal)
+    assert healthy.result["runtimeIdentity"] == _runtime_target()
+
+    forward_request = _v2_request(runtimeTarget=forward.runtime_target)
+    with pytest.raises(DriverTerminal, match="PROVISIONER_RUNTIME_CONTRACT_MISMATCH"):
+        await driver.execute("health", forward_request, context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field",
+    (
+        "releaseVersion",
+        "protocolVersion",
+        "agentProfile",
+        "gatewayContractDigest",
+        "commandFingerprint",
+        "schemaDigest",
+    ),
+)
+async def test_legacy_v2_identity_drift_is_terminal_before_any_provider_effect(
+    field: str,
+) -> None:
+    plane = _RenewingPlane(location="fsn1")
+    legacy, forward = _expand_configs()
+    await plane.seed_ready_cell(_metadata(), _v2_request(), legacy)
+    driver = CellLifecycleDriver(plane=plane, volume_worker=None, config=forward)
+    target = _runtime_target()
+    target[field] = "2" if field == "protocolVersion" else "e" * 64
+
+    with pytest.raises(DriverTerminal, match="PROVISIONER_RELEASE_UNIT_MISMATCH"):
+        await driver.execute(
+            "renew-authorization",
+            _v2_request(runtimeTarget=target),
+            _context(wire_protocol=WIRE_PROTOCOL_V2),
+        )
+
+    assert plane.renewals == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ("provision", "rollforward"))
+async def test_legacy_v2_identity_never_places_a_runtime_image(action: str) -> None:
+    plane = HighFidelityProviderPlane(location="fsn1")
+    _, forward = _expand_configs()
+    driver = CellLifecycleDriver(
+        plane=plane, volume_worker=VolumeLifecycleWorker(plane, plane), config=forward
+    )
+    request = _v2_request(**({"compatibilityDigest": "8" * 64} if action == "rollforward" else {}))
+
+    with pytest.raises(DriverTerminal, match="PROVISIONER_RELEASE_UNIT_MISMATCH"):
+        await driver.execute(action, request, _context(wire_protocol=WIRE_PROTOCOL_V2))
+
+    assert plane._cells == {}
+    assert plane._tenant_fences == {}
+
+
+def test_fixed_helm_values_keep_a_legacy_v2_cell_on_its_cataloged_image() -> None:
+    _, forward = _expand_configs()
+
+    legacy_values = _fixed_helm_values(_metadata(), _v2_request(), forward)
+    forward_values = _fixed_helm_values(
+        _metadata(), _v2_request(runtimeTarget=forward.runtime_target), forward
+    )
+
+    assert legacy_values["image"] == _LEGACY_IMAGE
+    assert legacy_values["expectedRelease"] == "0.22.0"
+    assert legacy_values["agentProfile"] == "hosted-alpha-agent-v1"
+    assert forward_values["image"] == _FORWARD_IMAGE
+    assert forward_values["expectedRelease"] == "0.23.0"
 
 
 @pytest.mark.asyncio

--- a/infra/provisioner/tests/test_repository.py
+++ b/infra/provisioner/tests/test_repository.py
@@ -32,6 +32,7 @@ from exomem_provisioner.repository import (
     StaleFence,
     _claim_statement,
     canonical_request_sha256,
+    legacy_targets_from,
 )
 from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V1, WIRE_PROTOCOL_V2
 
@@ -255,11 +256,130 @@ async def test_submission_admission_is_atomic_and_protocol_bound(
         await repository.submit(
             "provision",
             "wrong-v2-target",
-            {**v2_request, "operationId": "wrong-v2-target", "runtimeTarget": {**forward_target, "schemaDigest": "d" * 64}},
+            {
+                **v2_request,
+                "operationId": "wrong-v2-target",
+                "runtimeTarget": {**forward_target, "schemaDigest": "d" * 64},
+            },
             wire_protocol=WIRE_PROTOCOL_V2,
             admission=expand,
         )
     assert await repository.get("provision", "wrong-v2-target") is None
+
+
+@pytest.mark.asyncio
+async def test_expand_admits_a_cataloged_legacy_v2_target_only_when_its_identity_matches(
+    repository: OperationRepository,
+) -> None:
+    """A live v2 cell keeps renewing on its legacy release during an expand."""
+
+    forward_target = {
+        "releaseVersion": "0.35.1",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v1",
+        "gatewayContractDigest": "a" * 64,
+        "commandFingerprint": "b" * 64,
+        "schemaDigest": "c" * 64,
+        "compatibilityDigest": "e" * 64,
+    }
+    legacy_identity = {
+        "releaseVersion": "0.34.0",
+        "protocolVersion": "1",
+        "agentProfile": "hosted-alpha-agent-v1",
+        "gatewayContractDigest": "1" * 64,
+        "commandFingerprint": "b" * 64,
+        "schemaDigest": "c" * 64,
+    }
+    expand = AdmissionPolicy(
+        mode="expand",
+        legacy_catalog=frozenset({("0.34.0", "1")}),
+        forward_target=forward_target,
+        legacy_targets=legacy_targets_from([legacy_identity]),
+    )
+    legacy_request = {
+        **_request(operationId="legacy-v2-renew", fenceGeneration=3),
+        "runtimeTarget": {**legacy_identity, "compatibilityDigest": "9" * 64},
+    }
+    legacy_request.pop("releaseVersion")
+    legacy_request.pop("protocolVersion")
+
+    admitted = await repository.submit(
+        "renew-authorization",
+        "legacy-v2-renew",
+        legacy_request,
+        wire_protocol=WIRE_PROTOCOL_V2,
+        admission=expand,
+    )
+    assert admitted.wire_protocol == WIRE_PROTOCOL_V2
+
+    with pytest.raises(AdmissionRejected):
+        await repository.submit(
+            "renew-authorization",
+            "legacy-v2-drift",
+            {
+                **legacy_request,
+                "operationId": "legacy-v2-drift",
+                "runtimeTarget": {**legacy_request["runtimeTarget"], "schemaDigest": "d" * 64},
+            },
+            wire_protocol=WIRE_PROTOCOL_V2,
+            admission=expand,
+        )
+    assert await repository.get("renew-authorization", "legacy-v2-drift") is None
+
+    # Placing a runtime image always names the forward target, even for a cataloged
+    # legacy identity, and an explicit null target is not the absence of one.
+    for action, key, override in (
+        ("provision", "legacy-v2-provision", {}),
+        ("rollforward", "legacy-v2-rollforward", {"compatibilityDigest": "e" * 64}),
+        ("renew-authorization", "legacy-v2-null", {"runtimeTarget": None}),
+    ):
+        with pytest.raises(AdmissionRejected):
+            await repository.submit(
+                action,
+                key,
+                {**legacy_request, "operationId": key, **override},
+                wire_protocol=WIRE_PROTOCOL_V2,
+                admission=expand,
+            )
+        assert await repository.get(action, key) is None
+
+    uncataloged = AdmissionPolicy(
+        mode="expand",
+        legacy_catalog=frozenset(),
+        forward_target=forward_target,
+    )
+    with pytest.raises(AdmissionRejected):
+        await repository.submit(
+            "renew-authorization",
+            "legacy-v2-uncataloged",
+            {**legacy_request, "operationId": "legacy-v2-uncataloged"},
+            wire_protocol=WIRE_PROTOCOL_V2,
+            admission=uncataloged,
+        )
+
+    contract = AdmissionPolicy(
+        mode="contract",
+        legacy_catalog=frozenset({("0.34.0", "1")}),
+        forward_target=forward_target,
+        legacy_targets=legacy_targets_from([legacy_identity]),
+    )
+    with pytest.raises(AdmissionRejected):
+        await repository.submit(
+            "renew-authorization",
+            "legacy-v2-contract",
+            {**legacy_request, "operationId": "legacy-v2-contract"},
+            wire_protocol=WIRE_PROTOCOL_V2,
+            admission=contract,
+        )
+    assert await repository.get("renew-authorization", "legacy-v2-contract") is None
+    replay = await repository.submit(
+        "renew-authorization",
+        "legacy-v2-renew",
+        legacy_request,
+        wire_protocol=WIRE_PROTOCOL_V2,
+        admission=contract,
+    )
+    assert replay.id == admitted.id
 
 
 @pytest.mark.asyncio

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -194,7 +194,9 @@ def test_hosted_ci_wires_every_static_security_gate() -> None:
     )
     assert install_step["if"] == "steps.validator-cache.outputs.cache-hit != 'true'"
     expose_step = next(
-        step for step in static_job["steps"] if step.get("name") == "Expose infrastructure validators"
+        step
+        for step in static_job["steps"]
+        if step.get("name") == "Expose infrastructure validators"
     )
     assert 'echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"' in expose_step["run"]
     assert 'echo "$PWD/.venv-hosted-ci/bin" >> "$GITHUB_PATH"' in expose_step["run"]
@@ -244,8 +246,7 @@ def test_hosted_ci_wires_every_static_security_gate() -> None:
     release_proof_step = next(
         step
         for step in release_job["steps"]
-        if step.get("name")
-        == "Derive and prove both published images from the reviewed phase lock"
+        if step.get("name") == "Derive and prove both published images from the reviewed phase lock"
     )
     for script in (
         "prepare_hosted_release.py",
@@ -1363,15 +1364,11 @@ def test_active_secret_selection_is_complete_and_the_signer_publishes_a_verified
     assert selection["schema_version"] == 1
     assert set(selection["destinations"]) == expected
     assert all(
-        re.fullmatch(r"v[1-9][0-9]*", version)
-        for version in selection["destinations"].values()
+        re.fullmatch(r"v[1-9][0-9]*", version) for version in selection["destinations"].values()
     )
     assert all(
         (
-            ROOT
-            / destination["target"].format(
-                version=selection["destinations"][destination_id]
-            )
+            ROOT / destination["target"].format(version=selection["destinations"][destination_id])
         ).is_file()
         for secret in matrix["secrets"].values()
         for destination_id, destination in secret["destinations"].items()
@@ -2293,15 +2290,19 @@ def test_production_composition_contract_binds_release_and_operator_actions() ->
     # `protocol` names the default wire envelope, not an exhaustive action gate.
     # This map is the served HTTP surface, and the ingress route is generated
     # against it, so an action absent here is unreachable however it is called.
-    # `renew-authorization` is v2-only on the wire -- the frozen v1 corpus in
-    # provisioner-wire-v1.json never gains an action -- but it is still served,
-    # so it belongs in the composition.
+    # `renew-authorization`, `rollforward` and `rollback-rollforward` are v2-only
+    # on the wire -- the frozen v1 corpus in provisioner-wire-v1.json never gains
+    # an action -- but they are still served, so they belong in the composition;
+    # the 0.77.0 rollforward on the alpha was refused at the ingress because the
+    # two rollforward actions were missing here.
     assert set(contract["provisioner"]["actions"]) == {
         "provision",
         "health",
         "rotate-credential",
         "quiesce",
         "renew-authorization",
+        "rollforward",
+        "rollback-rollforward",
         "resume",
         "stop",
         "export",


### PR DESCRIPTION
## What

Two defects surfaced on 2026-09-10 the first time a live v2 cell survived a platform expand (0.73.1 cell under the 0.77.0 expand lock):

1. **v2 had no legacy branch.** API admission compared every v2 `runtimeTarget` with the lock's forward target only, and the worker's `LifecycleConfig` did the same, while the v1 branch has always admitted cataloged legacy releases. From the first minute after the expand, every `renew-authorization`, `health`, `quiesce` and `stop` for the outgoing cell was refused with `PROVISIONER_REJECTED`, and the cell's authorization window lapsed.
2. **The control route never carried the rollforward paths.** The Traefik `IngressRoute` is generated from `platform-composition-v1.json`, which omitted `rollforward` and `rollback-rollforward`. Substrate's rollforward got a plain 404, which its client records as the same `PROVISIONER_REJECTED`, so no provisioner operation was ever created.

## Change

- `platform-composition-v1.json` and `provisioner-route.yaml` gain `/cells/rollforward` and `/cells/rollback-rollforward`; the platform operations contract test expects them.
- `wire_protocol.py` names the six contract identity fields and the three actions that place a runtime image (`provision`, `rollforward`, `rollback-rollforward`). Those always require the forward target; every other action operates on the cell as it stands.
- API admission (`AdmissionPolicy.legacy_targets`, read from the lock through `DeploymentLock.legacy_targets`): a v2 request whose target equals the forward target is admitted as before. One whose six-field identity equals a cataloged legacy contract is admitted in expand mode, and in contract mode only when it replays an operation already accepted, mirroring the v1 rule. An explicit `runtimeTarget: null` is refused; an absent one is not a target.
- Worker gate (`LifecycleConfig.runtime_target_for`, `matches_runtime_request`, `runtime_image_for`, `CellLifecycleDriver.runtime_target_matches`): the same six-field legacy match against the lock's legacy catalog, returning the legacy identity with the request's own compatibility digest and the legacy unit's image, so a legacy cell renews, checks, stops and resumes on its own release. The governance provision and rollforward paths keep requiring the exact forward target.
- `PrivateCellApiAdapter.health` probes the agent profile and stamps the compatibility digest of the identity the request names instead of the selected forward target. The live cell's digest differs from the 0.77.0 one, so without this a legacy health check fails `PROVISIONER_RUNTIME_CONTRACT_MISMATCH`.
- `DeploymentLock.matches_runtime_request` gains the same legacy branch and action rule; operation recovery passes the operation's action.

## Verification

- Red-first against `main`: `test_expand_admits_a_cataloged_legacy_v2_target_only_when_its_identity_matches` (repository), `test_expand_lock_renews_a_live_legacy_v2_cell` (API, through the real app with a lock carrying a v2 legacy unit), `test_legacy_v2_cell_keeps_renewing_and_checking_under_the_expand_lock` and `test_fixed_helm_values_keep_a_legacy_v2_cell_on_its_cataloged_image` (worker driver on the high-fidelity plane), `test_private_cell_api_health_reports_the_identity_the_request_names` (adapter), `test_expand_lock_matches_a_cataloged_legacy_v2_identity_except_to_place_an_image` (lock). Drift in any of the six fields, a legacy target on `provision`/`rollforward`, a null target, and the contract-mode fresh case are asserted refused.
- Scoped: lifecycle, adapters, config, repository, API, live provider, operation recovery, durability driver, governance driver and rollforward-live modules: 319 passed. Helm contract and platform operations tests with pinned Helm: 120 passed; the five active-secret-registry signer tests fail identically on a clean `main` worktree on this machine (group-writable checkout under the local umask), so they are environmental, not this change. Full provisioner suite (`--with-editable`, PostgreSQL module excluded): 1542 passed, 50 skipped.
- `ruff check` and the privacy gate clean.
- Independent review: security-reviewer APPROVE after one correction round (round 1 found the worker gate still forward-only for every v2 action and an admitted explicit null target; both fixed). Its non-blocking suggestion to name `action="restore"` on the restore-candidate call sites is applied; the compatibility digest on the legacy branch is the request's own claim, echoed back and checked only against that same request, and no image, authorization or infrastructure decision consumes it.
