### PR TITLE
fix(hosted): validate the provisioner database at startup, not every five seconds

### DIFF
--- a/infra/helm/platform/templates/provisioner.yaml
+++ b/infra/helm/platform/templates/provisioner.yaml
@@ -126,11 +126,24 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          readinessProbe:
+          # /health/ready validates the database once: migration head, runtime role
+          # and schema owner. Those are boot-time invariants, so they belong on the
+          # startup probe. Polling them every five seconds cost four PostgreSQL
+          # queries per probe against a database billed by wakefulness, and on any
+          # database blip it pulled the only API pod out of the Service, which is a
+          # worse outage than the app answering 503 itself.
+          startupProbe:
             httpGet:
               path: /health/ready
               port: http
             periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 36
+          readinessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: 10
             timeoutSeconds: 2
           livenessProbe:
             httpGet:

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -2044,6 +2044,27 @@ def test_runtime_k3s_gate_pins_the_reviewed_release_unit() -> None:
     }
 
 
+def test_provisioner_api_validates_the_database_once_at_startup_not_every_five_seconds() -> None:
+    """Database validation is a boot-time invariant, not a serving-time one.
+
+    ``/health/ready`` runs four PostgreSQL queries. As a readiness probe it fired
+    every five seconds forever, which is one more consumer keeping a serverless
+    endpoint from ever suspending, and on any database blip it removed the only API
+    pod from the Service, turning a per-request 503 into a whole-service outage.
+    The startup probe keeps the validation; the periodic probes never touch the
+    database.
+    """
+    documents = _render(
+        PLATFORM, PLATFORM / "values.validation.yaml", namespace="exomem-platform"
+    )
+    api = _find(documents, "Deployment", "exomem-provisioner-api")
+    (container,) = api["spec"]["template"]["spec"]["containers"]
+    assert container["startupProbe"]["httpGet"]["path"] == "/health/ready"
+    assert container["startupProbe"]["failureThreshold"] >= 12
+    for periodic in ("readinessProbe", "livenessProbe"):
+        assert container[periodic]["httpGet"]["path"] == "/health/live", periodic
+
+
 def test_no_cronjob_schedule_sits_inside_the_database_autosuspend_window() -> None:
     """Every heartbeat must clear the endpoint's autosuspend window.
 


### PR DESCRIPTION
## What

Moves the provisioner API's database validation from the readiness probe to a startup probe. The periodic readiness and liveness probes now both hit `/health/live`, which touches nothing.

## Why

`/health/ready` runs four PostgreSQL queries: migration head, current role, current schema and schema owner. Those are boot-time invariants. As a readiness probe they ran every five seconds for the life of the pod, about 69,000 queries a day from Kubernetes alone, which is one more consumer keeping a serverless endpoint that is billed by wakefulness from ever suspending. Measured after the idle-backoff deploy the endpoint was still active 93% of the time, and this probe is the reason the other changes could not show.

It was also an availability defect in its own right. On any database blip the probe failed and removed the only API pod from the Service, so a condition the app would have reported as a per-request 503 became a whole-service outage at the ingress.

## Verification

Helm contract suite with real Helm 3.19.4 rendering (`HELM_BIN` set): 66 passed, including a new test that pins the startup probe on `/health/ready` and both periodic probes on `/health/live`, so the database check cannot drift back onto a periodic probe.

No provisioner code changes; chart only.
