### PR TITLE
fix(hosted): read a candidate's locks against its profile, not its directory name

### DIFF
--- a/scripts/_hosted_candidate_locks.py
+++ b/scripts/_hosted_candidate_locks.py
@@ -64,7 +64,13 @@ def read_lock(repo: Path, candidate: str, name: str) -> dict:
     lock = json.loads(path.read_text())
     # The `.zip.lock.json` files carry only an archive digest, so absence is fine;
     # a present-and-different profile is not.
-    expected = CANDIDATE_PROFILES.get(candidate, candidate)
+    expected = CANDIDATE_PROFILES.get(candidate)
+    if expected is None:
+        raise SystemExit(
+            f"candidate {candidate} is not in CANDIDATE_PROFILES "
+            f"(scripts/_hosted_candidate_locks.py); add it there, mirroring "
+            "exomem.hosted_plugins.CANDIDATE_PROFILES, before reading its locks."
+        )
     declared = lock.get("profile")
     if declared is not None and declared != expected:
         raise SystemExit(

--- a/scripts/_hosted_candidate_locks.py
+++ b/scripts/_hosted_candidate_locks.py
@@ -1,21 +1,22 @@
-"""Locate a release's generated Hosted plugin locks for one candidate profile.
+"""Locate a release's generated Hosted plugin locks for one candidate.
 
 `exomem.hosted_plugins` writes the default candidate's artifacts directly under
 `plugins/hosted/generated`, and every later candidate under
-`plugins/hosted/generated/candidates/<profile>`. The operator scripts read those
-files out of `--repo`, so they need the same rule.
+`plugins/hosted/generated/candidates/<candidate>`. The operator scripts read
+those files out of `--repo`, so they need the same rule.
 
 It is restated here rather than imported because `--repo` is routinely a
 different checkout from the one the script runs out of -- the harness is run
 from `main` while `--repo` points at a worktree of the released tag -- and an
-import would resolve against whichever tree is on `sys.path`. Only the layout is
-duplicated; every value still comes from the files under `--repo`.
+import would resolve against whichever tree is on `sys.path`. Only the layout
+and the candidate-to-profile map are duplicated; every digest still comes from
+the files under `--repo`.
 
-Reading the wrong profile's locks is not a loud failure. The digests simply
+Reading the wrong candidate's locks is not a loud failure. The digests simply
 belong to a different command surface, and the server-side joins that consume
 them answer a bare 500 or a silent false, inside the promotion window. So
 `read_lock` refuses a lock whose own `profile` field disagrees with the profile
-that was asked for.
+of the candidate that was asked for.
 """
 
 from __future__ import annotations
@@ -27,31 +28,48 @@ from pathlib import Path
 #: under `candidates/`. Mirrors `exomem.hosted_plugins.DEFAULT_CANDIDATE`.
 DEFAULT_CANDIDATE_PROFILE = "hosted-alpha-agent-v1"
 
+#: Candidate name -> the agent profile its locks declare. Mirrors
+#: `exomem.hosted_plugins.CANDIDATE_PROFILES`; `tests/test_reviewer_bootstrap_cli.py`
+#: pins the two maps equal. A candidate is a generated directory, and more than
+#: one candidate can carry the same profile -- the command-binding variant of v4
+#: declares `hosted-alpha-agent-v4` -- so the directory name is not what a lock
+#: declares and must not be compared against it.
+CANDIDATE_PROFILES = {
+    "hosted-alpha-agent-v1": "hosted-alpha-agent-v1",
+    "hosted-alpha-agent-v2": "hosted-alpha-agent-v2",
+    "hosted-alpha-agent-v3": "hosted-alpha-agent-v3",
+    "hosted-alpha-agent-v4": "hosted-alpha-agent-v4",
+    "hosted-alpha-agent-v5": "hosted-alpha-agent-v5",
+    "hosted-alpha-agent-v4-command-binding-v1": "hosted-alpha-agent-v4",
+}
 
-def candidate_generated_root(repo: Path, profile: str) -> Path:
-    """Directory holding `<platform>.lock.json` for `profile` inside `repo`."""
+
+def candidate_generated_root(repo: Path, candidate: str) -> Path:
+    """Directory holding `<platform>.lock.json` for `candidate` inside `repo`."""
     generated = repo / "plugins" / "hosted" / "generated"
-    if profile == DEFAULT_CANDIDATE_PROFILE:
+    if candidate == DEFAULT_CANDIDATE_PROFILE:
         return generated
-    return generated / "candidates" / profile
+    return generated / "candidates" / candidate
 
 
-def read_lock(repo: Path, profile: str, name: str) -> dict:
+def read_lock(repo: Path, candidate: str, name: str) -> dict:
     """Read one lock file, refusing a profile the file itself disagrees with."""
-    path = candidate_generated_root(repo, profile) / name
+    path = candidate_generated_root(repo, candidate) / name
     if not path.is_file():
         raise SystemExit(
             f"{path} does not exist; {repo} does not carry generated artifacts for "
-            f"profile {profile}. Point --repo at a worktree of the release the "
-            f"candidate was cut from, and --profile at that candidate's profile."
+            f"candidate {candidate}. Point --repo at a worktree of the release the "
+            f"candidate was cut from, and --profile at that candidate."
         )
     lock = json.loads(path.read_text())
     # The `.zip.lock.json` files carry only an archive digest, so absence is fine;
     # a present-and-different profile is not.
+    expected = CANDIDATE_PROFILES.get(candidate, candidate)
     declared = lock.get("profile")
-    if declared is not None and declared != profile:
+    if declared is not None and declared != expected:
         raise SystemExit(
-            f"{path} declares profile {declared}, not the requested {profile}; "
-            "refusing to promote one profile's candidate on another's digests."
+            f"{path} declares profile {declared}, not {expected} (the profile of "
+            f"candidate {candidate}); refusing to promote one profile's candidate on "
+            "another's digests."
         )
     return lock

--- a/tests/test_reviewer_bootstrap_cli.py
+++ b/tests/test_reviewer_bootstrap_cli.py
@@ -470,6 +470,26 @@ def test_candidate_lock_reader_mirrors_the_packages_candidate_profiles() -> None
     assert helper.DEFAULT_CANDIDATE_PROFILE in helper.CANDIDATE_PROFILES
 
 
+def test_candidate_lock_reader_refuses_an_unmapped_candidate(tmp_path: pathlib.Path) -> None:
+    """An unknown candidate name must not fall back to comparing against itself."""
+    _load_module()
+    helper = sys.modules["_hosted_candidate_locks"]
+    candidate = (
+        tmp_path / "plugins" / "hosted" / "generated" / "candidates" / "hosted-alpha-agent-v9"
+    )
+    candidate.mkdir(parents=True)
+    (candidate / "claude.lock.json").write_text(
+        json.dumps(
+            {**OPENAI_PACKAGE_LOCK, "platform": "claude", "profile": "hosted-alpha-agent-v9"}
+        )
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        helper.read_lock(tmp_path, "hosted-alpha-agent-v9", "claude.lock.json")
+
+    assert "not in CANDIDATE_PROFILES" in str(raised.value)
+
+
 def test_prepare_attaches_the_openai_locks_before_anything_else(monkeypatch) -> None:
     """Ordering is the whole point: after `run` starts, this is unrecoverable."""
     module = _load_module()

--- a/tests/test_reviewer_bootstrap_cli.py
+++ b/tests/test_reviewer_bootstrap_cli.py
@@ -422,6 +422,54 @@ def test_load_locks_refuses_a_lock_that_declares_another_profile(
     assert "declares profile hosted-alpha-agent-v1" in str(raised.value)
 
 
+def test_load_locks_accepts_a_candidate_whose_locks_declare_its_mapped_profile(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A candidate is a generated directory; its locks declare an agent profile.
+
+    `hosted-alpha-agent-v4-command-binding-v1` declares `hosted-alpha-agent-v4`,
+    exactly as `exomem.hosted_plugins.CANDIDATE_PROFILES` says it should, and it
+    is the candidate the 0.77.0 contract was cut from. Measured 2026-09-11: the
+    preflight refused it with "declares profile hosted-alpha-agent-v4, not the
+    requested hosted-alpha-agent-v4-command-binding-v1", comparing the lock
+    against the directory name instead of the candidate's profile.
+    """
+    module = _load_module()
+    candidate_name = "hosted-alpha-agent-v4-command-binding-v1"
+    candidate = tmp_path / "plugins" / "hosted" / "generated" / "candidates" / candidate_name
+    candidate.mkdir(parents=True)
+    (tmp_path / "plugins" / "hosted" / "marketplace-review-fixture-v2.json").write_text(
+        json.dumps({"fixture_version": "v2", "payload_sha256": "ff" * 32})
+    )
+    package = {
+        **OPENAI_PACKAGE_LOCK,
+        "profile": "hosted-alpha-agent-v4",
+        "artifact_sha256": "44" * 32,
+    }
+    (candidate / "claude.lock.json").write_text(json.dumps({**package, "platform": "claude"}))
+    (candidate / "claude.zip.lock.json").write_text(
+        json.dumps({"platform": "claude", "archive_sha256": "0d" * 32})
+    )
+    (candidate / "openai.lock.json").write_text(json.dumps(package))
+    (candidate / "openai.zip.lock.json").write_text(json.dumps(OPENAI_ARCHIVE_LOCK))
+
+    locks = module.load_locks(tmp_path, candidate_name)
+
+    assert locks["profile"] == candidate_name
+    assert locks["openai_package"] == "44" * 32
+
+
+def test_candidate_lock_reader_mirrors_the_packages_candidate_profiles() -> None:
+    """The helper restates the map instead of importing it; pin the two equal."""
+    from exomem.hosted_plugins import CANDIDATE_PROFILES
+
+    _load_module()
+    helper = sys.modules["_hosted_candidate_locks"]
+
+    assert helper.CANDIDATE_PROFILES == dict(CANDIDATE_PROFILES)
+    assert helper.DEFAULT_CANDIDATE_PROFILE in helper.CANDIDATE_PROFILES
+
+
 def test_prepare_attaches_the_openai_locks_before_anything_else(monkeypatch) -> None:
     """Ordering is the whole point: after `run` starts, this is unrecoverable."""
     module = _load_module()


### PR DESCRIPTION
## What

`scripts/_hosted_candidate_locks.read_lock` compared a lock's declared `profile` with the candidate **name** it was asked to read. `hosted-alpha-agent-v4-command-binding-v1` declares `hosted-alpha-agent-v4`, exactly as `exomem.hosted_plugins.CANDIDATE_PROFILES` maps it, so both `reviewer_bootstrap.py` and `promotion_evidence.py` refused it:

```
…/candidates/hosted-alpha-agent-v4-command-binding-v1/claude.lock.json declares profile hosted-alpha-agent-v4, not the requested hosted-alpha-agent-v4-command-binding-v1; refusing to promote one profile's candidate on another's digests.
```

That candidate is the one the live 0.77.0 contract candidate was cut from (compatibility `320e7516…`), so no 0.77.0 reviewer bootstrap could start.

## Change

- The helper restates the candidate-to-profile map next to the layout it already restates, and compares the declared profile against the mapped profile. Unknown candidates fall back to their own name, as before.
- A test pins the restated map equal to `exomem.hosted_plugins.CANDIDATE_PROFILES`.
- A red-first test reads the command-binding candidate whose locks declare v4; the existing refusal test (v1 locks under a v4 directory) still passes.

## Verification

- `tests/test_reviewer_bootstrap_cli.py` + `tests/test_promotion_evidence_dsn_handling.py`: 66 passed (the two new tests confirmed red before the change).
- Live read-only preflight against production with `--profile hosted-alpha-agent-v4-command-binding-v1` now passes the lock check.
- `ruff check` / `ruff format --check` clean; public-artifact privacy gate clean.
