### PR TITLE
fix(hosted): let a scheduler job adopt a changed cadence instead of refusing forever

### DIFF
--- a/infra/helm/platform/files/scheduler_runtime.py
+++ b/infra/helm/platform/files/scheduler_runtime.py
@@ -85,6 +85,23 @@ def _validate_state(state: dict[str, Any]) -> None:
         raise ValueError("scheduler histogram is invalid")
 
 
+def adopt_cadence(state: dict[str, Any], cadence_seconds: int) -> dict[str, Any]:
+    """Carry a job's counters across a change of its CronJob cadence.
+
+    The job name is identity; the cadence is deployment configuration for that
+    same job and the alert evaluator reads it from this state to place the
+    missed-run boundary. Refusing a changed cadence stops the job on every run
+    after a schedule change until someone rewrites the ConfigMap by hand, which
+    is what happened when the fleet moved from one-minute to five-minute ticks.
+    """
+    _validate_state(state)
+    if cadence_seconds <= 0:
+        raise ValueError("scheduler state identity is invalid")
+    updated = copy.deepcopy(state)
+    updated["cadence_seconds"] = cadence_seconds
+    return updated
+
+
 def record_attempt(
     state: dict[str, Any], *, success: bool, duration_seconds: float, observed_at: int
 ) -> dict[str, Any]:
@@ -387,8 +404,10 @@ def request_once() -> int:
     total_timeout = int(os.environ.get("TOTAL_TIMEOUT_SECONDS", "20"))
     resource, state = _read_state(STATE_PREFIX + job)
     _validate_state(state)
-    if state["job"] != job or state["cadence_seconds"] != cadence:
+    if state["job"] != job:
         raise RuntimeError("scheduler state identity does not match the job")
+    if state["cadence_seconds"] != cadence:
+        state = adopt_cadence(state, cadence)
     started = time.monotonic()
     previous_handler = signal.getsignal(signal.SIGALRM)
 

--- a/infra/helm/platform/files/scheduler_runtime.py
+++ b/infra/helm/platform/files/scheduler_runtime.py
@@ -407,6 +407,11 @@ def request_once() -> int:
     if state["job"] != job:
         raise RuntimeError("scheduler state identity does not match the job")
     if state["cadence_seconds"] != cadence:
+        print(
+            f"scheduler state for {job} adopts cadence {cadence}s "
+            f"(was {state['cadence_seconds']}s)",
+            file=sys.stderr,
+        )
         state = adopt_cadence(state, cadence)
     started = time.monotonic()
     previous_handler = signal.getsignal(signal.SIGALRM)

--- a/tests/test_hosted_scheduler_runtime.py
+++ b/tests/test_hosted_scheduler_runtime.py
@@ -96,6 +96,75 @@ def test_scheduler_alerts_transition_at_180_seconds_and_two_failures() -> None:
     )
 
 
+def _request_environment(monkeypatch: pytest.MonkeyPatch, *, job: str, cadence: int) -> None:
+    monkeypatch.setenv("JOB_NAME", job)
+    monkeypatch.setenv("TARGET_URL", "https://example.invalid/api/cron/" + job)
+    monkeypatch.setenv("EXOMEM_HOSTED_SCHEDULER_SECRET", "test-secret")
+    monkeypatch.setenv("CADENCE_SECONDS", str(cadence))
+
+
+def test_scheduler_request_adopts_a_changed_cadence_and_keeps_its_counters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The live fleet moved exomem-reconcile from one-minute to five-minute ticks
+    # (revision 54) while its state ConfigMap still said 60; every run refused
+    # "identity does not match" for twenty hours. The cadence is deployment
+    # configuration for the same job, so a run must carry the counters across.
+    module = _load()
+    stale = module.initial_state("exomem-reconcile", 60)
+    stale["attempts_total"] = 28_899
+    stale["failures_total"] = 199
+    stale["last_attempt_unixtime"] = 1_789_077_372
+    stale["last_success_unixtime"] = 1_789_077_372
+    stale["duration_seconds"] = {
+        "buckets": {"1": 115, "5": 28_865, "20": 28_899, "+Inf": 28_899},
+        "count": 28_899,
+        "sum": 51_324.173329,
+    }
+    written: list[dict[str, object]] = []
+    _request_environment(monkeypatch, job="exomem-reconcile", cadence=300)
+    monkeypatch.setattr(
+        module, "_read_state", lambda name: ({"metadata": {"name": name}}, dict(stale))
+    )
+    monkeypatch.setattr(module, "_write_state", lambda resource, state: written.append(state))
+    monkeypatch.setattr(module, "_exact_https_request", lambda *args, **kwargs: True)
+
+    assert module.request_once() == 0
+
+    assert len(written) == 1
+    persisted = written[0]
+    assert persisted["job"] == "exomem-reconcile"
+    assert persisted["cadence_seconds"] == 300
+    assert persisted["attempts_total"] == 28_900
+    assert persisted["failures_total"] == 199
+    assert persisted["consecutive_failures"] == 0
+    assert persisted["duration_seconds"]["count"] == 28_900
+    assert persisted["last_success_unixtime"] > 1_789_077_372
+
+
+def test_scheduler_request_still_refuses_another_jobs_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load()
+    foreign = module.initial_state("exomem-export-gc", 300)
+    written: list[dict[str, object]] = []
+    requested: list[str] = []
+    _request_environment(monkeypatch, job="exomem-reconcile", cadence=300)
+    monkeypatch.setattr(
+        module, "_read_state", lambda name: ({"metadata": {"name": name}}, dict(foreign))
+    )
+    monkeypatch.setattr(module, "_write_state", lambda resource, state: written.append(state))
+    monkeypatch.setattr(
+        module, "_exact_https_request", lambda target, *args, **kwargs: requested.append(target)
+    )
+
+    with pytest.raises(RuntimeError, match="identity does not match"):
+        module.request_once()
+
+    assert written == []
+    assert requested == []
+
+
 def test_scheduler_transport_rejects_redirects_and_non_exact_https(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

`scheduler_runtime.py` refused to run a job whenever the cadence recorded in its state ConfigMap differed from the CronJob's `CADENCE_SECONDS`. Revision 54 moved `exomem-reconcile` from one-minute to five-minute ticks while the ConfigMap kept `60`, so every reconcile run since 2026-09-10 21:56Z exited `scheduler state identity does not match the job`. Nothing provisioned, renewed or observed for twenty hours.

## Change

- The job name remains the identity check.
- A changed cadence is adopted: `adopt_cadence()` copies the state with the new cadence, counters and timestamps intact, and the run persists it with its attempt. The alert evaluator reads that cadence to place the missed-run boundary, so it must follow the CronJob.
- Red-first tests: a 60-second state under a 300-second CronJob now runs and persists `cadence_seconds: 300` with `attempts_total` advanced; another job's state is still refused with nothing written and nothing requested.

## Verification

- `tests/test_hosted_scheduler_runtime.py`: 6 passed (new test confirmed red before the change).
- Scheduler/observability Helm contract subset with the pinned Helm binary: green.
- `ruff check` / `ruff format --check` clean; public-artifact privacy gate clean.

## Deploy

Chart-only change: recompose the lock pair and roll the platform release. The live state ConfigMaps migrate themselves on the first run after the deploy.
