### PR TITLE
fix(hooks): retrieve-nudge stubs use hybrid recall and reach the REST lane

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -582,18 +582,30 @@ the defaults (tuned for English) can under-fire. (These tunables were renamed fr
 **Opt-in: upgrade the read-side reminder to real retrieved content.** By default
 the `UserPromptSubmit` hook only reminds Claude to run `ask_memory` — set
 `EXOMEM_RETRIEVE_INJECT=1` and it instead fetches the top 3 compact routing stubs
-(keyword mode, no embeddings) for the same gated prompt and appends them to the
-reminder, so relevant prior KB pages are already in context before Claude
-decides whether to search. It tries a short transport ladder and never blocks
-on a slow path: REST first (one `POST /api/ask_memory`, ~2s timeout) — only
-attempted when `EXOMEM_REST_API_KEY` is set **in the shell that launches the
-client** (not just the server's service environment — the hook can't read another
-process's env, so export it in the same profile Claude Code or Codex inherits from);
-then, only if you also set `EXOMEM_RETRIEVE_INJECT_CLI=1`, an `exomem ask_memory --json`
-subprocess call (~5s timeout, slower — cold Python start). If neither is
-configured or reachable, it falls straight back to the plain reminder — no
-network call is ever attempted unless `EXOMEM_RETRIEVE_INJECT` is on. (The legacy
-`KB_RETRIEVE_INJECT` / `KB_RETRIEVE_INJECT_CLI` names still work too.)
+(hybrid mode, so a pasted ticket or a sentence with punctuation still finds its
+pages; keyword mode is an all-tokens gate that real prompts never pass) for the
+same gated prompt and appends them to the reminder, so relevant prior KB pages
+are already in context before Claude decides whether to search. It tries a short
+transport ladder and never blocks on a slow path: REST first (one
+`POST /api/ask_memory`, 4s timeout) — attempted when `EXOMEM_REST_API_KEY` is set
+in the client's environment **or** persisted in the managed install's
+`service.env` (`~/.config/exomem/service.env` on Linux,
+`~/Library/Application Support/Exomem/service.env` on macOS; override the location
+with `EXOMEM_SERVICE_ENV`). A key read from that file is only ever sent to a
+loopback host: point `EXOMEM_HOST` elsewhere and the REST rung is skipped for it.
+Then, only if you also set `EXOMEM_RETRIEVE_INJECT_CLI=1`, an
+`exomem ask_memory --json` subprocess call (~5s timeout, slower — cold Python
+start). The two rungs share one 8s budget under the hook's 10s timeout, measured
+on elapsed time: a REST call that dribbles bytes past the budget is abandoned and
+the CLI rung gets what is left. If
+neither is configured or reachable, it falls straight back to the plain reminder
+— no network call is ever attempted unless `EXOMEM_RETRIEVE_INJECT` is on. The
+stub block is cut by whole lines (600 characters), never inside a path, with a
+`… N more not shown` marker when a hit was dropped. Each fired nudge writes one line to
+`~/.claude/exomem-retrieve-nudge.log` (or `~/.codex/...`) naming the lane that
+answered (`lane=rest|cli|none|off`) and the hit count, so a silent fall-through
+to the plain reminder is visible. (The legacy `KB_RETRIEVE_INJECT` /
+`KB_RETRIEVE_INJECT_CLI` names still work too.)
 
 (Hooks are local-client only — claude.ai web/mobile can't run them, so there the
 skill or `bootstrap()` contract stays best-effort: nudge it with *"save that to

--- a/benchmarks/membench/trackc/injection_ladder.py
+++ b/benchmarks/membench/trackc/injection_ladder.py
@@ -6,26 +6,31 @@ that file) against an ISOLATED corpus vault:
 
 - Inject mode is a payload upgrade on the same fire gate: with
   ``EXOMEM_RETRIEVE_INJECT`` truthy the hook fetches compact routing stubs and
-  appends them under the ``KB routing stubs`` header (lines 396-408, 337-356;
-  header at line 75, 400-char cap at line 76).
-- Ladder order (``_gather_hits``, lines 320-334): REST is attempted ONLY when
-  ``EXOMEM_REST_API_KEY`` is set (lines 325-329); otherwise, with
+  appends them under the ``KB routing stubs`` header (``_format_inject_block``;
+  ``_STUB_HEADER``, whole-line bound ``_STUB_BLOCK_MAX_CHARS``).
+- Ladder order (``_gather_hits_with_lane``): REST is attempted ONLY when a key
+  resolves (``_resolve_rest_key``: the env, else the managed install's
+  ``service.env``, loopback-only for a file-sourced key); otherwise, with
   ``EXOMEM_RETRIEVE_INJECT_CLI`` truthy, the CLI rung runs.
-- CLI rung resolution (``_fetch_via_cli``, lines 289-317): the hook locates
+- CLI rung resolution (``_fetch_via_cli``): the hook locates
   the executable via ``shutil.which("exomem") or shutil.which("kb")`` (line
   295) — i.e. PATH lookup, NOT an EXOMEM_COMMAND env var — then runs
-  ``<exe> ask_memory --detail compact --limit 3 --mode keyword --json
-  <prompt>`` with a hard 5.0s timeout (lines 299-311). It accepts the shared
+  ``<exe> ask_memory --detail compact --limit 3 --mode hybrid --json
+  <prompt>`` (``INJECT_MODE``) with a wall-clock timeout of at most
+  ``CLI_TIMEOUT_SECONDS``, bounded by the shared ``INJECT_BUDGET_SECONDS``. It
+  accepts the shared
   ``{"success": true, "data": [...]}`` envelope (``_parse_hits``, lines
   243-254). ANY failure — executable missing, non-zero exit, bad JSON,
   timeout — returns None and the hook falls to the reminder-only floor
-  (lines 330-334, 404-408); it never blocks or raises.
+  (the reminder-only floor in ``main``); it never blocks or raises.
 
-Determinism note: the CLI rung queries in keyword mode, which is strict
-case-insensitive substring matching over title+body (src/exomem/find.py line
-457), so the firing probe prompt must literally appear in a corpus page — a
-corpus source TITLE satisfies both the substring requirement and the nudge
-gate (>= 20 chars, non-control).
+Determinism note: the CLI rung queries in hybrid mode (``INJECT_MODE`` in the
+hook; keyword mode's all-tokens gate never passed a real prompt). Hybrid fuses
+the lexical lanes with a vector lane, so a probe that is a corpus source TITLE
+still ranks its own page first through the lexical lanes and satisfies the
+nudge gate (>= 20 chars, non-control); the vector lane can only add candidates
+below it. The ``cited_corpus`` assertion therefore stays deterministic against
+the isolated vault, but it now exercises an embedding-capable ``ask_memory``.
 
 REST rung: intentionally NOT exercised here (loopback availability in the
 test sandbox is uncertain); see ``rest_rung_stub`` for the exact manual
@@ -35,6 +40,7 @@ command.
 from __future__ import annotations
 
 import json
+import os
 import re
 import stat
 import subprocess
@@ -51,9 +57,9 @@ from membench.trackc.hook_home import (
 )
 from membench.trackc.nudge_driver import HOOK_TIMEOUT_SECONDS, parse_fired
 
-#: Inject-block header, mirrored from exomem_retrieve_nudge.py line 75.
+#: Inject-block header, mirrored from exomem_retrieve_nudge.py ``_STUB_HEADER``.
 STUB_HEADER = "KB routing stubs"
-#: Reminder prefix, mirrored from lines 60-61.
+#: Reminder prefix, mirrored from ``REMINDER``.
 REMINDER_PREFIX = "[Exomem retrieval check]"
 
 T00_TEMPLATE = "t00_mini_smoke"
@@ -86,9 +92,9 @@ def _gate_passes(prompt: str) -> bool:
     """Check the probe prompt against the hook's OWN gate predicates."""
     from exomem._hooks import exomem_retrieve_nudge as nudge
 
-    if len(prompt.strip()) < 20:  # min-chars default, lines 373, 378
+    if len(prompt.strip()) < 20:  # min-chars default (``EXOMEM_RETRIEVE_NUDGE_MIN_CHARS``)
         return False
-    return not nudge._is_obvious_control_prompt(prompt, 180)  # lines 178-191
+    return not nudge._is_obvious_control_prompt(prompt, 180)
 
 
 def _distinctive_token(title: str) -> str:
@@ -157,9 +163,10 @@ def build_seeded_vault(workdir: Path | None = None, *, seed: int = 1) -> SeededV
 
 
 def make_exomem_shim(bin_dir: Path) -> Path:
-    """An ``exomem`` executable for the hook's PATH lookup (line 295) that runs
+    """An ``exomem`` executable for the hook's PATH lookup (``shutil.which`` in
+    ``_fetch_via_cli``) that runs
     THIS worktree's code in the test venv. Vault/profile env is inherited from
-    the hook process (``_fetch_via_cli`` passes no explicit env, line 299)."""
+    the hook process (``_fetch_via_cli`` passes no explicit env)."""
     bin_dir.mkdir(parents=True, exist_ok=True)
     shim = bin_dir / "exomem"
     shim.write_text(
@@ -184,8 +191,8 @@ def run_injection(
 
     ``break_cli=True`` degrades the CLI rung the way the hook actually
     resolves it: the shim directory is left OFF PATH so
-    ``shutil.which("exomem"/"kb")`` (line 295) finds nothing and the ladder
-    falls to the reminder-only floor (lines 330-334). (There is no
+    ``shutil.which("exomem"/"kb")`` finds nothing and the ladder
+    falls to the reminder-only floor. (There is no
     EXOMEM_COMMAND override in the shipped hook — resolution is PATH-based.)
     """
     state_home = Path(state_home)
@@ -196,12 +203,15 @@ def run_injection(
     env = home.base_env(
         EXOMEM_HOOK_HOME=str(state_home),
         PATH=path,
-        # Opt-in inject mode + CLI rung (truthy-parsed flags, lines 113-133).
+        # Opt-in inject mode + CLI rung (truthy-parsed flags, ``_env_flag``).
         EXOMEM_RETRIEVE_INJECT="1",
         EXOMEM_RETRIEVE_INJECT_CLI="1",
         **seeded.env,
     )
-    env.pop("EXOMEM_REST_API_KEY", None)  # REST rung stays un-attempted (line 325)
+    # REST rung stays un-attempted: no key in the env, and the hook's
+    # service.env fallback (`_resolve_rest_key`) is pointed at an empty file.
+    env.pop("EXOMEM_REST_API_KEY", None)
+    env["EXOMEM_SERVICE_ENV"] = os.devnull
     ensure_isolated(env)
     probe = prompt if prompt is not None else seeded.probe_prompt
     event = {
@@ -244,13 +254,13 @@ def run_injection(
 def rest_rung_stub() -> dict:
     """Documented stub for the REST rung (NOT run here: loopback availability
     in this sandbox is uncertain, and the hook only attempts REST when
-    EXOMEM_REST_API_KEY is set — lines 257-286, 325-329).
+    a key resolves — ``_fetch_via_rest`` / ``_resolve_rest_key``).
 
     To exercise it manually on a workstation with the local REST facade
     running, execute the returned ``user_command`` (single line): it starts
     from the same seeded-vault env, sets the API key, and submits the probe
     event to the installed hook; REST reachability then short-circuits the
-    CLI rung entirely (line 328: a reachable REST — even with 0 hits — means
+    CLI rung entirely (a reachable REST — even with 0 hits — means
     CLI is never tried).
     """
     return {
@@ -265,8 +275,8 @@ def rest_rung_stub() -> dict:
         ),
         "contract": (
             "REST POST http://$EXOMEM_HOST:8765/api/ask_memory with "
-            '{"query": <prompt>, "detail": "compact", "limit": 3, "mode": "keyword"} '
-            "and Authorization: Bearer $EXOMEM_REST_API_KEY (lines 263-276); any "
-            "non-200/timeout/malformed response falls through (lines 277-286)"
+            '{"query": <prompt>, "detail": "compact", "limit": 3, "mode": "hybrid"} '
+            "and Authorization: Bearer $EXOMEM_REST_API_KEY (``_fetch_via_rest``); any "
+            "non-200/timeout/malformed response falls through (``_parse_hits`` -> None)"
         ),
     }

--- a/openspec/changes/fix-retrieve-inject-hybrid-recall/proposal.md
+++ b/openspec/changes/fix-retrieve-inject-hybrid-recall/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The retrieve hook's inject mode (`EXOMEM_RETRIEVE_INJECT=1`) is meant to append
+up to three KB routing stubs to the reminder so prior pages are in context
+before the agent decides whether to search. On a real prompt it appended
+nothing, and the log line could not tell that apart from success.
+
+Two causes, both in the hook. It queried `ask_memory` in `keyword` mode, which
+is an all-tokens-present gate over the whitespace-split query: any prompt with a
+punctuation-attached token or one term absent from every page returns zero
+hits, and every substantive prompt has both. Measured on one vault
+(2026-09-11): a two-word domain phrase 3 hits, the same phrase with a colon 0, a 3 KB
+ticket prompt 0; hybrid mode 3 relevant hits for the same prompt in 1.5 s over
+REST and 2.4 s via the CLI. On a maintainer's transcripts the stub rate was
+63% before the 0.73.1 hook refresh and 2% after. The REST rung also never ran
+on a managed install, because `EXOMEM_REST_API_KEY` is persisted only in the
+service `EnvironmentFile` and never in the client shell (#1142), so the slower
+CLI rung carried every prompt.
+
+## What Changes
+
+- The inject lane queries in hybrid mode on both rungs and reads the hit list
+  out of either REST envelope shape (`data` as a list, or `data.hits` when the
+  facade attaches a marker such as `degraded` or `warming`).
+- The REST socket timeout rises from about 2 s to 4 s; both rungs draw on one
+  shared wall-clock budget of 8 s under the registered 10 s hook timeout, and
+  a rung that would start with under 0.5 s left is skipped.
+- When `EXOMEM_REST_API_KEY` is absent from the environment, the hook reads it
+  from the managed install's `service.env` (Linux `$XDG_CONFIG_HOME/exomem/`,
+  macOS `~/Library/Application Support/Exomem/`, none on Windows;
+  `EXOMEM_SERVICE_ENV` overrides), reversing the installer's `systemd_quote`
+  escaping. A key read from disk is sent only to a loopback host; a
+  non-loopback `EXOMEM_HOST` disables the REST rung for it. A key exported into
+  the environment keeps today's behaviour.
+- The stub block is bounded by whole lines (600 chars): a line that does not
+  fit is dropped and counted in a trailing `- … N more not shown` marker, never
+  cut inside a path.
+- The session and client-wide cooldown stamps are written after the transport
+  ran, so a hook the client kills mid-ladder does not also silence the next
+  cooldown window.
+- Each fired nudge logs `lane=<rest|cli|none|off> hits=<n>` ahead of the prompt
+  head, never the key.
+
+Not in this change: `install-hook --check` reporting which inject lane is
+reachable (the second half of #1142), and the nudge firing on harness task
+notifications (#1141).
+
+## Impact
+
+- `src/exomem/_hooks/exomem_retrieve_nudge.py` and its verbatim copy under
+  `plugins/claude-code/hooks/`; `tests/test_retrieve_inject.py`;
+  `QUICKSTART.md`; `benchmarks/membench/trackc/injection_ladder.py` comments.
+- Spec `retrieve-inject-hook`: REST-first transport, CLI fallback and bounded
+  stub block requirements modified; key resolution, loopback binding, shared
+  budget, late cooldown stamp and lane logging added.
+- Hybrid recall embeds the prompt server-side (or in the CLI process), so an
+  inject-mode prompt costs about 1.2 s over REST and 2.5 s via the CLI on a
+  laptop CPU lane, against about 1 s today for a block that was always empty.

--- a/openspec/changes/fix-retrieve-inject-hybrid-recall/specs/retrieve-inject-hook/spec.md
+++ b/openspec/changes/fix-retrieve-inject-hybrid-recall/specs/retrieve-inject-hook/spec.md
@@ -1,0 +1,186 @@
+## MODIFIED Requirements
+
+### Requirement: REST-First Transport When Configured And Reachable
+
+The hook SHALL attempt exactly one `POST http://<host>:8765/api/ask_memory`
+request (`detail=compact`, `mode=hybrid`, `limit=3`, `Authorization: Bearer
+<key>`) with a socket timeout of about 4 seconds, bounded by the shared inject
+budget, before considering any other transport, whenever `EXOMEM_RETRIEVE_INJECT`
+is truthy and a key resolves (from the hook's environment, or from the managed
+install's `service.env`). `<host>` is `EXOMEM_HOST` or `127.0.0.1`. The hook
+SHALL treat any failure of that request (connection error, timeout, non-200
+status, malformed JSON, or an envelope with `success: false`) as "REST
+unreachable." The hook SHALL read the hit list from either envelope shape the
+facade emits: `data` as a list, or `data.hits` when the facade attaches a marker
+such as `degraded` or `warming`.
+
+#### Scenario: REST configured and reachable
+
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, a key resolves, and the local
+  REST facade answers with `{"success": true, "data": [...compact hits...]}` or
+  `{"success": true, "data": {"hits": [...], ...}}`
+- **THEN** the hook's `additionalContext` includes a routing-stub block built
+  from those hits
+- **AND** the CLI transport is never attempted
+
+#### Scenario: REST configured but unreachable, CLI not opted in
+
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, a key resolves, the REST request
+  fails (any of: connection error, timeout, non-200, malformed JSON,
+  `success: false`), and `EXOMEM_RETRIEVE_INJECT_CLI` is not set truthy
+- **THEN** the hook falls back to today's reminder-only `additionalContext`
+- **AND** no CLI subprocess is attempted
+
+#### Scenario: A punctuated or long prompt still finds its pages
+
+- **WHEN** the gated prompt is a pasted ticket or a sentence with a colon or a
+  comma, and the vault holds pages about its subject
+- **THEN** the request is made in hybrid mode and the block carries those pages
+- **AND** the hook never queries in keyword mode, whose all-tokens gate returns
+  nothing for such a prompt
+
+### Requirement: Opt-In CLI Transport Fallback
+
+The hook SHALL locate an installed `exomem` or `kb` console script via `PATH`
+lookup and invoke it as `ask_memory --detail compact --limit 3 --mode hybrid
+--json <prompt>` (subprocess timeout of about 5 seconds, bounded by the shared
+inject budget) whenever REST was not attempted (no key resolved, or a
+file-sourced key with a non-loopback host) or failed, and
+`EXOMEM_RETRIEVE_INJECT_CLI` is set truthy. The hook SHALL treat any failure of
+that invocation (console script not found, non-zero exit, malformed JSON,
+timeout) the same as "no hits."
+
+#### Scenario: REST unconfigured, CLI transport opted in
+
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, no key resolves, and
+  `EXOMEM_RETRIEVE_INJECT_CLI` is truthy, and an `exomem` or `kb` console script is
+  resolvable on `PATH`
+- **THEN** the hook invokes that console script's `ask_memory` command in hybrid
+  mode and, on success, includes a routing-stub block built from its compact
+  hits in `additionalContext`
+
+#### Scenario: Neither REST nor CLI transport available
+
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, no key resolves, and
+  `EXOMEM_RETRIEVE_INJECT_CLI` is not set truthy (or no `exomem`/`kb` console
+  script resolves on `PATH`)
+- **THEN** the hook falls back to today's reminder-only `additionalContext`
+- **AND** no REST request or CLI subprocess is attempted
+
+### Requirement: Injected Content Is Bounded, Stub-Only Routing Data
+
+The injected block SHALL contain only routing-stub fields already present in
+`ask_memory(detail="compact")` output (`path`, `type`, `updated`) — never
+`excerpt`, `signals`, or any other page body/text. It SHALL show at most 3 hits
+and SHALL be bounded to 600 characters by whole lines: a stub line that would
+not fit is dropped and counted in one trailing `- … N more not shown` marker
+line, and no path is ever cut. When not even the first stub line fits, the hook
+SHALL inject nothing beyond the reminder.
+
+#### Scenario: Three or fewer hits are shown verbatim
+
+- **WHEN** the active transport returns 1 to 3 compact hits whose lines fit
+  the bound
+- **THEN** the injected block contains one line per hit, in the order
+  returned, each showing only `path`, `type`, and `updated`
+- **AND** no hit's `excerpt` or `signals` (neither requested nor present in
+  compact mode) appears anywhere in the block
+
+#### Scenario: An oversized block drops whole lines, never part of a path
+
+- **WHEN** the formatted routing-stub block (3 hits, long titles/paths) would
+  exceed 600 characters
+- **THEN** the block keeps the header and the leading stub lines that fit
+  whole, followed by `- … N more not shown`
+- **AND** every path in the block is exactly a path the transport returned
+- **AND** the request itself never asked for more than 3 hits (`limit=3`)
+
+## ADDED Requirements
+
+### Requirement: REST Key Resolves From The Managed Install
+
+When `EXOMEM_REST_API_KEY` is absent from the hook's environment, the hook SHALL
+read it from the managed install's `service.env`: `$XDG_CONFIG_HOME/exomem/service.env`
+(default `~/.config/exomem/service.env`) on Linux, `~/Library/Application
+Support/Exomem/service.env` on macOS, none on Windows, with `EXOMEM_SERVICE_ENV`
+overriding the location. The read SHALL take the first `EXOMEM_REST_API_KEY=`
+line, strip one layer of matching quotes, reverse the installer's double-quote
+escaping of `\` and `"`, tolerate a leading byte-order mark, and never raise.
+The key value SHALL never appear on stdout, in the log, or in an error message.
+
+#### Scenario: Key only in service.env
+
+- **WHEN** `EXOMEM_REST_API_KEY` is unset and `service.env` holds
+  `EXOMEM_REST_API_KEY="<key>"`
+- **THEN** the REST rung runs with that key against a loopback host
+- **AND** the CLI rung is not attempted while REST is reachable
+
+#### Scenario: Environment wins over the file
+
+- **WHEN** both the environment and `service.env` carry a key
+- **THEN** the environment's value is used
+
+### Requirement: A File-Sourced Key Travels Only To Loopback
+
+A key the hook read from `service.env` SHALL be sent only when the REST host is
+a loopback literal (`127.0.0.1`, `localhost`, `::1`, `[::1]`). With any other
+`EXOMEM_HOST`, the hook SHALL not attempt the REST rung for that key and SHALL
+continue to the CLI rung or the reminder-only floor. A key present in the hook's
+environment is not subject to this bind.
+
+#### Scenario: Attacker-set host with a disk key
+
+- **WHEN** `EXOMEM_REST_API_KEY` is unset, `service.env` holds a key, and
+  `EXOMEM_HOST` names a non-loopback host
+- **THEN** no request is made to that host
+- **AND** the ladder continues to the CLI rung when opted in, else to the floor
+
+### Requirement: Both Rungs Share One Wall-Clock Budget
+
+The REST and CLI rungs SHALL draw on one budget of 8 seconds measured from the
+start of the inject attempt, each receiving at most its own timeout and at most
+the time remaining, and a rung that would start with less than 0.5 seconds left
+SHALL be skipped. The bound SHALL hold on elapsed time, not only on admission:
+the REST rung is waited for no longer than the remaining budget (its socket
+timeout is per operation and cannot bound a server that dribbles bytes), and the
+CLI subprocess timeout is the remaining budget. The budget sits under the
+10 second hook timeout the installer registers.
+
+#### Scenario: A slow REST rung shortens the CLI rung
+
+- **WHEN** the REST rung spends 3.5 seconds before failing and the CLI rung is
+  opted in
+- **THEN** the CLI subprocess runs with a timeout of about 4.5 seconds
+
+#### Scenario: A server dribbles bytes inside the socket timeout
+
+- **WHEN** the REST facade answers 200 and then emits one byte every 2 seconds
+- **THEN** the REST rung is abandoned when the budget runs out and counts as
+  failed
+- **AND** the hook prints within the budget, so the client's hook timeout is
+  never reached
+
+### Requirement: Cooldown Stamps Are Written After The Transport
+
+The per-session and client-wide cooldown stamps SHALL be written after the
+inject transport has run (or been skipped), immediately before the hook prints
+its output, so a hook the client kills mid-ladder does not consume the next
+cooldown window.
+
+#### Scenario: The client kills the hook mid-ladder
+
+- **WHEN** the hook process is terminated while a transport rung is running
+- **THEN** no cooldown stamp has been written for that prompt
+- **AND** the next qualifying prompt is nudged again
+
+### Requirement: The Log Names The Lane And The Hit Count
+
+Every fired nudge SHALL append one line to the client's retrieve-nudge log of
+the form `<timestamp> nudge fired | lane=<rest|cli|none|off> hits=<n> | <prompt head>`,
+where `none` marks a fall-through to the reminder-only floor and `off` marks
+inject mode not enabled. The line SHALL never contain the key.
+
+#### Scenario: A fall-through is visible
+
+- **WHEN** inject mode is on and neither rung returned hits
+- **THEN** the log line reads `lane=none hits=0`

--- a/openspec/changes/fix-retrieve-inject-hybrid-recall/specs/retrieve-inject-hook/spec.md
+++ b/openspec/changes/fix-retrieve-inject-hybrid-recall/specs/retrieve-inject-hook/spec.md
@@ -86,7 +86,7 @@ SHALL inject nothing beyond the reminder.
 - **AND** no hit's `excerpt` or `signals` (neither requested nor present in
   compact mode) appears anywhere in the block
 
-#### Scenario: An oversized block drops whole lines, never part of a path
+#### Scenario: An oversized block is truncated, never hit-count-limited beyond 3
 
 - **WHEN** the formatted routing-stub block (3 hits, long titles/paths) would
   exceed 600 characters

--- a/openspec/changes/fix-retrieve-inject-hybrid-recall/tasks.md
+++ b/openspec/changes/fix-retrieve-inject-hybrid-recall/tasks.md
@@ -1,0 +1,16 @@
+## 1. Hook
+
+- [x] 1.1 Red-first tests: hybrid mode on both rungs, marked REST envelope, service.env key fallback with quote un-escaping and BOM, loopback binding of a file-sourced key, shared budget, late cooldown stamp, whole-line stub bound, lane logging (`tests/test_retrieve_inject.py`).
+- [x] 1.2 Implement in `src/exomem/_hooks/exomem_retrieve_nudge.py`; keep `plugins/claude-code/hooks/exomem_retrieve_nudge.py` byte-identical.
+- [x] 1.3 Reproduce on a live local service with a 3 KB ticket prompt: original hook emits no stub block; fixed hook emits three stubs over REST (1.2 s) and via the CLI (2.5 s); a file-sourced key with a non-loopback `EXOMEM_HOST` sends nothing to that host.
+- [x] 1.4 Run `tests/test_retrieve_inject.py`, `tests/test_prominence.py` and `scripts/validate-public-artifacts.py --repository` green.
+
+## 2. Docs and neighbours
+
+- [x] 2.1 Update the QUICKSTART inject paragraph and the benchmark `injection_ladder.py` notes.
+- [x] 2.2 Author-independent review of the actual diff, with the reproduction rerun by the reviewer; correction round applied and rechecked.
+
+## 3. Follow-ups
+
+- [ ] 3.1 `install-hook --check` reports which inject lane is reachable (second half of #1142).
+- [ ] 3.2 After merge, synchronize this delta into `openspec/specs/retrieve-inject-hook/spec.md` and archive the change.

--- a/plugins/claude-code/hooks/exomem_retrieve_nudge.py
+++ b/plugins/claude-code/hooks/exomem_retrieve_nudge.py
@@ -17,11 +17,30 @@ default.)
 
 Opt-in **inject mode** (`EXOMEM_RETRIEVE_INJECT`) upgrades the reminder to real
 retrieved content: on the same gated prompt, it fetches the top compact routing
-stubs (`ask_memory(detail="compact")`, keyword mode only — no embeddings, no GPU) via a
-short transport ladder — REST first (`EXOMEM_REST_API_KEY` in this env), then an
-opt-in CLI fallback (`EXOMEM_RETRIEVE_INJECT_CLI`) — and appends them to the
-reminder. Any transport failure (or the flag being off) falls straight through to
-the reminder-only floor; the hook never blocks or raises past that point.
+stubs (`ask_memory(detail="compact", mode="hybrid")`) via a short transport
+ladder — REST first (`EXOMEM_REST_API_KEY` in this env, else read from the
+managed install's `service.env`), then an opt-in CLI fallback
+(`EXOMEM_RETRIEVE_INJECT_CLI`) — and appends them to the reminder. Any transport
+failure (or the flag being off) falls straight through to the reminder-only
+floor; the hook never blocks or raises past that point.
+
+Hybrid, not keyword: keyword mode is an all-tokens-present gate over the raw
+whitespace-split query, so a real prompt — a pasted ticket, a sentence with a
+colon or a comma, a harness notification — never passes it, and the stub block
+was silently empty on every substantive prompt (measured 2026-09-11: 0 hits for
+a 3 KB ticket prompt and for "deploy notes: rollback"; 3 relevant hits in
+hybrid mode for the same prompt, ~1.5 s over REST, ~2.4 s via the CLI). The log
+line names the lane that answered and the hit count so that fall-through is
+visible instead of indistinguishable from success.
+
+A key this hook lifts out of the managed install's `service.env` travels only
+to loopback: an `EXOMEM_HOST` that points anywhere else disables the REST rung
+for a file-sourced key (a key the user exported into the environment keeps
+today's behaviour, since they placed both). The stub block is cut by whole
+lines, never inside a path. The two rungs share one wall-clock budget under the
+registered hook timeout: the REST rung is joined against the remaining budget
+and the CLI subprocess gets the remainder as its timeout, so a slow or
+dribbling server cannot burn the reminder.
 
 Tunables (env): EXOMEM_RETRIEVE_NUDGE_DISABLE=1 (off),
 EXOMEM_RETRIEVE_NUDGE_MIN_CHARS (default 20 — short, since prompts are short and
@@ -53,6 +72,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from pathlib import Path
@@ -73,7 +93,25 @@ REMINDER = (
 # Inject-mode routing-stub block: header + up to 3 `- path (type, updated)` lines,
 # capped to keep the worst case (long titles/paths) small and predictable.
 _STUB_HEADER = "KB routing stubs — verify with `read_memory` before relying on these:"
-_STUB_BLOCK_MAX_CHARS = 400
+# Whole lines only: three readable-filename stubs run to ~140 chars each, and a
+# path cut in the middle is a fabricated path presented as a retrieved one.
+_STUB_BLOCK_MAX_CHARS = 600
+_STUB_OMITTED_LINE = "- … {n} more not shown"
+
+# Recall mode for the inject lane. See the module docstring for why this is not
+# "keyword".
+INJECT_MODE = "hybrid"
+# Hybrid recall embeds the prompt server-side; the old 2 s keyword budget was
+# measured too tight for it (1.5 s warm on a laptop CPU lane).
+REST_TIMEOUT_SECONDS = 4.0
+CLI_TIMEOUT_SECONDS = 5.0
+# One wall-clock budget shared by both rungs, under the 10 s hook timeout that
+# `install-hook` registers, leaving room for the wrapper and interpreter start.
+# A rung that would start with less than `_MIN_RUNG_SECONDS` left is skipped.
+INJECT_BUDGET_SECONDS = 8.0
+_MIN_RUNG_SECONDS = 0.5
+# A key read from disk is only ever sent to the local service.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
 
 # Local mirror of extract.py::_env_flag's truthy-parse convention. This script
 # deliberately never imports exomem (see module docstring), so the helper is
@@ -297,13 +335,19 @@ def _touch(stamp: Path) -> None:
         pass
 
 
-def _log(prompt: str) -> None:
+def _log(prompt: str, lane: str = "off", hits: int = 0) -> None:
+    """One line per fired nudge: which inject lane answered ("rest" / "cli",
+    "none" for the reminder-only floor, "off" when inject mode is not on) and
+    how many stubs it returned, then the prompt head. Never the key."""
     try:
         logp = _hook_home() / "exomem-retrieve-nudge.log"
         logp.parent.mkdir(parents=True, exist_ok=True)
         snippet = re.sub(r"\s+", " ", prompt)[:160]
         with open(logp, "a", encoding="utf-8") as f:
-            f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} nudge fired | {snippet}\n")
+            f.write(
+                f"{time.strftime('%Y-%m-%d %H:%M:%S')} nudge fired | "
+                f"lane={lane} hits={hits} | {snippet}\n"
+            )
     except Exception:  # noqa: BLE001 - hook must never break prompt submission
         pass
 
@@ -319,22 +363,30 @@ def _parse_hits(payload) -> list[dict] | None:
     if isinstance(payload, list):
         return payload
     if isinstance(payload, dict):
-        if payload.get("success") is True and isinstance(payload.get("data"), list):
-            return payload["data"]
+        if payload.get("success") is not True:
+            return None
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        # The REST facade wraps the hits in a dict whenever it attaches a marker
+        # (`degraded`, `warming`, timings, a continuation, ...); otherwise `data`
+        # is the bare list. Either shape may arrive in any mode, so both are read.
+        if isinstance(data, dict) and isinstance(data.get("hits"), list):
+            return data["hits"]
         return None
     return None
 
 
 def _fetch_via_rest(
-    prompt: str, api_key: str, limit: int = 3, timeout: float = 2.0
+    prompt: str, api_key: str, limit: int = 3, timeout: float = REST_TIMEOUT_SECONDS
 ) -> list[dict] | None:
-    """One POST to the local REST facade's `/api/ask_memory` (keyword mode, compact
+    """One POST to the local REST facade's `/api/ask_memory` (hybrid mode, compact
     detail). Returns the compact hit list, or `None` on ANY failure — connection
     error, timeout, non-200, malformed JSON, `success: false` — never raises."""
-    host = os.environ.get("EXOMEM_HOST") or "127.0.0.1"
+    host = _rest_host()
     url = f"http://{host}:8765/api/ask_memory"
     body = json.dumps(
-        {"query": prompt, "detail": "compact", "limit": limit, "mode": "keyword"}
+        {"query": prompt, "detail": "compact", "limit": limit, "mode": INJECT_MODE}
     ).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -357,7 +409,13 @@ def _fetch_via_rest(
     return _parse_hits(payload)
 
 
-def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[dict] | None:
+def _rest_host() -> str:
+    return (os.environ.get("EXOMEM_HOST") or "").strip() or "127.0.0.1"
+
+
+def _fetch_via_cli(
+    prompt: str, limit: int = 3, timeout: float = CLI_TIMEOUT_SECONDS
+) -> list[dict] | None:
     """Locate the installed `exomem`/`kb` console script and run its `ask_memory`
     subcommand. Returns the compact hit list, or `None` on ANY failure — script
     not found, non-zero exit, malformed JSON, timeout — never raises. Never falls
@@ -372,7 +430,7 @@ def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[di
                 script, "ask_memory",
                 "--detail", "compact",
                 "--limit", str(limit),
-                "--mode", "keyword",
+                "--mode", INJECT_MODE,
                 "--json", prompt,
             ],
             capture_output=True,
@@ -388,28 +446,129 @@ def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[di
     return _parse_hits(payload)
 
 
-def _gather_hits(prompt: str) -> list[dict]:
-    """Transport ladder decision: REST first (only when `EXOMEM_REST_API_KEY` is
-    set), CLI only when REST wasn't attempted/failed AND `EXOMEM_RETRIEVE_INJECT_CLI`
-    is truthy. Returns [] when neither rung is usable, or when the resolved
-    transport itself reports zero hits (caller renders that as "nothing extra")."""
-    api_key = os.environ.get("EXOMEM_REST_API_KEY", "").strip()
-    if api_key:
-        hits = _fetch_via_rest(prompt, api_key)
-        if hits is not None:  # REST reachable (even with 0 hits) -> CLI never tried
-            return hits
+def _service_env_path() -> Path | None:
+    """The managed install's service EnvironmentFile, where `install-service.sh`
+    persists `EXOMEM_REST_API_KEY` (mirrors its CONFIG_ROOT per platform).
+    `EXOMEM_SERVICE_ENV` overrides the location; Windows has no service env."""
+    explicit = os.environ.get("EXOMEM_SERVICE_ENV", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    if os.name == "nt":
+        return None
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Exomem" / "service.env"
+    base = os.environ.get("XDG_CONFIG_HOME", "").strip() or str(Path.home() / ".config")
+    return Path(base) / "exomem" / "service.env"
+
+
+def _resolve_rest_key() -> tuple[str, str]:
+    """`(key, source)`: the key from this env (`source="env"`), else from the
+    managed install's `service.env` (`source="file"`, #1142), else `("", "")`.
+    On a managed install the key lives only in the service's EnvironmentFile,
+    so the client shell never carries it and the REST rung never ran.
+
+    The file read mirrors `scripts/_service-common.sh`'s
+    `exomem_dotenv_file_value` — first `NAME=` line, one layer of matching
+    quotes stripped — and additionally reverses the `systemd_quote` escaping
+    `install-service.sh` writes inside double quotes (`\\` and `\"`). Never
+    raises; the value is never logged."""
+    from_env = os.environ.get("EXOMEM_REST_API_KEY", "").strip()
+    if from_env:
+        return from_env, "env"
+    path = _service_env_path()
+    if path is None:
+        return "", ""
+    try:
+        text = path.read_text(encoding="utf-8").lstrip("\ufeff")
+    except Exception:  # noqa: BLE001 - hook must never break prompt submission
+        return "", ""
+    for line in text.splitlines():
+        match = re.match(r"^\s*EXOMEM_REST_API_KEY\s*=\s*(.*)$", line)
+        if not match:
+            continue
+        value = match.group(1).strip()
+        if len(value) >= 2 and value[0] == value[-1] == '"':
+            value = value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+        elif len(value) >= 2 and value[0] == value[-1] == "'":
+            value = value[1:-1]
+        value = value.strip()
+        return (value, "file") if value else ("", "")
+    return "", ""
+
+
+def _rest_api_key() -> str:
+    """The resolved key alone; see `_resolve_rest_key`."""
+    return _resolve_rest_key()[0]
+
+
+def _bounded(call, budget: float):
+    """Run `call()` on a daemon thread and wait at most `budget` seconds for it.
+    Returns its result, or `None` when it has not finished in time (the thread
+    is left to end with the process; the hook exits right after printing)."""
+    box: list = []
+
+    def _run() -> None:
+        try:
+            box.append(call())
+        except Exception:  # noqa: BLE001 - hook must never break prompt submission
+            box.append(None)
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(max(0.0, budget))
+    return box[0] if box else None
+
+
+def _gather_hits_with_lane(prompt: str) -> tuple[list[dict], str]:
+    """Transport ladder decision, plus the name of the rung that answered:
+    "rest", "cli", or "none" when the ladder fell through to the reminder-only
+    floor. REST runs first when a key resolves; CLI only when REST wasn't
+    attempted or failed AND `EXOMEM_RETRIEVE_INJECT_CLI` is truthy. A resolved
+    transport that reports zero hits is still the answer (rendered as "nothing
+    extra"), so CLI is never a second opinion on REST.
+
+    A key read from `service.env` is bound to loopback: the hook must not become
+    the primitive that posts a key it lifted off disk, plus the prompt, to a host
+    named by `EXOMEM_HOST`. A key the user exported into the environment keeps
+    today's behaviour — they placed both variables.
+
+    Both rungs draw on one wall-clock budget (`INJECT_BUDGET_SECONDS`). The
+    CLI rung's `subprocess.run(timeout=)` is a wall-clock bound already; the
+    REST rung's `urlopen(timeout=)` is only a per-socket-operation timeout, so a
+    server that dribbles a byte every few seconds would never trip it (measured
+    52 s against an 8 s budget). The REST rung therefore runs on a daemon thread
+    joined against the remaining budget: past the deadline the rung counts as
+    failed and the ladder moves on, while the abandoned request dies with the
+    hook process."""
+    deadline = time.monotonic() + INJECT_BUDGET_SECONDS
+    api_key, source = _resolve_rest_key()
+    if api_key and (source == "env" or _rest_host() in _LOOPBACK_HOSTS):
+        remaining = deadline - time.monotonic()
+        if remaining >= _MIN_RUNG_SECONDS:
+            hits = _bounded(
+                lambda: _fetch_via_rest(prompt, api_key, timeout=min(REST_TIMEOUT_SECONDS, remaining)),
+                remaining,
+            )
+            if hits is not None:  # REST reachable (even with 0 hits) -> CLI never tried
+                return hits, "rest"
     if _env_flag("EXOMEM_RETRIEVE_INJECT_CLI"):
-        hits = _fetch_via_cli(prompt)
-        if hits is not None:
-            return hits
-    return []
+        remaining = deadline - time.monotonic()
+        if remaining >= _MIN_RUNG_SECONDS:
+            hits = _fetch_via_cli(prompt, timeout=min(CLI_TIMEOUT_SECONDS, remaining))
+            if hits is not None:
+                return hits, "cli"
+    return [], "none"
 
 
 def _format_inject_block(hits: list[dict]) -> str:
     """Render up to 3 compact hits as `- path (type, updated)` lines under a
-    header, truncated to ~400 chars total. `""` for no hits — the caller must
-    never inject an empty header or a "no results" placeholder. Only reads the
-    `path`/`type`/`updated` compact-dict fields (never `excerpt`/`signals`)."""
+    header, bounded to `_STUB_BLOCK_MAX_CHARS` by WHOLE lines: a line that would
+    not fit is dropped and counted in a trailing `- … N more not shown` marker,
+    never cut inside the path (a truncated path is a path that does not exist,
+    presented as retrieved). `""` for no hits, and `""` when not even the first
+    line fits — the caller must never inject an empty header or a "no results"
+    placeholder. Only reads the `path`/`type`/`updated` compact-dict fields
+    (never `excerpt`/`signals`)."""
     lines: list[str] = []
     for hit in hits[:3]:
         if not isinstance(hit, dict):
@@ -421,10 +580,23 @@ def _format_inject_block(hits: list[dict]) -> str:
         lines.append(f"- {path} ({meta})" if meta else f"- {path}")
     if not lines:
         return ""
-    block = "\n".join([_STUB_HEADER, *lines])
-    if len(block) > _STUB_BLOCK_MAX_CHARS:
-        block = block[: _STUB_BLOCK_MAX_CHARS - 1].rstrip() + "…"
-    return block
+    kept: list[str] = [_STUB_HEADER]
+    used = len(_STUB_HEADER)
+    omitted = 0
+    for index, line in enumerate(lines):
+        # Reserve room for the marker if anything after this line could be dropped.
+        marker = _STUB_OMITTED_LINE.format(n=len(lines) - index) if index < len(lines) - 1 else ""
+        reserve = len(marker) + 1 if marker else 0
+        if used + 1 + len(line) + reserve > _STUB_BLOCK_MAX_CHARS:
+            omitted = len(lines) - index
+            break
+        kept.append(line)
+        used += 1 + len(line)
+    if len(kept) == 1:
+        return ""
+    if omitted:
+        kept.append(_STUB_OMITTED_LINE.format(n=omitted))
+    return "\n".join(kept)
 
 
 def main() -> int:
@@ -464,23 +636,27 @@ def main() -> int:
     if not global_ok:  # another tab/session already got the reminder recently
         return 0
 
-    _touch(stamp)
-    if global_cooldown > 0:
-        _touch(global_stamp)
-    _log(prompt)
-
     additional_context = REMINDER
+    lane, hit_count = "off", 0
     if _env_flag("EXOMEM_RETRIEVE_INJECT"):
         # Inject mode is a payload upgrade on this same gate, not a second
         # trigger — REST/CLI are only ever attempted past this point. Any
         # unanticipated failure here must still fall through to the
         # reminder-only floor, never raise past the hook.
         try:
-            block = _format_inject_block(_gather_hits(prompt))
+            hits, lane = _gather_hits_with_lane(prompt)
+            hit_count = len(hits)
+            block = _format_inject_block(hits)
         except Exception:  # noqa: BLE001 - hook must never break prompt submission
-            block = ""
+            lane, hit_count, block = "none", 0, ""
         if block:
             additional_context = REMINDER + "\n\n" + block
+    # Stamped after the transport ran: a hook the client kills mid-ladder must
+    # not also burn the session's cooldown and the client-wide one.
+    _touch(stamp)
+    if global_cooldown > 0:
+        _touch(global_stamp)
+    _log(prompt, lane, hit_count)
 
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",

--- a/src/exomem/_hooks/exomem_retrieve_nudge.py
+++ b/src/exomem/_hooks/exomem_retrieve_nudge.py
@@ -17,11 +17,30 @@ default.)
 
 Opt-in **inject mode** (`EXOMEM_RETRIEVE_INJECT`) upgrades the reminder to real
 retrieved content: on the same gated prompt, it fetches the top compact routing
-stubs (`ask_memory(detail="compact")`, keyword mode only — no embeddings, no GPU) via a
-short transport ladder — REST first (`EXOMEM_REST_API_KEY` in this env), then an
-opt-in CLI fallback (`EXOMEM_RETRIEVE_INJECT_CLI`) — and appends them to the
-reminder. Any transport failure (or the flag being off) falls straight through to
-the reminder-only floor; the hook never blocks or raises past that point.
+stubs (`ask_memory(detail="compact", mode="hybrid")`) via a short transport
+ladder — REST first (`EXOMEM_REST_API_KEY` in this env, else read from the
+managed install's `service.env`), then an opt-in CLI fallback
+(`EXOMEM_RETRIEVE_INJECT_CLI`) — and appends them to the reminder. Any transport
+failure (or the flag being off) falls straight through to the reminder-only
+floor; the hook never blocks or raises past that point.
+
+Hybrid, not keyword: keyword mode is an all-tokens-present gate over the raw
+whitespace-split query, so a real prompt — a pasted ticket, a sentence with a
+colon or a comma, a harness notification — never passes it, and the stub block
+was silently empty on every substantive prompt (measured 2026-09-11: 0 hits for
+a 3 KB ticket prompt and for "deploy notes: rollback"; 3 relevant hits in
+hybrid mode for the same prompt, ~1.5 s over REST, ~2.4 s via the CLI). The log
+line names the lane that answered and the hit count so that fall-through is
+visible instead of indistinguishable from success.
+
+A key this hook lifts out of the managed install's `service.env` travels only
+to loopback: an `EXOMEM_HOST` that points anywhere else disables the REST rung
+for a file-sourced key (a key the user exported into the environment keeps
+today's behaviour, since they placed both). The stub block is cut by whole
+lines, never inside a path. The two rungs share one wall-clock budget under the
+registered hook timeout: the REST rung is joined against the remaining budget
+and the CLI subprocess gets the remainder as its timeout, so a slow or
+dribbling server cannot burn the reminder.
 
 Tunables (env): EXOMEM_RETRIEVE_NUDGE_DISABLE=1 (off),
 EXOMEM_RETRIEVE_NUDGE_MIN_CHARS (default 20 — short, since prompts are short and
@@ -53,6 +72,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from pathlib import Path
@@ -73,7 +93,25 @@ REMINDER = (
 # Inject-mode routing-stub block: header + up to 3 `- path (type, updated)` lines,
 # capped to keep the worst case (long titles/paths) small and predictable.
 _STUB_HEADER = "KB routing stubs — verify with `read_memory` before relying on these:"
-_STUB_BLOCK_MAX_CHARS = 400
+# Whole lines only: three readable-filename stubs run to ~140 chars each, and a
+# path cut in the middle is a fabricated path presented as a retrieved one.
+_STUB_BLOCK_MAX_CHARS = 600
+_STUB_OMITTED_LINE = "- … {n} more not shown"
+
+# Recall mode for the inject lane. See the module docstring for why this is not
+# "keyword".
+INJECT_MODE = "hybrid"
+# Hybrid recall embeds the prompt server-side; the old 2 s keyword budget was
+# measured too tight for it (1.5 s warm on a laptop CPU lane).
+REST_TIMEOUT_SECONDS = 4.0
+CLI_TIMEOUT_SECONDS = 5.0
+# One wall-clock budget shared by both rungs, under the 10 s hook timeout that
+# `install-hook` registers, leaving room for the wrapper and interpreter start.
+# A rung that would start with less than `_MIN_RUNG_SECONDS` left is skipped.
+INJECT_BUDGET_SECONDS = 8.0
+_MIN_RUNG_SECONDS = 0.5
+# A key read from disk is only ever sent to the local service.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
 
 # Local mirror of extract.py::_env_flag's truthy-parse convention. This script
 # deliberately never imports exomem (see module docstring), so the helper is
@@ -297,13 +335,19 @@ def _touch(stamp: Path) -> None:
         pass
 
 
-def _log(prompt: str) -> None:
+def _log(prompt: str, lane: str = "off", hits: int = 0) -> None:
+    """One line per fired nudge: which inject lane answered ("rest" / "cli",
+    "none" for the reminder-only floor, "off" when inject mode is not on) and
+    how many stubs it returned, then the prompt head. Never the key."""
     try:
         logp = _hook_home() / "exomem-retrieve-nudge.log"
         logp.parent.mkdir(parents=True, exist_ok=True)
         snippet = re.sub(r"\s+", " ", prompt)[:160]
         with open(logp, "a", encoding="utf-8") as f:
-            f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} nudge fired | {snippet}\n")
+            f.write(
+                f"{time.strftime('%Y-%m-%d %H:%M:%S')} nudge fired | "
+                f"lane={lane} hits={hits} | {snippet}\n"
+            )
     except Exception:  # noqa: BLE001 - hook must never break prompt submission
         pass
 
@@ -319,22 +363,30 @@ def _parse_hits(payload) -> list[dict] | None:
     if isinstance(payload, list):
         return payload
     if isinstance(payload, dict):
-        if payload.get("success") is True and isinstance(payload.get("data"), list):
-            return payload["data"]
+        if payload.get("success") is not True:
+            return None
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        # The REST facade wraps the hits in a dict whenever it attaches a marker
+        # (`degraded`, `warming`, timings, a continuation, ...); otherwise `data`
+        # is the bare list. Either shape may arrive in any mode, so both are read.
+        if isinstance(data, dict) and isinstance(data.get("hits"), list):
+            return data["hits"]
         return None
     return None
 
 
 def _fetch_via_rest(
-    prompt: str, api_key: str, limit: int = 3, timeout: float = 2.0
+    prompt: str, api_key: str, limit: int = 3, timeout: float = REST_TIMEOUT_SECONDS
 ) -> list[dict] | None:
-    """One POST to the local REST facade's `/api/ask_memory` (keyword mode, compact
+    """One POST to the local REST facade's `/api/ask_memory` (hybrid mode, compact
     detail). Returns the compact hit list, or `None` on ANY failure — connection
     error, timeout, non-200, malformed JSON, `success: false` — never raises."""
-    host = os.environ.get("EXOMEM_HOST") or "127.0.0.1"
+    host = _rest_host()
     url = f"http://{host}:8765/api/ask_memory"
     body = json.dumps(
-        {"query": prompt, "detail": "compact", "limit": limit, "mode": "keyword"}
+        {"query": prompt, "detail": "compact", "limit": limit, "mode": INJECT_MODE}
     ).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -357,7 +409,13 @@ def _fetch_via_rest(
     return _parse_hits(payload)
 
 
-def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[dict] | None:
+def _rest_host() -> str:
+    return (os.environ.get("EXOMEM_HOST") or "").strip() or "127.0.0.1"
+
+
+def _fetch_via_cli(
+    prompt: str, limit: int = 3, timeout: float = CLI_TIMEOUT_SECONDS
+) -> list[dict] | None:
     """Locate the installed `exomem`/`kb` console script and run its `ask_memory`
     subcommand. Returns the compact hit list, or `None` on ANY failure — script
     not found, non-zero exit, malformed JSON, timeout — never raises. Never falls
@@ -372,7 +430,7 @@ def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[di
                 script, "ask_memory",
                 "--detail", "compact",
                 "--limit", str(limit),
-                "--mode", "keyword",
+                "--mode", INJECT_MODE,
                 "--json", prompt,
             ],
             capture_output=True,
@@ -388,28 +446,129 @@ def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[di
     return _parse_hits(payload)
 
 
-def _gather_hits(prompt: str) -> list[dict]:
-    """Transport ladder decision: REST first (only when `EXOMEM_REST_API_KEY` is
-    set), CLI only when REST wasn't attempted/failed AND `EXOMEM_RETRIEVE_INJECT_CLI`
-    is truthy. Returns [] when neither rung is usable, or when the resolved
-    transport itself reports zero hits (caller renders that as "nothing extra")."""
-    api_key = os.environ.get("EXOMEM_REST_API_KEY", "").strip()
-    if api_key:
-        hits = _fetch_via_rest(prompt, api_key)
-        if hits is not None:  # REST reachable (even with 0 hits) -> CLI never tried
-            return hits
+def _service_env_path() -> Path | None:
+    """The managed install's service EnvironmentFile, where `install-service.sh`
+    persists `EXOMEM_REST_API_KEY` (mirrors its CONFIG_ROOT per platform).
+    `EXOMEM_SERVICE_ENV` overrides the location; Windows has no service env."""
+    explicit = os.environ.get("EXOMEM_SERVICE_ENV", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    if os.name == "nt":
+        return None
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Exomem" / "service.env"
+    base = os.environ.get("XDG_CONFIG_HOME", "").strip() or str(Path.home() / ".config")
+    return Path(base) / "exomem" / "service.env"
+
+
+def _resolve_rest_key() -> tuple[str, str]:
+    """`(key, source)`: the key from this env (`source="env"`), else from the
+    managed install's `service.env` (`source="file"`, #1142), else `("", "")`.
+    On a managed install the key lives only in the service's EnvironmentFile,
+    so the client shell never carries it and the REST rung never ran.
+
+    The file read mirrors `scripts/_service-common.sh`'s
+    `exomem_dotenv_file_value` — first `NAME=` line, one layer of matching
+    quotes stripped — and additionally reverses the `systemd_quote` escaping
+    `install-service.sh` writes inside double quotes (`\\` and `\"`). Never
+    raises; the value is never logged."""
+    from_env = os.environ.get("EXOMEM_REST_API_KEY", "").strip()
+    if from_env:
+        return from_env, "env"
+    path = _service_env_path()
+    if path is None:
+        return "", ""
+    try:
+        text = path.read_text(encoding="utf-8").lstrip("\ufeff")
+    except Exception:  # noqa: BLE001 - hook must never break prompt submission
+        return "", ""
+    for line in text.splitlines():
+        match = re.match(r"^\s*EXOMEM_REST_API_KEY\s*=\s*(.*)$", line)
+        if not match:
+            continue
+        value = match.group(1).strip()
+        if len(value) >= 2 and value[0] == value[-1] == '"':
+            value = value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+        elif len(value) >= 2 and value[0] == value[-1] == "'":
+            value = value[1:-1]
+        value = value.strip()
+        return (value, "file") if value else ("", "")
+    return "", ""
+
+
+def _rest_api_key() -> str:
+    """The resolved key alone; see `_resolve_rest_key`."""
+    return _resolve_rest_key()[0]
+
+
+def _bounded(call, budget: float):
+    """Run `call()` on a daemon thread and wait at most `budget` seconds for it.
+    Returns its result, or `None` when it has not finished in time (the thread
+    is left to end with the process; the hook exits right after printing)."""
+    box: list = []
+
+    def _run() -> None:
+        try:
+            box.append(call())
+        except Exception:  # noqa: BLE001 - hook must never break prompt submission
+            box.append(None)
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(max(0.0, budget))
+    return box[0] if box else None
+
+
+def _gather_hits_with_lane(prompt: str) -> tuple[list[dict], str]:
+    """Transport ladder decision, plus the name of the rung that answered:
+    "rest", "cli", or "none" when the ladder fell through to the reminder-only
+    floor. REST runs first when a key resolves; CLI only when REST wasn't
+    attempted or failed AND `EXOMEM_RETRIEVE_INJECT_CLI` is truthy. A resolved
+    transport that reports zero hits is still the answer (rendered as "nothing
+    extra"), so CLI is never a second opinion on REST.
+
+    A key read from `service.env` is bound to loopback: the hook must not become
+    the primitive that posts a key it lifted off disk, plus the prompt, to a host
+    named by `EXOMEM_HOST`. A key the user exported into the environment keeps
+    today's behaviour — they placed both variables.
+
+    Both rungs draw on one wall-clock budget (`INJECT_BUDGET_SECONDS`). The
+    CLI rung's `subprocess.run(timeout=)` is a wall-clock bound already; the
+    REST rung's `urlopen(timeout=)` is only a per-socket-operation timeout, so a
+    server that dribbles a byte every few seconds would never trip it (measured
+    52 s against an 8 s budget). The REST rung therefore runs on a daemon thread
+    joined against the remaining budget: past the deadline the rung counts as
+    failed and the ladder moves on, while the abandoned request dies with the
+    hook process."""
+    deadline = time.monotonic() + INJECT_BUDGET_SECONDS
+    api_key, source = _resolve_rest_key()
+    if api_key and (source == "env" or _rest_host() in _LOOPBACK_HOSTS):
+        remaining = deadline - time.monotonic()
+        if remaining >= _MIN_RUNG_SECONDS:
+            hits = _bounded(
+                lambda: _fetch_via_rest(prompt, api_key, timeout=min(REST_TIMEOUT_SECONDS, remaining)),
+                remaining,
+            )
+            if hits is not None:  # REST reachable (even with 0 hits) -> CLI never tried
+                return hits, "rest"
     if _env_flag("EXOMEM_RETRIEVE_INJECT_CLI"):
-        hits = _fetch_via_cli(prompt)
-        if hits is not None:
-            return hits
-    return []
+        remaining = deadline - time.monotonic()
+        if remaining >= _MIN_RUNG_SECONDS:
+            hits = _fetch_via_cli(prompt, timeout=min(CLI_TIMEOUT_SECONDS, remaining))
+            if hits is not None:
+                return hits, "cli"
+    return [], "none"
 
 
 def _format_inject_block(hits: list[dict]) -> str:
     """Render up to 3 compact hits as `- path (type, updated)` lines under a
-    header, truncated to ~400 chars total. `""` for no hits — the caller must
-    never inject an empty header or a "no results" placeholder. Only reads the
-    `path`/`type`/`updated` compact-dict fields (never `excerpt`/`signals`)."""
+    header, bounded to `_STUB_BLOCK_MAX_CHARS` by WHOLE lines: a line that would
+    not fit is dropped and counted in a trailing `- … N more not shown` marker,
+    never cut inside the path (a truncated path is a path that does not exist,
+    presented as retrieved). `""` for no hits, and `""` when not even the first
+    line fits — the caller must never inject an empty header or a "no results"
+    placeholder. Only reads the `path`/`type`/`updated` compact-dict fields
+    (never `excerpt`/`signals`)."""
     lines: list[str] = []
     for hit in hits[:3]:
         if not isinstance(hit, dict):
@@ -421,10 +580,23 @@ def _format_inject_block(hits: list[dict]) -> str:
         lines.append(f"- {path} ({meta})" if meta else f"- {path}")
     if not lines:
         return ""
-    block = "\n".join([_STUB_HEADER, *lines])
-    if len(block) > _STUB_BLOCK_MAX_CHARS:
-        block = block[: _STUB_BLOCK_MAX_CHARS - 1].rstrip() + "…"
-    return block
+    kept: list[str] = [_STUB_HEADER]
+    used = len(_STUB_HEADER)
+    omitted = 0
+    for index, line in enumerate(lines):
+        # Reserve room for the marker if anything after this line could be dropped.
+        marker = _STUB_OMITTED_LINE.format(n=len(lines) - index) if index < len(lines) - 1 else ""
+        reserve = len(marker) + 1 if marker else 0
+        if used + 1 + len(line) + reserve > _STUB_BLOCK_MAX_CHARS:
+            omitted = len(lines) - index
+            break
+        kept.append(line)
+        used += 1 + len(line)
+    if len(kept) == 1:
+        return ""
+    if omitted:
+        kept.append(_STUB_OMITTED_LINE.format(n=omitted))
+    return "\n".join(kept)
 
 
 def main() -> int:
@@ -464,23 +636,27 @@ def main() -> int:
     if not global_ok:  # another tab/session already got the reminder recently
         return 0
 
-    _touch(stamp)
-    if global_cooldown > 0:
-        _touch(global_stamp)
-    _log(prompt)
-
     additional_context = REMINDER
+    lane, hit_count = "off", 0
     if _env_flag("EXOMEM_RETRIEVE_INJECT"):
         # Inject mode is a payload upgrade on this same gate, not a second
         # trigger — REST/CLI are only ever attempted past this point. Any
         # unanticipated failure here must still fall through to the
         # reminder-only floor, never raise past the hook.
         try:
-            block = _format_inject_block(_gather_hits(prompt))
+            hits, lane = _gather_hits_with_lane(prompt)
+            hit_count = len(hits)
+            block = _format_inject_block(hits)
         except Exception:  # noqa: BLE001 - hook must never break prompt submission
-            block = ""
+            lane, hit_count, block = "none", 0, ""
         if block:
             additional_context = REMINDER + "\n\n" + block
+    # Stamped after the transport ran: a hook the client kills mid-ladder must
+    # not also burn the session's cooldown and the client-wide one.
+    _touch(stamp)
+    if global_cooldown > 0:
+        _touch(global_stamp)
+    _log(prompt, lane, hit_count)
 
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",

--- a/tests/test_retrieve_inject.py
+++ b/tests/test_retrieve_inject.py
@@ -42,7 +42,7 @@ hook_mod = _load_hook_module()
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Every test starts from a known-clean env — a real EXOMEM_REST_API_KEY or
     EXOMEM_RETRIEVE_INJECT already set on the host machine must never leak in. The
     legacy KB_RETRIEVE_* names are cleared too: they still alias onto the EXOMEM_*
@@ -57,6 +57,9 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "EXOMEM_RETRIEVE_INJECT_CLI",
         "EXOMEM_REST_API_KEY",
         "EXOMEM_HOST",
+        "EXOMEM_SERVICE_ENV",
+        "EXOMEM_PROMINENCE",
+        "XDG_CONFIG_HOME",
         # Legacy aliases (still honored via _normalize_env_aliases).
         "KB_RETRIEVE_NUDGE_DISABLE",
         "KB_RETRIEVE_NUDGE_MIN_CHARS",
@@ -67,6 +70,9 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "KB_RETRIEVE_INJECT_CLI",
     ):
         monkeypatch.delenv(var, raising=False)
+    # The key fallback reads the managed install's `service.env`. Point it at an
+    # absent temp file for every test so a real key on the host never leaks in.
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(tmp_path / "absent-service.env"))
 
 
 class _FakeResponse:
@@ -183,12 +189,34 @@ def test_format_inject_block_omits_missing_fields_gracefully() -> None:
     assert block.splitlines()[1] == "- Notes/only-path.md"
 
 
-def test_format_inject_block_truncates_oversized_block() -> None:
+def test_format_inject_block_drops_whole_lines_and_never_cuts_a_path() -> None:
     long_path = "Knowledge Base/" + ("very-long-segment-" * 15) + "note.md"
     hits = [{"path": long_path, "type": "note", "updated": "2026-01-01"} for _ in range(3)]
     block = hook_mod._format_inject_block(hits)
     assert len(block) <= hook_mod._STUB_BLOCK_MAX_CHARS
-    assert block.endswith("…")
+    lines = block.splitlines()
+    assert lines[0] == hook_mod._STUB_HEADER
+    stub_lines = [ln for ln in lines[1:] if not ln.startswith("- …")]
+    assert stub_lines, "at least one whole stub line must survive"
+    for ln in stub_lines:
+        assert ln == f"- {long_path} (note, 2026-01-01)", "a stub line was cut"
+    assert lines[-1] == hook_mod._STUB_OMITTED_LINE.format(n=3 - len(stub_lines))
+
+
+def test_format_inject_block_three_readable_filenames_fit_whole() -> None:
+    hits = [
+        {"path": f"Knowledge Base/Notes/Insights/{'a-readable-slug-' * 6}{i}.md", "type": "insight", "updated": "2026-09-11T19:27:00Z"}
+        for i in range(3)
+    ]
+    block = hook_mod._format_inject_block(hits)
+    assert len([ln for ln in block.splitlines() if ln.startswith("- Knowledge")]) == 3
+    assert "more not shown" not in block
+    assert len(block) <= hook_mod._STUB_BLOCK_MAX_CHARS
+
+
+def test_format_inject_block_is_empty_when_not_even_one_line_fits() -> None:
+    hits = [{"path": "x" * (hook_mod._STUB_BLOCK_MAX_CHARS + 10), "type": "note"}]
+    assert hook_mod._format_inject_block(hits) == ""
 
 
 def test_format_inject_block_never_contains_excerpt_text() -> None:
@@ -227,7 +255,7 @@ def test_fetch_via_rest_success_returns_hits(monkeypatch: pytest.MonkeyPatch) ->
         "query": "what did I conclude about X?",
         "detail": "compact",
         "limit": 3,
-        "mode": "keyword",
+        "mode": "hybrid",
     }
 
 
@@ -306,7 +334,7 @@ def test_fetch_via_cli_success_invokes_expected_command(monkeypatch: pytest.Monk
         "/usr/local/bin/exomem", "ask_memory",
         "--detail", "compact",
         "--limit", "3",
-        "--mode", "keyword",
+        "--mode", "hybrid",
         "--json", "find my thing",
     ]
     assert captured["kwargs"]["capture_output"] is True
@@ -377,7 +405,7 @@ def test_gather_hits_rest_reachable_never_calls_cli(monkeypatch: pytest.MonkeyPa
         raise AssertionError("_fetch_via_cli must not be called when REST succeeds")
 
     monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
-    assert hook_mod._gather_hits("prompt") == hits
+    assert hook_mod._gather_hits_with_lane("prompt")[0] == hits
 
 
 def test_gather_hits_rest_failing_cli_unset_is_nudge_only(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -388,7 +416,7 @@ def test_gather_hits_rest_failing_cli_unset_is_nudge_only(monkeypatch: pytest.Mo
         raise AssertionError("_fetch_via_cli must not be called when EXOMEM_RETRIEVE_INJECT_CLI is unset")
 
     monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
-    assert hook_mod._gather_hits("prompt") == []
+    assert hook_mod._gather_hits_with_lane("prompt")[0] == []
 
 
 def test_gather_hits_rest_unconfigured_cli_opted_in_uses_cli(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -400,7 +428,7 @@ def test_gather_hits_rest_unconfigured_cli_opted_in_uses_cli(monkeypatch: pytest
 
     monkeypatch.setattr(hook_mod, "_fetch_via_rest", _boom)
     monkeypatch.setattr(hook_mod, "_fetch_via_cli", lambda prompt, **kw: hits)
-    assert hook_mod._gather_hits("prompt") == hits
+    assert hook_mod._gather_hits_with_lane("prompt")[0] == hits
 
 
 def test_gather_hits_neither_configured_calls_neither_seam(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -409,7 +437,382 @@ def test_gather_hits_neither_configured_calls_neither_seam(monkeypatch: pytest.M
 
     monkeypatch.setattr(hook_mod, "_fetch_via_rest", _boom)
     monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
-    assert hook_mod._gather_hits("prompt") == []
+    assert hook_mod._gather_hits_with_lane("prompt")[0] == []
+
+
+# --- hit envelopes (_parse_hits) --------------------------------------------------
+
+
+def test_parse_hits_accepts_list_envelope() -> None:
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    assert hook_mod._parse_hits({"success": True, "data": hits}) == hits
+
+
+def test_parse_hits_accepts_marked_rest_envelope() -> None:
+    """The REST facade wraps the hits in `data: {hits, ...}` whenever it attaches
+    a marker (`degraded`, `warming`, timings, ...), in any mode; otherwise `data`
+    is the bare list. The lane must read either shape instead of falling through
+    to the CLI and paying a second search."""
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    payload = {"success": True, "data": {"hits": hits, "degraded": ["clip"]}}
+    assert hook_mod._parse_hits(payload) == hits
+
+
+def test_parse_hits_rejects_dict_without_hits() -> None:
+    assert hook_mod._parse_hits({"success": True, "data": {"degraded": []}}) is None
+
+
+def test_fetch_via_rest_reads_marked_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    body = json.dumps({"success": True, "data": {"hits": hits, "degraded": []}}).encode("utf-8")
+    monkeypatch.setattr(urllib_request, "urlopen", lambda req, timeout=None: _FakeResponse(200, body))
+    assert hook_mod._fetch_via_rest("prompt", "key") == hits
+
+
+def test_fetch_via_rest_passes_the_rest_timeout_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hybrid recall embeds the prompt server-side, so the budget is wider than
+    the old keyword lookup; the wiring, not the number, is what this pins."""
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["timeout"] = timeout
+        return _FakeResponse(200, _envelope_bytes([]))
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    hook_mod._fetch_via_rest("prompt", "key")
+    assert captured["timeout"] == hook_mod.REST_TIMEOUT_SECONDS
+    assert hook_mod.REST_TIMEOUT_SECONDS > 2.0
+
+
+# --- REST key resolution (_rest_api_key) ------------------------------------------
+
+
+def _write_service_env(path: Path, key_line: str) -> None:
+    path.write_text(
+        "EXOMEM_VAULT_PATH=some vault\n"
+        f"{key_line}\n"
+        "EXOMEM_JWT_SIGNING_KEY=other-secret\n",
+        encoding="utf-8",
+    )
+
+
+def test_rest_api_key_prefers_the_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    env_file = tmp_path / "service.env"
+    _write_service_env(env_file, "EXOMEM_REST_API_KEY=from-file")
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "from-env")
+    assert hook_mod._rest_api_key() == "from-env"
+
+
+@pytest.mark.parametrize(
+    "key_line, expected",
+    [
+        ("EXOMEM_REST_API_KEY=plain-key", "plain-key"),
+        ('EXOMEM_REST_API_KEY="double quoted"', "double quoted"),
+        ("EXOMEM_REST_API_KEY='single quoted'", "single quoted"),
+        ("  EXOMEM_REST_API_KEY = spaced ", "spaced"),
+    ],
+)
+def test_rest_api_key_falls_back_to_the_managed_service_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, key_line: str, expected: str,
+) -> None:
+    """Issue #1142: on a managed install the key lives only in the service's
+    EnvironmentFile, so the client shell never carries it and the REST lane
+    never ran. Read it the way `scripts/_service-common.sh` does: first
+    `NAME=` line, one layer of matching quotes stripped."""
+    env_file = tmp_path / "service.env"
+    _write_service_env(env_file, key_line)
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+    assert hook_mod._rest_api_key() == expected
+
+
+def test_rest_api_key_ignores_other_keys_and_comments(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    env_file = tmp_path / "service.env"
+    env_file.write_text(
+        "# EXOMEM_REST_API_KEY=commented-out\n"
+        "EXOMEM_REST_API_KEY_OLD=not-this\n"
+        "EXOMEM_JWT_SIGNING_KEY=not-this-either\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+    assert hook_mod._rest_api_key() == ""
+
+
+def test_rest_api_key_absent_file_is_empty_never_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(tmp_path / "nowhere" / "service.env"))
+    assert hook_mod._rest_api_key() == ""
+
+
+def test_service_env_path_defaults_to_xdg_config_on_posix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("EXOMEM_SERVICE_ENV", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(hook_mod.os, "name", "posix")
+    monkeypatch.setattr(hook_mod.sys, "platform", "linux")
+    assert hook_mod._service_env_path() == tmp_path / "xdg" / "exomem" / "service.env"
+
+
+def test_service_env_path_on_macos_uses_application_support(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("EXOMEM_SERVICE_ENV", raising=False)
+    monkeypatch.setattr(hook_mod.os, "name", "posix")
+    monkeypatch.setattr(hook_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(hook_mod.Path, "home", classmethod(lambda cls: tmp_path / "mac-home"))
+    assert hook_mod._service_env_path() == (
+        tmp_path / "mac-home" / "Library" / "Application Support" / "Exomem" / "service.env"
+    )
+
+
+def test_service_env_path_is_none_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_SERVICE_ENV", raising=False)
+    monkeypatch.setattr(hook_mod.os, "name", "nt")
+    assert hook_mod._service_env_path() is None
+    assert hook_mod._rest_api_key() == ""
+
+
+def test_rest_api_key_reverses_the_installers_double_quote_escaping(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """`install-service.sh` renders values through `systemd_quote`: double
+    quotes around the value, backslash and double quote escaped inside. The
+    shell reader strips only the quotes; this one also undoes the escaping, so a
+    key containing either character is the bearer the service expects."""
+    env_file = tmp_path / "service.env"
+    env_file.write_text('EXOMEM_REST_API_KEY="a\\"b\\\\c"\n', encoding="utf-8")
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+    assert hook_mod._rest_api_key() == 'a"b\\c'
+
+
+def test_rest_api_key_survives_a_byte_order_mark(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    env_file = tmp_path / "service.env"
+    env_file.write_bytes("\ufeffEXOMEM_REST_API_KEY=first-line-key\n".encode("utf-8"))
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+    assert hook_mod._rest_api_key() == "first-line-key"
+
+
+# --- a key read from disk only travels to loopback ------------------------------
+
+
+def _file_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    env_file = tmp_path / "service.env"
+    _write_service_env(env_file, "EXOMEM_REST_API_KEY=from-file")
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+
+
+def test_file_sourced_key_never_leaves_loopback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Two attacker-set variables (`EXOMEM_HOST` and `EXOMEM_RETRIEVE_INJECT`)
+    must not turn the hook into a primitive that posts a key it read off disk,
+    plus the prompt, to a host of the attacker's choosing."""
+    _file_key(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXOMEM_HOST", "10.0.0.5")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
+    hits = [{"path": "Notes/c.md", "type": "note", "updated": "2026-01-03"}]
+
+    def _boom(*a, **kw):
+        raise AssertionError("REST must not be attempted with a file-sourced key and a non-loopback host")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", _boom)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", lambda prompt, **kw: hits)
+    assert hook_mod._gather_hits_with_lane("prompt") == (hits, "cli")
+
+
+def test_file_sourced_key_with_non_loopback_host_and_no_cli_is_the_floor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    _file_key(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXOMEM_HOST", "evil.example/collect?x=")
+
+    def _boom(*a, **kw):
+        raise AssertionError("no transport may run")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", _boom)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    assert hook_mod._gather_hits_with_lane("prompt") == ([], "none")
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "[::1]", ""])
+def test_file_sourced_key_reaches_loopback_hosts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, host: str) -> None:
+    _file_key(monkeypatch, tmp_path)
+    if host:
+        monkeypatch.setenv("EXOMEM_HOST", host)
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", lambda prompt, api_key, **kw: hits)
+    assert hook_mod._gather_hits_with_lane("prompt") == (hits, "rest")
+
+
+def test_env_sourced_key_keeps_the_configured_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The user who exported the key into the client environment also chose the
+    host; that path is unchanged."""
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "from-env")
+    monkeypatch.setenv("EXOMEM_HOST", "10.0.0.5")
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    seen: dict = {}
+
+    def fake_rest(prompt, api_key, **kw):
+        seen["api_key"] = api_key
+        return hits
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", fake_rest)
+    assert hook_mod._gather_hits_with_lane("prompt") == (hits, "rest")
+    assert seen["api_key"] == "from-env"
+
+
+# --- one wall-clock budget across both rungs ------------------------------------
+
+
+def test_gather_hits_hands_each_rung_the_remaining_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "key")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
+    seen: dict = {}
+    # start, before REST, before CLI (REST took 3.5 s); the last value repeats because
+    # `hook_mod.time` is the shared stdlib module and pytest reads the clock too.
+    ticks = [100.0, 100.0, 103.5]
+    monkeypatch.setattr(hook_mod.time, "monotonic", lambda: ticks.pop(0) if len(ticks) > 1 else ticks[0])
+
+    def fake_rest(prompt, api_key, **kw):
+        seen["rest_timeout"] = kw["timeout"]
+        return None
+
+    def fake_cli(prompt, **kw):
+        seen["cli_timeout"] = kw["timeout"]
+        return []
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", fake_rest)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", fake_cli)
+    assert hook_mod._gather_hits_with_lane("prompt") == ([], "cli")
+    assert seen["rest_timeout"] == hook_mod.REST_TIMEOUT_SECONDS
+    assert seen["cli_timeout"] == pytest.approx(hook_mod.INJECT_BUDGET_SECONDS - 3.5)
+    # time already spent (3.5 s) plus what the CLI rung may still spend stays inside the budget
+    assert 3.5 + seen["cli_timeout"] <= hook_mod.INJECT_BUDGET_SECONDS + 1e-6
+
+
+def test_rest_rung_that_dribbles_past_its_socket_timeout_is_cut_at_the_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`urlopen(timeout=)` is a per-socket-operation timeout: a server that
+    returns a byte every few seconds never trips it. The ladder must still end
+    within the shared budget — measured 52 s against an 8 s budget before this
+    bound existed. This test lets the rung spend real wall-clock time."""
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "key")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
+    monkeypatch.setattr(hook_mod, "INJECT_BUDGET_SECONDS", 0.6)
+    monkeypatch.setattr(hook_mod, "_MIN_RUNG_SECONDS", 0.05)
+
+    def dribbling_rest(prompt, api_key, **kw):
+        hook_mod.time.sleep(3.0)  # the socket-level timeout never fires; only the budget can
+        return [{"path": "Notes/late.md"}]
+
+    def _boom(*a, **kw):
+        raise AssertionError("no budget is left for the CLI rung after REST overran")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", dribbling_rest)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    started = hook_mod.time.monotonic()
+    result = hook_mod._gather_hits_with_lane("prompt")
+    elapsed = hook_mod.time.monotonic() - started
+    assert result == ([], "none")
+    assert elapsed < 1.5, f"ladder ran {elapsed:.2f}s against a 0.6s budget"
+
+
+def test_gather_hits_skips_a_rung_the_budget_cannot_cover(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "key")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
+    ticks = [100.0, 100.0, 100.0 + hook_mod.INJECT_BUDGET_SECONDS - 0.1]
+    monkeypatch.setattr(hook_mod.time, "monotonic", lambda: ticks.pop(0) if len(ticks) > 1 else ticks[0])
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", lambda prompt, api_key, **kw: None)
+
+    def _boom(*a, **kw):
+        raise AssertionError("the CLI rung must be skipped when the budget is spent")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    assert hook_mod._gather_hits_with_lane("prompt") == ([], "none")
+
+
+def test_cooldown_stamp_is_written_only_after_the_transport_ran(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    """A hook the client kills mid-ladder must not also burn the session's
+    cooldown: the stamp is written after the transport, so a killed hook
+    re-nudges on the next prompt instead of going quiet for the cooldown."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
+
+    def _killed(prompt):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(hook_mod, "_gather_hits_with_lane", _killed)
+    with pytest.raises(KeyboardInterrupt):
+        _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "killed-mid-ladder"}, home)
+    assert not list((home / ".claude").glob("**/retrieve_killed-mid-ladder")), "stamp written before the transport"
+
+
+def test_gather_hits_uses_rest_when_the_key_is_only_in_service_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    env_file = tmp_path / "service.env"
+    _write_service_env(env_file, "EXOMEM_REST_API_KEY=from-file")
+    monkeypatch.setenv("EXOMEM_SERVICE_ENV", str(env_file))
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
+    seen: dict = {}
+
+    def fake_rest(prompt, api_key, **kw):
+        seen["api_key"] = api_key
+        return hits
+
+    def _boom(*a, **kw):
+        raise AssertionError("_fetch_via_cli must not run when the service.env key reaches REST")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", fake_rest)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    assert hook_mod._gather_hits_with_lane("prompt")[0] == hits
+    assert seen["api_key"] == "from-file"
+
+
+# --- the log names the lane and the hit count -------------------------------------
+
+
+def test_log_records_lane_and_hit_count_without_the_key(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    """A silent fall-through to the reminder-only floor looked identical to a
+    successful inject in the log for months; the line now says which lane
+    answered and with how many hits, and never the key."""
+    home = tmp_path / "home"
+    home.mkdir()
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret-key-value")
+    monkeypatch.setattr(urllib_request, "urlopen", lambda req, timeout=None: _FakeResponse(200, _envelope_bytes(hits)))
+
+    _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-log-lane"}, home)
+
+    log = (home / ".claude" / "exomem-retrieve-nudge.log").read_text(encoding="utf-8")
+    assert "nudge fired | lane=rest hits=1 |" in log
+    assert "secret-key-value" not in log
+
+
+def test_log_records_the_reminder_only_floor(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: None)
+
+    _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-log-floor"}, home)
+
+    log = (home / ".claude" / "exomem-retrieve-nudge.log").read_text(encoding="utf-8")
+    assert "nudge fired | lane=none hits=0 |" in log
+
+
+def test_log_records_inject_off(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-log-off"}, home)
+
+    log = (home / ".claude" / "exomem-retrieve-nudge.log").read_text(encoding="utf-8")
+    assert "nudge fired | lane=off hits=0 |" in log
 
 
 # --- end-to-end main() wiring ------------------------------------------------------


### PR DESCRIPTION
## What

The retrieve nudge's inject mode (`EXOMEM_RETRIEVE_INJECT=1`) is meant to append up to three KB routing stubs to the reminder. On a real prompt it appended nothing, and the log line could not tell that apart from success.

Two causes, both in `exomem_retrieve_nudge.py`:

1. The lane queried `ask_memory` in `keyword` mode. Server-side that is an all-tokens-present gate over `query.lower().split()` (`find.py`, `_find_keyword`): any query with a punctuation-attached token or a term absent from every page returns zero hits. Every substantive prompt has both.
2. The REST rung ran only when `EXOMEM_REST_API_KEY` was in the client's environment. On a managed install the key is persisted in the service `EnvironmentFile` (`service.env`) and nowhere else, so REST never ran (#1142) and the slower CLI rung carried every prompt.

## Change

- `INJECT_MODE = "hybrid"` on both rungs; `_parse_hits` reads `data` as a list or `data.hits` (the facade wraps hits in a dict whenever it attaches a marker such as `degraded` or `warming`, in any mode).
- `REST_TIMEOUT_SECONDS = 4.0` (was 2.0). Both rungs draw on one `INJECT_BUDGET_SECONDS = 8.0` wall-clock budget under the registered 10 s hook timeout; a rung that would start with under 0.5 s left is skipped. The bound holds on elapsed time: `urlopen(timeout=)` is per socket operation, so the REST rung runs on a daemon thread joined against the remaining budget (`_bounded`), and the CLI subprocess gets the remainder as its timeout. A server that answers 200 and dribbles one byte every 2 s cost the hook 52 s before this bound and exactly 8.0 s after (plain reminder printed, `lane=none hits=0`).
- `_resolve_rest_key()`: environment first, else the managed install's `service.env` (`$XDG_CONFIG_HOME/exomem/service.env` on Linux, `~/Library/Application Support/Exomem/service.env` on macOS, none on Windows, `EXOMEM_SERVICE_ENV` overrides). Same read as `scripts/_service-common.sh::exomem_dotenv_file_value`, plus reversal of the installer's `systemd_quote` escaping and BOM tolerance. **A key read from disk is sent only to a loopback host**: a non-loopback `EXOMEM_HOST` disables the REST rung for it, so two attacker-set environment variables cannot turn the hook into a key-and-prompt exfiltration primitive. A key exported into the environment keeps today's behaviour. The value never reaches stdout, the log, or an exception message.
- The stub block is bounded by whole lines (`_STUB_BLOCK_MAX_CHARS = 600`): a line that does not fit is dropped and counted in a trailing `- … N more not shown` marker, never cut inside a path.
- The session and client-wide cooldown stamps are written after the transport ran, so a hook the client kills mid-ladder does not also silence the next cooldown window.
- Log line: `nudge fired | lane=<rest|cli|none|off> hits=<n> | <prompt head>`.
- OpenSpec change `fix-retrieve-inject-hybrid-recall` (MODIFIED REST/CLI/bounded-block requirements; ADDED key resolution, loopback bind, shared budget, late stamp, lane logging). QUICKSTART inject paragraph and the membench `injection_ladder.py` notes updated. `plugins/claude-code/hooks/` copy byte-identical.

Not in this PR: `install-hook --check` reporting the reachable lane (second half of #1142), and #1141 (nudge on harness task notifications). The two follow-up tasks stay unchecked in `tasks.md`; the change is archived after merge.

## Measurements behind the mode change

`exomem ask_memory --detail compact --limit 3 --json`, same vault, 2026-09-11:

| query | keyword | hybrid |
|---|---|---|
| two domain words, no punctuation | 3 | 3 |
| the same two words with a colon | 0 | 3 |
| the same two words with a comma | 0 | 3 |
| a 67-character ticket title | 0 | 3 |
| a 3 KB ticket prompt | 0 | 3 (REST 1.49 s, CLI 2.4 s) |

Keyword parity between the sidecar and `EXOMEM_LEXICAL_BACKEND=python` held on every row, so the gate is by design; the hook's use of it on whole prompts is the defect. On the maintainer's transcripts the stub rate was 63% before the 0.73.1 hook refresh on 2026-09-07 and 2% after; the exact server-side change that made the gate bite between 0.53.0 and 0.73.1 is not pinned, and the fix does not depend on it.

## Verification

```
uv run --no-sync pytest -q tests/test_retrieve_inject.py tests/test_prominence.py -p no:cacheprovider
166 passed
uv run --no-sync python scripts/validate-public-artifacts.py --repository
public repository inputs clean: 4059 files, 4171 text payloads
openspec validate --all --strict   -> ✓ change/fix-retrieve-inject-hybrid-recall; pre-existing failure set unchanged
scripts/check_openspec_archive_discipline.py -> OK
```

Red first: the new or changed tests failed against the unmodified hook (`17 failed, 60 passed` in the first round), then passed. With `EXOMEM_PROMINENCE=maximal` leaking from the host shell, four pre-existing tests in this file used to fail because the autouse fixture did not clear it; the fixture now clears it and the file is green either way.

Reproduction on a live local service with the 3 KB ticket prompt (note names redacted):

```
fixed hook, REST lane (key from service.env): 1.2s
KB routing stubs — verify with `read_memory` before relying on these:
- Knowledge Base/Notes/Insights/<note-1>.md (insight, 2026-09-09)
- Knowledge Base/Notes/Insights/<note-2>.md (insight, 2026-09-07)
- Knowledge Base/Notes/Insights/<note-3>.md (insight, 2026-09-11T19:27:00Z)
nudge fired | lane=rest hits=3 | <prompt head>
fixed hook, CLI lane (service.env hidden): 2.5s, same stubs, lane=cli hits=3
file key + EXOMEM_HOST=127.0.0.2 (sink listening there): sink received nothing, lane=cli hits=3
dribbling server (200, one byte every 2 s), env key: 8.0s wall clock, lane=none hits=0, plain reminder (52 s before the bound)
original hook, same prompt: no stub block (with the key handed in via the env, REST answered 0 hits in 0.11 s)
```

Reviewed adversarially by an author-independent lane that reran the tests, the gate and the reproductions, including the exfiltration and dribbling-server ones. Round 1 returned REQUEST_CHANGES (loopback binding, Windows lane, whole-line truncation, OpenSpec delta, envelope attribution, budget, un-escaping); round 2 confirmed the exfiltration fix against nine host spellings and held on the budget being admission-only, fixed above; round 3: APPROVE, "every finding was fixed at the mechanism, not at the symptom", with the dribbling server at 8.04 s five times out of five and the new test shown red against the pre-fix code.

`tests/test_install_hook.py` has 15 pre-existing failures on `origin/main` on the maintainer's box (`hook config is unsafe or writable` under `/tmp`); the failure set is unchanged by this PR. One teardown error moves between tests across runs: the conftest state-root guard sees the live local service writing `~/.local/state/exomem/state` during the run.
