### PR TITLE
fix(provisioner): preserve lifecycle progress during capacity waits

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/repository.py
+++ b/infra/provisioner/src/exomem_provisioner/repository.py
@@ -1339,6 +1339,7 @@ class OperationRepository:
         claim_generation: int,
         checkpoint: str,
         retry_after_seconds: int,
+        capacity_wait_reason: str | None = None,
         now: datetime | None = None,
     ) -> OperationSnapshot:
         async with self._sessions.begin() as session:
@@ -1390,6 +1391,11 @@ class OperationRepository:
             operation.progress = {
                 **operation.progress,
                 "pending_count": int(operation.progress.get("pending_count", 0)) + 1,
+                **(
+                    {"last_capacity_wait_reason": capacity_wait_reason}
+                    if capacity_wait_reason is not None
+                    else {}
+                ),
             }
             operation.retry_after_seconds = retry_after_seconds
             operation.available_at = pending_at + timedelta(seconds=retry_after_seconds)

--- a/infra/provisioner/src/exomem_provisioner/worker.py
+++ b/infra/provisioner/src/exomem_provisioner/worker.py
@@ -328,7 +328,10 @@ class ProvisionerWorker:
                 await self._repository.mark_pending(
                     operation.id,
                     self._worker_id,
-                    checkpoint=block_reason,
+                    # Admission pauses scheduling; it must not replace the
+                    # durable lifecycle step needed by the next worker.
+                    checkpoint=operation.checkpoint,
+                    capacity_wait_reason=block_reason,
                     retry_after_seconds=300,
                     **claim,
                 )

--- a/infra/provisioner/tests/test_worker.py
+++ b/infra/provisioner/tests/test_worker.py
@@ -780,9 +780,76 @@ async def test_blocked_capacity_never_calls_driver_or_consumes_failure_attempt(
     assert admission.calls == [operation.id]
     assert driver.effect_count("provision", operation.id) == 0
     assert pending is not None and pending.state is OperationState.PENDING
-    assert pending.checkpoint == "capacity-user-exhausted"
+    assert pending.checkpoint == "effect-prepared"
+    assert pending.progress["last_capacity_wait_reason"] == "capacity-user-exhausted"
     assert pending.retry_after_seconds == 300
     assert pending.progress.get("failure_attempts", 0) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "checkpoint",
+    [
+        "namespace-ready",
+        "release-applied",
+        "csi-binding",
+        "volume-registration-required",
+        "volume-owned",
+    ],
+)
+async def test_capacity_pause_resumes_the_durable_provision_step(
+    worker_context: tuple[ProvisionerDatabase, OperationRepository, FakeDriver],
+    checkpoint: str,
+) -> None:
+    _, repository, _ = worker_context
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+    operation = await repository.submit(
+        "provision", "capacity-resume", _v2_request(), wire_protocol=WIRE_PROTOCOL_V2
+    )
+    claimed = await repository.claim_next("preparer", now=now)
+    assert claimed is not None and claimed.claim_token
+    await repository.mark_pending(
+        operation.id,
+        "preparer",
+        claim_token=claimed.claim_token,
+        claim_generation=claimed.claim_generation,
+        checkpoint=checkpoint,
+        retry_after_seconds=0,
+        now=now,
+    )
+
+    class ResumingDriver:
+        checkpoints: list[str] = []
+
+        async def observed_fence(self, tenant_id):
+            return 0
+
+        async def execute(self, action, request, context):
+            self.checkpoints.append(context.checkpoint)
+            return DriverPending("volume-owned", 1)
+
+    driver = ResumingDriver()
+    admission = _AllowingAdmission("capacity-live-observation-mismatch")
+    worker = ProvisionerWorker(
+        repository, driver, worker_id="capacity-worker", capacity_admission=admission
+    )
+    assert await worker.run_once(now=now)
+    paused = await repository.get_by_id(operation.id)
+    assert paused is not None and paused.state is OperationState.PENDING
+    assert paused.checkpoint == checkpoint
+    assert paused.progress["last_capacity_wait_reason"] == admission.reason
+    assert paused.progress.get("failure_attempts", 0) == 0
+    assert driver.checkpoints == []
+
+    admission.reason = None
+    resumed = ProvisionerWorker(
+        repository, driver, worker_id="replacement-worker", capacity_admission=admission
+    )
+    assert await resumed.run_once(now=now + timedelta(seconds=301))
+    assert driver.checkpoints == [checkpoint]
+    after = await repository.get_by_id(operation.id)
+    assert after is not None and after.checkpoint == "volume-owned"
+    assert after.progress["last_capacity_wait_reason"] == "capacity-live-observation-mismatch"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Temporary capacity checks overwrote provisioning checkpoints such as `namespace-ready`, so resumed workers could skip storage setup and fail before creating a PVC. Preserve the lifecycle checkpoint and retain the last capacity wait reason in progress. Regression tests cover five provisioning stages and resumption by a replacement worker.

Existing operations whose checkpoints were already overwritten still need supported recovery or cleanup before reprovisioning; this change does not reconstruct lost progress.

Validation:

- Full provisioner suite: 1,563 passed, 67 skipped, with runtime state confined to temporary directories.
- PostgreSQL 17 and governance barrier gates: 41 passed, 7 skipped; the recovery fixture's unsupported `action` argument also fails on unchanged base `e6543940`.
- Ruff, whitespace checks, and the public-artifact privacy gate passed. Independent review verified volume-worker ownership across a capacity pause.
