### PR TITLE
fix(provisioner): spend the replay restart so a repeatable failure still settles

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/repository.py
+++ b/infra/provisioner/src/exomem_provisioner/repository.py
@@ -242,6 +242,12 @@ def _governance_recovery_snapshot(
     return _governance_recovery_digest(operation, fence.fence_generation)
 
 
+# One restart per row. A caller that must retry gets its work re-attempted once;
+# if it fails again the row stays terminal, so the refusal reaches the caller and
+# counts against its own budget instead of hiding a repeatable failure behind a
+# perpetual pending.
+_REPLAY_RESTART_MARKER = "_replay_restart_v1"
+
 LegacyTarget = tuple[tuple[str, str], ...]
 
 
@@ -893,6 +899,13 @@ class OperationRepository:
                             existing.finalized_at = None
                             existing.available_at = restarted_at
                             existing.retry_after_seconds = retry_after_seconds
+                            # Recording the restart also spends it: the predicate
+                            # requires empty progress, so this row can never be
+                            # restarted a second time.
+                            existing.progress = {
+                                **existing.progress,
+                                _REPLAY_RESTART_MARKER: restarted_at.isoformat(),
+                            }
                             await session.flush()
                         return _operation_snapshot(existing)
                     if fence is None:

--- a/infra/provisioner/tests/test_repository.py
+++ b/infra/provisioner/tests/test_repository.py
@@ -1069,9 +1069,24 @@ async def test_replay_restarts_a_terminal_operation_that_recorded_nothing(
         row = await session.get(Operation, submitted.id)
         assert row is not None
         assert (row.checkpoint, row.error_code, row.finalized_at) == ("queued", None, None)
-        assert row.progress == {}
+        # The restart is recorded, which also spends it.
+        assert list(row.progress) == ["_replay_restart_v1"]
     reclaimed = await repository.claim_next("requeue-worker-two")
     assert reclaimed is not None and reclaimed.id == submitted.id
+    assert reclaimed.claim_token is not None
+
+    # A second failure is the caller's answer, not another restart: the refusal has
+    # to reach it so the failure counts against its own budget.
+    await repository.fail(
+        submitted.id,
+        "requeue-worker-two",
+        claim_token=reclaimed.claim_token,
+        claim_generation=reclaimed.claim_generation,
+        code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+    )
+    second = await repository.submit("rollback-rollforward", "requeue-effect-free", request)
+    assert second.state is OperationState.ERROR
+    assert await repository.claim_next("requeue-worker-three") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

#1190 let a replay restart a terminal operation that provably did nothing. Deployed as helm revision 52, it unstuck the incident exactly as intended: the recovery rollback ran as a no-op, the cell returned to active and running, and its tenant was unsuspended.

The very next operation exposed the other edge of it. A `renew-authorization` for that cell now fails deterministically at the worker, because the cell's authorization window lapsed during the incident and minting a successor bundle is fenced for a cell that has already served. Each replay restarted the row and answered 202, so the control plane saw "pending" forever, never counted a failure, and could not give up. Measured: an operation created at 14:46:11 was still `waiting` with `attempts=0` nine minutes later while the worker logged three terminal failures for the same operation digest. Before #1190 the caller got a refusal, counted an attempt, and would eventually settle.

So #1190 traded "the caller can never retry" for "the caller can never give up". Same defect, other direction.

## Change

The restart is now recorded in `progress`, which also spends it: the predicate requires empty progress, so a row can be restarted exactly once. A second terminal failure stays terminal, the refusal reaches the caller, and it counts against the caller's own budget.

## Verification

- `test_replay_restarts_a_terminal_operation_that_recorded_nothing` now asserts the restarted row carries exactly the restart marker, then fails the reclaimed operation again and asserts the next replay returns the row still in error and unclaimable.
- Full provisioner suite (`--with-editable`, PostgreSQL module excluded): 1550 passed, 50 skipped.
- `ruff check` and the privacy gate clean.
- Independent review: security-reviewer APPROVE. It weighed the trade directly: a row stuck after two effect-free failures is bounded to one cell, while the uncapped restart was an unbounded livelock that the fleet gate treats as unfinished work and so stalls unrelated operations. It confirmed the marker is inert to every other progress reader (the init-retry and retarget recoveries and the governance resume all gate on their own key) and never leaves the process, since neither the fleet observation nor any response model carries progress.

Fast-follow it raised, not blocking: `reopen()` is hardcoded to `PROVISION`, so none of the three actions this mechanism covers has a reviewed operator lever if a row does get stuck after its one restart. Worth building before this rule sees much traffic.
