### PR TITLE
fix(hosted): bind an alert transition id to its evaluation time so a counter regression cannot silence it

### DIFF
--- a/infra/helm/platform/files/scheduler_runtime.py
+++ b/infra/helm/platform/files/scheduler_runtime.py
@@ -363,11 +363,16 @@ def transition_identifier(
 
     The receiver deduplicates on this id, so it must never repeat for a *new*
     transition. The sequence counter alone is not enough: the alert-state
-    ConfigMap's `transitions_total` fell behind the receiver's record (79 against
-    83 rows on 2026-09-11), so the missed-run FIRING for a twenty-hour reconcile
-    outage carried the same id as a transition from four days earlier and was
-    dropped as a duplicate, with no email. Binding the evaluation time keeps a
-    retry within one evaluation idempotent while a later firing is always new.
+    ConfigMap's `transitions_total` fell behind the receiver's record (it stood
+    at 78 when the receiver already held sequence 79; 79 against 83 rows once
+    the run had advanced it, measured 2026-09-11), so the missed-run FIRING for
+    a twenty-hour reconcile outage carried the same id as a transition from four
+    days earlier and was dropped as a duplicate, with no email. Binding the
+    evaluation time keeps a retry within one evaluation idempotent while a later
+    firing is always new. A pass that dies after delivering and before writing
+    its state re-derives the transition under a fresh id on the next loop; the
+    receiver's redundancy check against the last delivered row is what folds
+    that resend, so it is load-bearing rather than a safety net.
     """
     transitions_total = alert_state.get("transitions_total")
     if (

--- a/infra/helm/platform/files/scheduler_runtime.py
+++ b/infra/helm/platform/files/scheduler_runtime.py
@@ -357,8 +357,18 @@ def deliver_transition(transition: dict[str, Any], *, webhook_url: str, transiti
 
 
 def transition_identifier(
-    alert_state: dict[str, Any], transition: dict[str, Any], index: int
+    alert_state: dict[str, Any], transition: dict[str, Any], index: int, *, observed_at: int
 ) -> str:
+    """Identity of one alert transition, stable across retries of one evaluation.
+
+    The receiver deduplicates on this id, so it must never repeat for a *new*
+    transition. The sequence counter alone is not enough: the alert-state
+    ConfigMap's `transitions_total` fell behind the receiver's record (79 against
+    83 rows on 2026-09-11), so the missed-run FIRING for a twenty-hour reconcile
+    outage carried the same id as a transition from four days earlier and was
+    dropped as a duplicate, with no email. Binding the evaluation time keeps a
+    retry within one evaluation idempotent while a later firing is always new.
+    """
     transitions_total = alert_state.get("transitions_total")
     if (
         not isinstance(transitions_total, int)
@@ -367,11 +377,14 @@ def transition_identifier(
         or not isinstance(index, int)
         or isinstance(index, bool)
         or index < 0
+        or not isinstance(observed_at, int)
+        or isinstance(observed_at, bool)
+        or observed_at <= 0
     ):
         raise RuntimeError("scheduler alert transition identity is invalid")
     return hashlib.sha256(
         json.dumps(
-            {"sequence": transitions_total + index + 1, **transition},
+            {"sequence": transitions_total + index + 1, "observed_at": observed_at, **transition},
             separators=(",", ":"),
             sort_keys=True,
         ).encode()
@@ -428,7 +441,9 @@ def evaluate_once() -> None:
         failure_threshold=int(os.environ["FAILURE_THRESHOLD"]),
     )
     for index, transition in enumerate(transitions):
-        transition_id = transition_identifier(alert_state, transition, index)
+        transition_id = transition_identifier(
+            alert_state, transition, index, observed_at=observed_at
+        )
         deliver_transition(
             transition,
             webhook_url=os.environ["ALERT_WEBHOOK_URL"],

--- a/infra/helm/platform/templates/observability.yaml
+++ b/infra/helm/platform/templates/observability.yaml
@@ -45,11 +45,15 @@ data:
 {{- end }}
 {{- $stateName := printf "exomem-hosted-scheduler-state-%s" $job.name -}}
 {{- $initialState := printf `{"schema_version":1,"job":%q,"cadence_seconds":%d,"attempts_total":0,"failures_total":0,"consecutive_failures":0,"last_attempt_unixtime":0,"last_success_unixtime":0,"duration_seconds":{"buckets":{"1":0,"5":0,"20":0,"+Inf":0},"count":0,"sum":0.0}}` $job.name $cadenceSeconds -}}
+{{- /*
+The runtime owns this state after first creation. Re-rendering it from a
+`lookup` snapshot is a read-modify-write across the whole upgrade: anything the
+job recorded between render and apply was erased, and a stale cadence was carried
+forward verbatim. So the chart seeds the ConfigMap only when it does not exist;
+`helm.sh/resource-policy: keep` then leaves it alone on every later upgrade.
+*/ -}}
 {{- $existingState := lookup "v1" "ConfigMap" $.Release.Namespace $stateName -}}
-{{- $persistedState := $initialState -}}
-{{- if and $existingState $existingState.data (hasKey $existingState.data "state.json") -}}
-{{- $persistedState = index $existingState.data "state.json" -}}
-{{- end }}
+{{- if not $existingState }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -62,15 +66,19 @@ metadata:
     helm.sh/resource-policy: keep
 immutable: false
 data:
-  state.json: {{ $persistedState | quote }}
+  state.json: {{ $initialState | quote }}
+{{- end }}
 {{- end }}
 {{- $alertStateName := "exomem-hosted-scheduler-alert-state" -}}
 {{- $initialAlertState := `{"schema_version":1,"baselines":{},"active":{},"transitions_total":0,"last_evaluated_unixtime":0}` -}}
+{{- /*
+Seeded once, then owned by the evaluator. Re-rendering it from a `lookup`
+snapshot rolled `transitions_total`, `baselines` and `active` back to whatever
+the render saw, so a transition committed while the upgrade ran was erased and
+its sequence number reused: the receiver deduplicated the next real alert.
+*/ -}}
 {{- $existingAlertState := lookup "v1" "ConfigMap" .Release.Namespace $alertStateName -}}
-{{- $persistedAlertState := $initialAlertState -}}
-{{- if and $existingAlertState $existingAlertState.data (hasKey $existingAlertState.data "state.json") -}}
-{{- $persistedAlertState = index $existingAlertState.data "state.json" -}}
-{{- end }}
+{{- if not $existingAlertState }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -83,7 +91,8 @@ metadata:
     helm.sh/resource-policy: keep
 immutable: false
 data:
-  state.json: {{ $persistedAlertState | quote }}
+  state.json: {{ $initialAlertState | quote }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/test_hosted_scheduler_runtime.py
+++ b/tests/test_hosted_scheduler_runtime.py
@@ -179,11 +179,15 @@ def test_alert_evaluator_scrapes_content_free_snapshot_and_requires_delivery(
     opener = Opener()
     monkeypatch.setattr(module.urllib.request, "build_opener", lambda *_args: opener)
     transition = {"job": "exomem-reconcile", "alert": "missed-run", "active": True}
-    first_id = module.transition_identifier(module.initial_alert_state(), transition, 0)
-    assert first_id == module.transition_identifier(module.initial_alert_state(), transition, 0)
+    first_id = module.transition_identifier(
+        module.initial_alert_state(), transition, 0, observed_at=1_000
+    )
+    assert first_id == module.transition_identifier(
+        module.initial_alert_state(), transition, 0, observed_at=1_000
+    )
     later_state = module.initial_alert_state()
     later_state["transitions_total"] = 1
-    assert module.transition_identifier(later_state, transition, 0) != first_id
+    assert module.transition_identifier(later_state, transition, 0, observed_at=1_000) != first_id
     module.deliver_transition(
         transition,
         webhook_url=target,
@@ -196,3 +200,30 @@ def test_alert_evaluator_scrapes_content_free_snapshot_and_requires_delivery(
             webhook_url=target,
             transition_id="transition-0001",
         )
+
+
+def test_alert_transition_id_does_not_repeat_after_a_counter_regression() -> None:
+    # Measured 2026-09-11: the alert-state ConfigMap's transitions_total stood at
+    # 78 while the receiver already held sequence 79 from 2026-09-07, so the
+    # FIRING for a twenty-hour reconcile outage was deduplicated and never mailed.
+    # The receiver keys on this id, so a later evaluation must never reuse one.
+    module = _load()
+    transition = {"job": "exomem-reconcile", "alert": "missed-run", "active": True}
+    earlier = module.initial_alert_state()
+    earlier["transitions_total"] = 78
+    earlier_id = module.transition_identifier(earlier, transition, 0, observed_at=1_788_996_839)
+
+    regressed = module.initial_alert_state()
+    regressed["transitions_total"] = 78
+    later_id = module.transition_identifier(regressed, transition, 0, observed_at=1_789_078_320)
+    assert later_id != earlier_id
+
+    # A retry of the same evaluation keeps the same id, so the receiver can
+    # still deduplicate a resend after a lost acknowledgement.
+    assert (
+        module.transition_identifier(regressed, transition, 0, observed_at=1_789_078_320)
+        == later_id
+    )
+
+    with pytest.raises(RuntimeError, match="transition identity is invalid"):
+        module.transition_identifier(regressed, transition, 0, observed_at=0)

--- a/tests/test_hosted_scheduler_runtime.py
+++ b/tests/test_hosted_scheduler_runtime.py
@@ -279,9 +279,17 @@ def test_alert_evaluation_reads_the_clock_once_so_every_transition_shares_it(
 
 
 def test_chart_seeds_scheduler_state_once_and_never_re_renders_it() -> None:
-    # Re-rendering the state ConfigMaps from a render-time `lookup` snapshot was a
-    # read-modify-write across the whole upgrade: counters, baselines and active
-    # alerts rolled back to whatever the render saw. The chart must only seed.
+    """Pin the seed-once guards at source level.
+
+    Re-rendering the state ConfigMaps from a render-time `lookup` snapshot was a
+    read-modify-write across the whole upgrade: counters, baselines and active
+    alerts rolled back to whatever the render saw. The chart must only seed.
+
+    This is second-best on purpose: `helm template` runs with an empty `lookup`,
+    so no render-level test can reach the omit-when-present branch. The live
+    evidence is the `Skipping delete ... resource-policy: keep` line in the first
+    upgrade's log after this lands.
+    """
     template = (ROOT / "infra/helm/platform/templates/observability.yaml").read_text()
     assert "{{- if not $existingState }}" in template
     assert "{{- if not $existingAlertState }}" in template

--- a/tests/test_hosted_scheduler_runtime.py
+++ b/tests/test_hosted_scheduler_runtime.py
@@ -227,3 +227,64 @@ def test_alert_transition_id_does_not_repeat_after_a_counter_regression() -> Non
 
     with pytest.raises(RuntimeError, match="transition identity is invalid"):
         module.transition_identifier(regressed, transition, 0, observed_at=0)
+
+
+def test_alert_evaluation_reads_the_clock_once_so_every_transition_shares_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Retry idempotence rests on one observed_at per pass. Two transitions in one
+    # pass must carry the same timestamp, and a resend of that pass must produce
+    # the same ids, which a clock read inside the delivery loop would break.
+    module = _load()
+    clock = iter(range(5_000, 5_100))
+    monkeypatch.setattr(module.time, "time", lambda: next(clock))
+    stale = module.record_attempt(
+        module.initial_state("exomem-reconcile", 60),
+        success=False,
+        duration_seconds=0.1,
+        observed_at=1_000,
+    )
+    stale = module.record_attempt(stale, success=False, duration_seconds=0.1, observed_at=1_001)
+    alert_state = module.initial_alert_state()
+    alert_state["baselines"] = {"exomem-reconcile": 1_000}
+    monkeypatch.setenv("COLLECTOR_SNAPSHOT_URL", "http://collector.invalid/snapshot")
+    monkeypatch.setenv("MISSED_RUN_SECONDS", "180")
+    monkeypatch.setenv("FAILURE_THRESHOLD", "2")
+    monkeypatch.setenv("ALERT_WEBHOOK_URL", "https://alerts.example.invalid/hooks/opaque")
+    monkeypatch.setattr(module, "_fetch_snapshot", lambda url: [stale])
+    monkeypatch.setattr(
+        module, "_read_state", lambda name: ({"metadata": {"name": name}}, dict(alert_state))
+    )
+    delivered: list[tuple[dict[str, object], str]] = []
+    monkeypatch.setattr(
+        module,
+        "deliver_transition",
+        lambda transition, *, webhook_url, transition_id: delivered.append(
+            (transition, transition_id)
+        ),
+    )
+    written: list[dict[str, object]] = []
+    monkeypatch.setattr(module, "_write_state", lambda resource, state: written.append(state))
+    monkeypatch.setattr(module, "_api_request", lambda *args, **kwargs: {})
+
+    module.evaluate_once()
+
+    assert {item[0]["alert"] for item in delivered} == {"missed-run", "consecutive-failures"}
+    observed_at = written[0]["last_evaluated_unixtime"]
+    assert observed_at == 5_000, "one clock read per evaluation"
+    for index, (transition, transition_id) in enumerate(delivered):
+        assert transition_id == module.transition_identifier(
+            alert_state, transition, index, observed_at=observed_at
+        )
+
+
+def test_chart_seeds_scheduler_state_once_and_never_re_renders_it() -> None:
+    # Re-rendering the state ConfigMaps from a render-time `lookup` snapshot was a
+    # read-modify-write across the whole upgrade: counters, baselines and active
+    # alerts rolled back to whatever the render saw. The chart must only seed.
+    template = (ROOT / "infra/helm/platform/templates/observability.yaml").read_text()
+    assert "{{- if not $existingState }}" in template
+    assert "{{- if not $existingAlertState }}" in template
+    assert "$persistedState" not in template
+    assert "$persistedAlertState" not in template
+    assert template.count("helm.sh/resource-policy: keep") >= 2


### PR DESCRIPTION
## What

The scheduler alert evaluator derives each transition's id from its local `transitions_total` counter, and Substrate's alert receiver deduplicates on that id. On the live cluster the alert-state ConfigMap's counter stands at 79 while the receiver already holds 83 transitions, so the missed-run FIRING for the twenty-hour reconcile outage (from 2026-09-10 22:12Z) was computed as sequence 79, the id of a transition from 2026-09-07 23:33Z, and the receiver answered "duplicate": no email, no row, and the evaluator advanced its state as delivered. The RESOLVED after the fix lands would have collided with sequence 80 the same way.

Verified by recomputing every stored id: sequences 1 to 80 match the receiver's rows and the current counter is 79.

## Change

- `transition_identifier` also binds the evaluation timestamp (`observed_at`) into the id and refuses a non-positive one. A resend within the same evaluation keeps its id, so a lost acknowledgement still deduplicates; a later firing is always a new id whatever the counter says.
- `evaluate_once` passes its `observed_at`.
- Red-first: the regression scenario (same counter value, later evaluation) reuses the id on main and now does not; retry idempotence and the invalid-timestamp refusal are pinned.

The receiver only validates the id as 64 hex matching its header (`alert-receiver.ts:121-131`), so no Substrate change is needed.

## Verification

- `tests/test_hosted_scheduler_runtime.py`: 5 passed; scheduler/observability Helm contract subset with the pinned Helm binary: 3 passed.
- `ruff check` / `ruff format --check` clean; public-artifact privacy gate clean.

## Deploy

Chart-only change; rides the next platform lock cycle together with #1199.
