### PR TITLE
fix(provisioner): treat the rollback of a never-applied rollforward as a no-op

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -3525,14 +3525,15 @@ class HelmCliAdapter:
             )
         return prior
 
-    async def _rollback_already_committed(
+    async def _operation_prior_revisions(
         self,
         metadata: OpaqueProviderMetadata,
         environment: dict[str, str],
         *,
-        current: dict[str, Any],
         operation_digest: str,
-    ) -> bool:
+    ) -> set[int]:
+        """The rollback points recorded by every revision this operation ever applied."""
+
         prior_revisions: set[int] = set()
         for item in await self._release_history(metadata, environment):
             revision = item["revision"]
@@ -3540,6 +3541,16 @@ class HelmCliAdapter:
             prior = self._runtime_upgrade_prior(historical.get("runtimeUpgrade"), operation_digest)
             if prior is not None:
                 prior_revisions.add(prior)
+        return prior_revisions
+
+    async def _rollback_already_committed(
+        self,
+        metadata: OpaqueProviderMetadata,
+        environment: dict[str, str],
+        *,
+        current: dict[str, Any],
+        prior_revisions: set[int],
+    ) -> bool:
         if not prior_revisions:
             return False
         if len(prior_revisions) != 1:
@@ -3617,19 +3628,31 @@ class HelmCliAdapter:
         digest = self._operation_digest(operation_id)
         prior = self._runtime_upgrade_prior(marker, digest)
         if prior is None:
-            if require_marker and await self._rollback_already_committed(
-                metadata,
-                environment,
-                current=current,
-                operation_digest=digest,
+            if not require_marker:
+                return
+            prior_revisions = await self._operation_prior_revisions(
+                metadata, environment, operation_digest=digest
+            )
+            if await self._rollback_already_committed(
+                metadata, environment, current=current, prior_revisions=prior_revisions
             ):
                 return
-            if require_marker:
-                raise MetadataConflict(
-                    "Helm runtime rollback authority is absent",
-                    reason=ConflictReason.HELM_RUNTIME_ROLLBACK_AUTHORITY_IS_ABSENT,
-                )
-            return
+            if marker is None and not prior_revisions:
+                # No revision ever carried this operation's marker and nothing else
+                # holds one: the rollforward never reached Helm, so the release is
+                # already the runtime a rollback would restore. Refusing here would
+                # leave the caller's recovery unable to finish for a cell that was
+                # never touched. A marker owned by another operation still refuses:
+                # reverting someone else's transition is not this operation's authority.
+                # Accepted residual: a worker that dies right after its apply, followed by
+                # enough unrelated transitions to age the marked revision out of Helm's
+                # retained history, reads the same way; the cell operation lock makes
+                # that a crash-plus-ten-mutations event, not an ordinary retry.
+                return
+            raise MetadataConflict(
+                "Helm runtime rollback authority is absent",
+                reason=ConflictReason.HELM_RUNTIME_ROLLBACK_AUTHORITY_IS_ABSENT,
+            )
         result = await self._runner(
             (
                 self._binary,

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -704,10 +704,90 @@ async def test_helm_runtime_transition_replays_and_rolls_back_the_original_revis
     )
     assert sum(call[1] == "rollback" for call in calls) == 1
 
+    # An operation that never applied anything has nothing to revert once the
+    # release carries no marker at all: its rollback is a no-op, not a refusal.
+    await adapter.rollback_release(
+        _metadata(), operation_id="different-operation", require_marker=True
+    )
+    assert sum(call[1] == "rollback" for call in calls) == 1
+    assert current_values == {"workloadMode": "serve", "image": "old"}
+
+
+@pytest.mark.asyncio
+async def test_helm_rollback_of_a_never_applied_rollforward_is_a_no_op(tmp_path: Path) -> None:
+    """A recovery may roll back a rollforward that never reached Helm; another operation's
+    live marker still refuses."""
+
+    calls: list[tuple[str, ...]] = []
+    current_values: dict[str, object] = {"workloadMode": "serve", "image": "old"}
+    revision_values: dict[int, dict[str, object]] = {1: dict(current_values)}
+    current_revision = 1
+
+    async def runner(argv: tuple[str, ...], environment: dict[str, str]) -> SimpleNamespace:
+        nonlocal current_revision, current_values
+        calls.append(argv)
+        del environment
+        if argv[1] == "version":
+            return SimpleNamespace(returncode=0, stdout="v3.19.4\n", stderr="")
+        if argv[1:3] == ("get", "values"):
+            selected = (
+                revision_values[int(argv[argv.index("--revision") + 1])]
+                if "--revision" in argv
+                else current_values
+            )
+            return SimpleNamespace(returncode=0, stdout=json.dumps(selected), stderr="")
+        if argv[1] == "history":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "revision": revision,
+                            "status": "deployed" if revision == current_revision else "superseded",
+                        }
+                        for revision in sorted(revision_values)
+                    ]
+                ),
+                stderr="",
+            )
+        if argv[1] == "upgrade":
+            values_path = Path(argv[argv.index("--values") + 1])
+            current_values = json.loads(values_path.read_text(encoding="utf-8"))
+            current_revision += 1
+            revision_values[current_revision] = dict(current_values)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(argv)
+
+    adapter = HelmCliAdapter(
+        binary="helm",
+        expected_version="3.19.4",
+        chart_path="chart",
+        chart_version="0.1.0",
+        runner=runner,
+        temporary_directory=tmp_path,
+    )
+
+    await adapter.rollback_release(_metadata(), operation_id="never-applied", require_marker=True)
+
+    assert not any(call[1] == "rollback" for call in calls)
+    assert current_values == {"workloadMode": "serve", "image": "old"}
+    assert revision_values == {1: {"workloadMode": "serve", "image": "old"}}
+
+    await adapter.transition_release(
+        _metadata(), {"workloadMode": "serve", "image": "target"}, operation_id="rollforward-alpha"
+    )
+    assert current_values["runtimeUpgrade"] == {
+        "schemaVersion": 1,
+        "operationDigest": hashlib.sha256(b"rollforward-alpha").hexdigest(),
+        "priorRevision": 1,
+    }
+
     with pytest.raises(MetadataConflict, match="rollback authority is absent"):
         await adapter.rollback_release(
-            _metadata(), operation_id="different-operation", require_marker=True
+            _metadata(), operation_id="never-applied", require_marker=True
         )
