### PR TITLE
fix(provisioner): let a replay restart a single-phase operation that did nothing

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/repository.py
+++ b/infra/provisioner/src/exomem_provisioner/repository.py
@@ -42,6 +42,7 @@ from .provider_identity import cell_resource_name
 from .wire_protocol import (
     FORWARD_ONLY_ACTIONS,
     RUNTIME_IDENTITY_FIELDS,
+    SINGLE_PHASE_ACTIONS,
     WIRE_PROTOCOL_V1,
     WIRE_PROTOCOL_V2,
 )
@@ -129,6 +130,39 @@ def _terminal_failure_checkpoint(operation: Operation) -> str:
     if _holds_governance_checkpoint(operation, operation.checkpoint):
         return operation.checkpoint
     return "failed"
+
+
+def _is_effect_free_terminal(operation: Operation) -> bool:
+    """Whether a terminal row still describes work that was submitted and never done.
+
+    Only a single-phase action qualifies -- one whose dispatch settles or raises
+    without parking on a checkpoint of its own. A terminal failure collapses any
+    non-governance checkpoint to "failed", so for a multi-phase action the row no
+    longer says how far the attempt got: a rollforward that failed while releasing
+    its maintenance lease, with the new image already live and serving, reads
+    exactly like one that never started. Restarting that would close the routes of
+    a healthy cell to redo work it had already finished.
+
+    Within the single-phase set, failure state and retained progress are still
+    distinct. A governance checkpoint, a counted retry attempt, a stored result, a
+    live claim, provider identity drift -- any of them means the attempt reached
+    something, and only a reviewed recovery may restart it.
+    """
+
+    return (
+        operation.action.value in SINGLE_PHASE_ACTIONS
+        and operation.state is OperationState.ERROR
+        and operation.checkpoint == "failed"
+        and not operation.progress
+        and operation.result_ciphertext is None
+        and not operation.result_redacted
+        and operation.claim_owner is None
+        and operation.claim_token is None
+        and operation.claim_expires_at is None
+        and operation.finalized_at is not None
+        and operation.external_operation_id == operation.provider_operation_id
+        and operation.fence_generation == operation.provider_fence_generation
+    )
 
 
 def _retained_governance_checkpoint(operation: Operation) -> bool:
@@ -842,6 +876,24 @@ class OperationRepository:
                         action=action_value.value,
                     )
                     if existing is not None:
