### PR TITLE
fix(provisioner): honor completed destruction in fleet history

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/repository.py
+++ b/infra/provisioner/src/exomem_provisioner/repository.py
@@ -15,6 +15,7 @@ from typing import Any
 from sqlalchemy import and_, case, func, or_, select, true, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import aliased
 
 from .crypto import EnvelopeCodec
 from .driver import DriverTerminal
@@ -963,11 +964,39 @@ class OperationRepository:
     ) -> tuple[FleetOperationSnapshot, ...]:
         """Decrypt requests internally and return no credential-bearing fields."""
 
+        destruction = aliased(Operation)
+        destroyed_history = (
+            select(destruction.id)
+            .where(
+                destruction.action.in_({OperationAction.DESTROY, OperationAction.DISCARD}),
+                destruction.state == OperationState.FINAL,
+                destruction.tenant_id == Operation.tenant_id,
+                or_(
+                    and_(
+                        destruction.action == OperationAction.DESTROY,
+                        destruction.cell_id.is_(None),
+                    ),
+                    destruction.cell_id == Operation.cell_id,
+                ),
+                destruction.fence_generation >= Operation.fence_generation,
+                destruction.created_at >= Operation.created_at,
+            )
+            .exists()
+        )
         observations: list[FleetOperationSnapshot] = []
         async with self._sessions() as session:
             operations = await session.scalars(
                 select(Operation)
-                .where(Operation.cell_id.is_not(None))
+                .where(
+                    Operation.cell_id.is_not(None),
+                    # A completed tenant-wide destroy has no cell ID. Apply its
+                    # scope before replaying obsolete runtime/rollback history,
+                    # without changing the ledger or hiding unfinished work.
+                    ~and_(
+                        Operation.state.in_({OperationState.FINAL, OperationState.ERROR}),
+                        destroyed_history,
+                    ),
+                )
                 .order_by(Operation.created_at, Operation.id)
             )
             for operation in operations:

--- a/infra/provisioner/tests/test_repository.py
+++ b/infra/provisioner/tests/test_repository.py
@@ -137,6 +137,129 @@ async def test_fleet_operation_projection_never_returns_request_secrets(
     assert request["tenantId"] not in repr(observation)
 
 
+async def _fleet_history_row(
+    repository: OperationRepository,
+    action: str,
+    identity: str,
+    *,
+    state: OperationState = OperationState.FINAL,
+    offset: int = 0,
+    **overrides: object,
+) -> str:
+    operation = await repository.submit(
+        action, identity, _request(operationId=identity, **overrides)
+    )
+    async with repository._sessions() as session, session.begin():
+        row = await session.get(Operation, operation.id)
+        assert row is not None
+        row.state = state
+        row.created_at = datetime(2026, 8, 21, tzinfo=UTC) + timedelta(seconds=offset)
+        row.finalized_at = row.created_at if state is OperationState.FINAL else None
+    return operation.id
+
+
+@pytest.mark.parametrize("action,cell_id", [("destroy", None), ("discard", "cell-alpha")])
+@pytest.mark.parametrize("terminal_state", [OperationState.FINAL, OperationState.ERROR])
+async def test_fleet_destroy_supersedes_terminal_history_before_runtime_replay(
+    repository: OperationRepository,
+    action: str,
+    cell_id: str | None,
+    terminal_state: OperationState,
+) -> None:
+    await _fleet_history_row(repository, "provision", "old-provision", state=terminal_state)
+    await _fleet_history_row(repository, "rollback-rollforward", "orphan-rollback", offset=1)
+    await _fleet_history_row(
+        repository,
+        action,
+        "tenant-destroy",
+        cellId=cell_id,
+        fenceGeneration=8,
+        offset=2,
+    )
+
+    assert await repository.list_fleet_operation_observations() == ()
+    async with repository._sessions() as session:
+        assert await session.scalar(select(func.count()).select_from(Operation)) == 3
+
+
+@pytest.mark.parametrize(
+    "destroy_state",
+    [
+        OperationState.PENDING,
+        OperationState.CLAIMED,
+        OperationState.ERROR,
+    ],
+)
+async def test_fleet_unfinished_or_failed_destroy_does_not_erase_desired_history(
+    repository: OperationRepository, destroy_state: OperationState
+) -> None:
+    await _fleet_history_row(repository, "provision", "old-provision")
+    await _fleet_history_row(
+        repository,
+        "destroy",
+        "tenant-destroy",
+        cellId=None,
+        fenceGeneration=8,
+        offset=1,
+        state=destroy_state,
+    )
+
+    observations = await repository.list_fleet_operation_observations()
+    assert [item.external_operation_id for item in observations] == ["old-provision"]
+
+
+@pytest.mark.parametrize("unfinished_state", [OperationState.PENDING, OperationState.CLAIMED])
+async def test_fleet_destroy_never_hides_unfinished_work(
+    repository: OperationRepository, unfinished_state: OperationState
+) -> None:
+    await _fleet_history_row(
+        repository, "provision", "unfinished-provision", state=unfinished_state
+    )
+    await _fleet_history_row(
+        repository,
+        "destroy",
+        "tenant-destroy",
+        cellId=None,
+        fenceGeneration=8,
+        offset=1,
+    )
+
+    [observation] = await repository.list_fleet_operation_observations()
+    assert observation.external_operation_id == "unfinished-provision"
+    assert observation.state is unfinished_state
+
+
+@pytest.mark.parametrize("boundary", ["tenant", "cell", "fence", "time", "null_discard"])
+async def test_fleet_destroy_cannot_supersede_uncovered_history(
+    repository: OperationRepository, boundary: str
+) -> None:
+    await _fleet_history_row(
+        repository,
+        "provision",
+        "retained-provision",
+        offset=2 if boundary == "time" else 0,
+    )
+    await _fleet_history_row(
+        repository,
+        "discard" if boundary in {"cell", "null_discard"} else "destroy",
+        "other-destroy",
+        tenantId="tenant-other" if boundary == "tenant" else "tenant-alpha",
+        cellId="cell-other" if boundary == "cell" else None,
+        fenceGeneration=7,
+        offset=1,
+    )
+    if boundary == "fence":
+        async with repository._sessions() as session, session.begin():
+            row = await session.scalar(
+                select(Operation).where(Operation.external_operation_id == "retained-provision")
+            )
+            assert row is not None
+            row.fence_generation = 8
+
+    observations = await repository.list_fleet_operation_observations()
+    assert any(item.external_operation_id == "retained-provision" for item in observations)
+
+
 @pytest.mark.asyncio
 async def test_completed_rollforward_evidence_projection_is_content_free(
     repository: OperationRepository,


### PR DESCRIPTION
Fleet inventory can fail on obsolete rollback records after tenant-wide deletion because its history reader excludes operations without a cell ID.

Apply completed destruction scope before replaying terminal history. The query preserves the operation ledger, unfinished work, and operations outside the deletion's tenant, cell, fence, or creation-time boundary. Only DESTROY can apply tenant-wide; DISCARD remains cell-scoped.

Verification: 1,577 provisioner tests passed, 67 skipped; 59 fleet/upgrade integration tests passed; all four positive DESTROY/DISCARD regression cases passed after review. Ruff, the public-artifact privacy gate, and whitespace checks passed. Independent review is complete.