+    assert not any(call[1] == "rollback" for call in calls)
+    assert current_values["image"] == "target"
 
 
 class _CustomObjects:


### PR DESCRIPTION
## What

Once #1186 was live (helm revision 50), Substrate's stuck rollforward recovery finally reached the provisioner: its `rollback-rollforward` was admitted and claimed, then failed terminally with `PROVISIONER_PROVIDER_METADATA_CONFLICT / helm-runtime-rollback-authority-is-absent`. The original rollforward never reached Helm (it died on the route 404), so the cell's release carries no `runtimeUpgrade` marker and no revision ever applied under that operation. The adapter treated that as a missing authority and refused, and Substrate's recovery cannot complete without a successful rollback, so the tenant stays suspended after 126 retries.

## Change

`HelmCliAdapter.rollback_release(require_marker=True)`: when the current values carry no marker at all and no revision in the release history ever applied under the operation, the rollback is a no-op success: the release already is the runtime a rollback would restore. A marker owned by another operation still refuses (reverting someone else's transition is not this operation's authority), and an operation that did apply but whose marker was later rewritten still requires the recorded prior revision to match the current values, as before. The history walk is factored into `_operation_prior_revisions`, shared with the already-committed check.

## Verification

- Red-first: `test_helm_rollback_of_a_never_applied_rollforward_is_a_no_op` fails on `main` (refusal) and passes here; it also asserts the other-operation marker still refuses with no Helm rollback issued. The existing transition test now expects the never-applied case to be a no-op after a completed rollback (rollback count stays 1, values unchanged).
- Scoped: adapter, guarded Helm transition, rollforward-live, provider lifecycle and live provider modules: 230 passed.
- Full provisioner suite (`--with-editable`, PostgreSQL module excluded): 1543 passed, 50 skipped.
- `ruff check` and the privacy gate clean.
- Live evidence: the cell's release is at revision 3 (2026-09-06), values carry no `runtimeUpgrade`, image is the 0.73.1 one.
- Independent review: security-reviewer APPROVE (157 passed on its own run; red-first confirmed against `main`). Its one MEDIUM is an accepted residual, recorded in the code comment: a worker that dies right after its Helm apply, followed by enough unrelated transitions to age the marked revision out of Helm's ten retained revisions, would read as never applied and succeed instead of refusing. The cell operation lock makes that a crash-plus-ten-mutations event; the refusal it replaces stranded a tenant on every never-applied rollforward, which is the ordinary recovery case.