+                        if _is_effect_free_terminal(existing) and not await session.scalar(
+                            select(func.count())
+                            .select_from(Resource)
+                            .where(Resource.operation_id == existing.id)
+                        ):
+                            # The caller is asking for exactly this work again and the
+                            # row proves the first attempt did nothing. Answering the
+                            # replay with a permanent refusal strands it: a control
+                            # plane whose own contract requires it to retry has no
+                            # other move, and no operator stands in that loop.
+                            restarted_at = datetime.now(UTC)
+                            existing.state = OperationState.PENDING
+                            existing.checkpoint = "queued"
+                            existing.error_code = None
+                            existing.finalized_at = None
+                            existing.available_at = restarted_at
+                            existing.retry_after_seconds = retry_after_seconds
+                            await session.flush()
                         return _operation_snapshot(existing)
                     if fence is None:
                         session.add(

--- a/infra/provisioner/src/exomem_provisioner/wire_protocol.py
+++ b/infra/provisioner/src/exomem_provisioner/wire_protocol.py
@@ -35,6 +35,18 @@ RUNTIME_IDENTITY_FIELDS = (
 # and resuming through an expand window instead of lapsing.
 FORWARD_ONLY_ACTIONS = frozenset({"provision", "rollforward", "rollback-rollforward"})
 
+# Actions whose own dispatch settles in one pass: it returns a final result or
+# raises, and never parks on a checkpoint of its own, so a terminally failed
+# attempt cannot have left durable progress behind. Every other action advances
+# through checkpoints whose names a terminal failure collapses to "failed", which
+# destroys the evidence of how far it got. The shared observation that runs before
+# dispatch can still park any action -- a cell carrying a stray governance
+# migration Job, say -- but that keeps the operation pending rather than failing
+# it. `CellLifecycleDriver.execute` is the authority for this set and
+# `test_single_phase_actions_settle_without_a_checkpoint_of_their_own` keeps it
+# honest.
+SINGLE_PHASE_ACTIONS = frozenset({"health", "renew-authorization", "rollback-rollforward"})
+
 REQUEST_MODELS_BY_PROTOCOL: Mapping[str, Mapping[str, type[StrictSchema]]] = MappingProxyType(
     {
         WIRE_PROTOCOL_V1: V1_REQUEST_MODELS,

--- a/infra/provisioner/tests/test_api.py
+++ b/infra/provisioner/tests/test_api.py
@@ -16,6 +16,7 @@ from exomem_provisioner.config import PROVISIONER_PROTOCOL, ProvisionerSettings
 from exomem_provisioner.crypto import AesGcmEnvelopeCodec
 from exomem_provisioner.database import ProvisionerDatabase
 from exomem_provisioner.driver import FakeDriver
+from exomem_provisioner.models import OperationState
 from exomem_provisioner.provider_identity import ProviderRecoveryIdentityCodec
 from exomem_provisioner.repository import OperationRepository
 from exomem_provisioner.schemas import FailureResponse, ProvisionRequest, TargetRequest
@@ -1221,3 +1222,54 @@ async def test_unexpected_exception_response_and_repr_do_not_expose_request_secr
     assert response.json() == {"code": "PROVISIONER_UNAVAILABLE", "retryable": True}
     assert _SERVICE_CREDENTIAL not in response.text
     assert "person@example.invalid" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_replay_of_an_effect_free_terminal_operation_is_accepted_again(
+    tmp_path: Path,
+) -> None:
+    """A control plane whose contract makes it retry is not refused forever."""
+
+    path = tmp_path / "requeue-api.sqlite"
+    settings = _settings(path)
+    database = ProvisionerDatabase(settings)
+    await database.create_for_tests()
+    repository = OperationRepository(
+        database.session_factory,
+        codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
+        claim_seconds=settings.claim_seconds,
+    )
+    app = create_app(
+        settings=settings,
+        readiness_probe=database.ready,
+        repository=repository,
+        provider_identity_codec=ProviderRecoveryIdentityCodec.from_secret("provider-recovery-root"),
+    )
+    body = _body_for("renew-authorization")
+    headers = _headers("requeue-api") | {"X-Exomem-Provisioner-Protocol": WIRE_PROTOCOL_V2}
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="https://provisioner.test"
+        ) as client:
+            accepted = await client.post("/cells/renew-authorization", headers=headers, json=body)
+            assert accepted.status_code == 202
+            operation = await repository.get("renew-authorization", "requeue-api")
+            assert operation is not None
+            claim = await repository.claim_next("requeue-api-worker")
+            assert claim is not None and claim.claim_token is not None
+            await repository.fail(
+                operation.id,
+                "requeue-api-worker",
+                claim_token=claim.claim_token,
+                claim_generation=claim.claim_generation,
+                code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+            )
+
+            replay = await client.post("/cells/renew-authorization", headers=headers, json=body)
+
+        assert replay.status_code == 202
+        assert replay.json()["operationId"] == body["operationId"]
+        restarted = await repository.get("renew-authorization", "requeue-api")
+        assert restarted is not None and restarted.state is OperationState.PENDING
+    finally:
+        await database.dispose()

--- a/infra/provisioner/tests/test_provider_lifecycle.py
+++ b/infra/provisioner/tests/test_provider_lifecycle.py
@@ -47,7 +47,11 @@ from exomem_provisioner.provider_identity import (
     provider_operation_resource_name,
 )
 from exomem_provisioner.repository import OperationRepository
-from exomem_provisioner.wire_protocol import WIRE_PROTOCOL_V2, runtime_identity
+from exomem_provisioner.wire_protocol import (
+    SINGLE_PHASE_ACTIONS,
+    WIRE_PROTOCOL_V2,
+    runtime_identity,
+)
 from exomem_provisioner.worker import ProvisionerWorker
 
 
@@ -485,9 +489,7 @@ async def test_rollforward_waits_for_zero_runtime_proof_before_fingerprint_and_m
                 return False
             return await super().runtime_stopped(metadata)
 
-        async def canonical_vault_fingerprint(
-            self, metadata, request, operation_id, *, phase
-        ):
+        async def canonical_vault_fingerprint(self, metadata, request, operation_id, *, phase):
             self.events.append(f"fingerprint:{phase}")
             return await super().canonical_vault_fingerprint(
                 metadata, request, operation_id, phase=phase
@@ -2279,3 +2281,34 @@ def test_every_provider_conflict_on_the_provision_path_names_its_condition() -> 
                 unlabelled.append(f"{module.__name__}:{node.lineno}")
 
     assert unlabelled == [], f"MetadataConflict raised without a condition label: {unlabelled}"
+
+
+@pytest.mark.asyncio
+async def test_single_phase_actions_settle_without_a_checkpoint_of_their_own() -> None:
+    """The repository's restart rule reads this set as proof of no retained progress.
+
+    A terminal failure collapses any non-governance checkpoint to "failed", so the
+    only actions whose failed row still proves nothing was retained are the ones
+    whose dispatch never parks on a checkpoint of its own. This keeps that
+    declaration true. The shared observation ahead of dispatch can still park a
+    cell carrying a stray migration artifact, but that leaves the operation
+    pending rather than terminally failed, which is not what the rule acts on.
+    """
+
+    plane = _RenewingPlane(location="fsn1")
+    config = replace(_config(), runtime_target=_runtime_target(), compatibility_digest="9" * 64)
+    driver = CellLifecycleDriver(plane=plane, volume_worker=None, config=config)
+    request = _v2_request()
+    await plane.seed_ready_cell(_metadata(), request, config)
+    context = _context(wire_protocol=WIRE_PROTOCOL_V2)
+
+    assert isinstance(await driver.execute("health", request, context), DriverFinal)
+    assert isinstance(await driver.execute("renew-authorization", request, context), DriverFinal)
+    # No prior rollforward is committed, so this is the failing shape; it must still
+    # settle in one pass rather than parking on a checkpoint.
+    with pytest.raises(DriverTerminal, match="PROVISIONER_PROVIDER_METADATA_CONFLICT"):
+        await driver.execute(
+            "rollback-rollforward", _v2_request(compatibilityDigest="9" * 64), context
+        )
+
+    assert SINGLE_PHASE_ACTIONS == {"health", "renew-authorization", "rollback-rollforward"}

--- a/infra/provisioner/tests/test_repository.py
+++ b/infra/provisioner/tests/test_repository.py
@@ -1039,3 +1039,101 @@ async def test_encrypted_request_and_refs_survive_restart_without_plaintext_in_d
         operation_columns = {row[1] for row in connection.execute("PRAGMA table_info(operations)")}
     assert "request_json" not in operation_columns
     assert "request_ciphertext" in operation_columns
+
+
+@pytest.mark.asyncio
+async def test_replay_restarts_a_terminal_operation_that_recorded_nothing(
+    repository: OperationRepository,
+) -> None:
+    """A control plane that must retry gets its work restarted, not refused forever."""
+
+    request = _request(operationId="requeue-alpha")
+    submitted = await repository.submit("rollback-rollforward", "requeue-effect-free", request)
+    claim = await repository.claim_next("requeue-worker")
+    assert claim is not None and claim.claim_token is not None
+    await repository.fail(
+        submitted.id,
+        "requeue-worker",
+        claim_token=claim.claim_token,
+        claim_generation=claim.claim_generation,
+        code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+    )
+    failed = await repository.get("rollback-rollforward", "requeue-effect-free")
+    assert failed is not None and failed.state is OperationState.ERROR
+
+    replay = await repository.submit("rollback-rollforward", "requeue-effect-free", request)
+
+    assert replay.id == submitted.id
+    assert replay.state is OperationState.PENDING
+    async with repository.session_factory() as session:
+        row = await session.get(Operation, submitted.id)
+        assert row is not None
+        assert (row.checkpoint, row.error_code, row.finalized_at) == ("queued", None, None)
+        assert row.progress == {}
+    reclaimed = await repository.claim_next("requeue-worker-two")
+    assert reclaimed is not None and reclaimed.id == submitted.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "effect", ("resource", "counted-retry", "retained-checkpoint", "multi-phase-action")
+)
+async def test_replay_refuses_a_terminal_operation_that_recorded_anything(
+    repository: OperationRepository,
+    effect: str,
+) -> None:
+    """Anything the first attempt may have retained keeps the row terminal.
+
+    `multi-phase-action` is the case a terminal failure cannot describe: it
+    collapses the checkpoint to "failed", so a provision that got most of the way
+    through is durably indistinguishable from one that never began.
+    """
+
+    action = "provision" if effect == "multi-phase-action" else "rollback-rollforward"
+    request = _request(operationId=f"kept-{effect}")
+    submitted = await repository.submit(action, f"kept-{effect}", request)
+    claim = await repository.claim_next("kept-worker")
+    assert claim is not None and claim.claim_token is not None
+    if effect == "resource":
+        await repository.record_resource(
+            operation_id=submitted.id,
+            worker_id="kept-worker",
+            claim_token=claim.claim_token,
+            claim_generation=claim.claim_generation,
+            tenant_id=str(request["tenantId"]),
+            cell_id=str(request["cellId"]),
+            kind=ResourceKind.KUBERNETES_NAMESPACE,
+            recoverable_reference="cell-namespace",
+            provider_operation_id=str(request["operationId"]),
+            provider_fence_generation=int(request["fenceGeneration"]),  # type: ignore[arg-type]
+        )
+    elif effect == "counted-retry":
+        await repository.record_retryable_failure(
+            submitted.id,
+            "kept-worker",
+            claim_token=claim.claim_token,
+            claim_generation=claim.claim_generation,
+            retry_after_seconds=1,
+        )
+        claim = await repository.claim_next(
+            "kept-worker", now=datetime.now(UTC) + timedelta(days=1)
+        )
+        assert claim is not None and claim.claim_token is not None
+    await repository.fail(
+        submitted.id,
+        "kept-worker",
+        claim_token=claim.claim_token,
+        claim_generation=claim.claim_generation,
+        code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+    )
+    if effect == "retained-checkpoint":
+        async with repository.session_factory.begin() as session:
+            row = await session.get(Operation, submitted.id)
+            assert row is not None
+            row.checkpoint = "gm1:complete:" + "A" * 43
+
+    replay = await repository.submit(action, f"kept-{effect}", request)
+
+    assert replay.id == submitted.id
+    assert replay.state is OperationState.ERROR
+    assert await repository.claim_next("kept-worker-two") is None


### PR DESCRIPTION
## What

With the rollback fix (#1188) live, Substrate's rollforward recovery still looped. The provisioner's own row for that recovery is terminal: state `error`, checkpoint `failed`, error `PROVISIONER_PROVIDER_METADATA_CONFLICT`, no claim, no progress, finalized before the fix shipped. Substrate builds a stable idempotency key per recovery step, so every retry replays that key, and the API answers a permanent 409 for an operation in `error`. The worker never sees the request again, so the fix that would now succeed is unreachable, and the control plane cannot give up: restoring the cell is its job. Two correct contracts deadlock with no operator in the loop.

## Change

A replay may restart the operation when the durable row proves the first attempt did nothing:

- the action is single-phase, meaning its driver either settles or raises and never parks on a checkpoint: `health`, `renew-authorization`, `rollback-rollforward`;
- state `error`, `progress` empty (no counted retry, no recovery marker), no result, no claim, and no provider identity or fence drift;
- and no `resources` row recorded under that operation.

Then the row returns to `pending` at checkpoint `queued` with the error and finalization cleared, which is the row a fresh submission would have created for the same request. Anything the attempt may have retained keeps it terminal for a reviewed recovery, as before.

The single-phase restriction is the load-bearing part. A terminal failure collapses every non-governance checkpoint to the literal `failed`, so for a multi-phase action the row no longer records how far the attempt got: a rollforward that fails while releasing its maintenance lease, with the new image already live and serving, is durably indistinguishable from one that never started. Restarting that would close a healthy cell's routes and stop it to redo work it had already finished. The set is declared next to the driver contract it describes, and a driver test asserts each member settles in one pass so the declaration cannot quietly go stale.

Within that set the rule is deliberately not restricted by error code and deliberately not an operator-only path. The reviewed init-retry `reopen` recovery restricts to one code, but a release-unit mismatch after a lock fix is equally recoverable, and this incident was both. Every condition is machine-checkable and the caller re-asks on its own, so a human in the loop would add an unbounded wait and no judgment.

## Verification

- Red-first against `main`: the repository restart test and the API test both fail there (409, row stays `error`).
- `test_replay_refuses_a_terminal_operation_that_recorded_anything` is parametrized over a recorded resource, a counted retry attempt, a retained governance checkpoint and a multi-phase action; all four pass on `main` too and exist to keep that boundary.
- `test_single_phase_actions_never_return_a_pending_checkpoint` drives each member of the set through the real driver, including the failing rollback shape, and pins the set itself.
- Full provisioner suite (`--with-editable`, PostgreSQL module excluded): 1548 passed, 50 skipped.
- `ruff check` and the privacy gate clean.
- Independent review: security-reviewer REQUEST_CHANGES then APPROVE. Round one found the defect this change is now built around: the collapsed checkpoint made a rollforward that failed on its last step, with the new image already serving, indistinguishable from one that never started. The single-phase restriction and its regression test came from that finding. The recheck cleared convergence of a partially applied rollback, the admission path, lock ordering and concurrency, and left one wording nit, now fixed: the pre-dispatch observation can still park any action for a cell carrying a stray governance migration artifact, so the claim is scoped to each action's own dispatch.
- A single unrelated test, `test_final_void_and_proof_responses_are_strictly_validated`, failed once across the runs and did not reproduce in isolation, in its own module, or on repeated full runs. The reviewer reproduced it once in four scoped runs and traced it to a fresh `stop` operation not being immediately claimable, which touches nothing this change adds. Reported here rather than dismissed; it deserves its own investigation.
