### PR TITLE
docs(hosted): bound recovery from fleet observer defects

### DIFF
--- a/docs/runbooks/hosted/runtime-upgrades.md
+++ b/docs/runbooks/hosted/runtime-upgrades.md
@@ -61,14 +61,56 @@ closed; add it only after recovering its exact retained compatibility evidence.
 
 Collect Substrate, provisioner, and Kubernetes authority in one pass:
 
-Normally the collector executes inside the installed provisioner API. For the first
-upgrade from a provisioner that predates `exomem-provisioner-fleet-observe`, verify
-the incoming provisioner candidate and set
+Normally the collector executes inside the installed provisioner API. Use the
+incoming-image path only if the installed provisioner predates
+`exomem-provisioner-fleet-observe`, or a documented history-reading defect has been
+reproduced by regression tests and repaired in the reviewed incoming candidate.
+For a repair, retain a private operator receipt beside `execution.json`, not as an
+extra field inside its closed schema. Bind the trusted-phase execution ID and
+canonical SHA-256 to the installed image, observed failure, repair source commit,
+candidate file SHA-256, and exact signed image. Verify that candidate and set
 `EXOMEM_PROVISIONER_BOOTSTRAP_IMAGE` to its exact digest-pinned image. This selects a
 one-shot, tokenless observer Job that carries no real API bearer or provider signer
 and is deleted before its observation is accepted. Never use a mutable tag or an
-image that did not pass the signed-candidate checks. Omit the option once the
-installed provisioner contains the collector.
+image that did not pass the signed-candidate checks. This is an explicit operator
+selection, not an automatic fallback for authentication, connectivity, unknown
+runtime identity, or inconsistent fleet authority. Fresh three-authority
+reconciliation remains required. After deploying the repaired provisioner, omit the
+option and require the installed collector to pass.
+
+Before **every** repair-observer Job, including a resumed attempt, reproduce the
+installed failure with the ordinary collector and record only its bounded diagnostic
+(no credentials) as `installed_failure`. Read the current API image as
+`installed_image`. Set `candidate`, `bundle`, and `candidate_bundle` to the reviewed
+incoming candidate files. Keep the reviewed receipt at
+`$operation_dir/observer-recovery-receipt.json` with the keys compared below. Run
+this check immediately before collection, in a shell that stops on any failure:
+
+```bash
+set -euo pipefail
+infra/scripts/hosted_image_candidate.py verify \
+  --candidate "$candidate" --bundle "$bundle" \
+  --candidate-bundle "$candidate_bundle"
+observer_execution=$(infra/scripts/hosted_runtime_upgrade.py inspect --execution "$execution")
+observer_candidate_sha=$(sha256sum "$candidate" | cut -d ' ' -f 1)
+jq -e --argjson execution "$observer_execution" \
+  --arg installedImage "$installed_image" --arg installedFailure "$installed_failure" \
+  --arg candidateSha256 "$observer_candidate_sha" --slurpfile candidate "$candidate" '
+  $execution.phase == "trusted" and
+  .executionId == $execution.executionId and
+  .executionSha256 == $execution.executionSha256 and
+  .installedImage == $installedImage and .installedFailure == $installedFailure and
+  .candidateSha256 == $candidateSha256 and
+  .repairSourceCommit == $candidate[0].source.commit and
+  .candidateImage == $candidate[0].image.reference
+' "$operation_dir/observer-recovery-receipt.json"
+export EXOMEM_PROVISIONER_BOOTSTRAP_IMAGE=$(jq -er '.image.reference' "$candidate")
+```
+
+A changed execution, installed image/failure, or candidate stops the attempt: obtain
+a newly reviewed receipt, not an automatic overwrite. Retain the receipt with the
+private operation evidence. After expand, use the installed observer; do not rebind
+this receipt to authorize another incoming-image Job at a later phase.
 
 The collector shells out to `kubectl`. A k3s node has no bare `kubectl` — it is
 `k3s kubectl` — so when running this on the node, put a wrapper on a private path

--- a/openspec/changes/standardize-hosted-runtime-upgrades/design.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/design.md
@@ -67,9 +67,10 @@ The inventory classifies each cell as target, legacy, reviewer-purpose, terminal
 
 Relying only on the routable table was rejected because prior out-of-band upgrades and destroy-path ghosts have already proven that one view can be stale.
 
-The first release adopting this workflow has one bootstrap asymmetry: the installed
-legacy provisioner cannot execute a collector introduced by the incoming image. In
-that case only, the inventory CLI runs the fixed observation command in a bounded
+The installed provisioner may lack the collector or contain a documented
+history-reading defect reproduced by regression tests and repaired in the reviewed
+incoming candidate. Only in those cases may the operator explicitly select the
+fixed observation command in a bounded
 one-shot Job from the exact digest-pinned, signed provisioner candidate. It derives
 only the runtime database reference, envelope-key reference, database identity, and
 current deployment-lock ConfigMap from the installed API deployment; supplies a
@@ -77,8 +78,18 @@ non-authoritative dummy API bearer; disables service-account token mounting; and
 retains the same non-root, read-only, no-capability security boundary. The Job has no
 tenant mutation command or provider signer, is deadline/TTL bounded, and must be
 deleted before its observation is accepted. Mutable or foreign images, unexpected
-deployment shapes, failed output, and failed cleanup all stop the upgrade. Once the
-installed provisioner contains the collector, the ordinary in-place path is used.
+deployment shapes, failed output, and failed cleanup all stop the upgrade. For a
+reader repair, a private operator receipt beside the closed-schema execution record
+binds its trusted-phase execution ID and canonical SHA-256 to the installed image
+and observed failure, repair source commit, candidate file SHA-256, and signed image.
+Before every Job, including a resumed attempt, the operator re-verifies the candidate
+signatures and compares those current inputs against the receipt. Changed inputs
+stop the attempt and require a newly reviewed receipt; the execution schema is not
+extended. This is not an automatic
+fallback for authentication, connectivity, unknown runtime identity, or inconsistent
+fleet authority. Fresh three-authority reconciliation remains mandatory. Once the
+repaired provisioner is deployed, the ordinary in-place path must pass without the
+bootstrap-image option.
 
 Provisioner operation history outlives destroyed tenants. The observer therefore
 validates every stored runtime identity structurally while deferring catalog

--- a/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
+++ b/openspec/changes/standardize-hosted-runtime-upgrades/specs/hosted-runtime-upgrade/spec.md
@@ -83,6 +83,16 @@ Before expand deployment or any cell rollforward, the workflow SHALL reconcile S
 - **AND** it receives no API bearer, provider signer, Kubernetes service-account token, tenant credential, or mutation command
 - **AND** inventory is refused if the Job, its fixed security shape, its output, or its cleanup cannot be proven
 
+#### Scenario: The installed observer has a reproduced history-reading defect
+
+- **WHEN** the installed fleet-observation command fails because of a documented history-reading defect reproduced by regression tests, and the reviewed incoming provisioner candidate contains its verified repair
+- **THEN** the operator MAY explicitly select the same bounded incoming-candidate observation Job with all of the preceding credential, command, security-shape, output, and cleanup restrictions unchanged
+- **AND** a private operator receipt beside, not inside, the closed-schema execution record binds its trusted-phase execution ID and canonical SHA-256 to the installed image and observed failure, repair source commit, candidate file SHA-256, and exact signed image before the Job runs
+- **AND** before every such Job, including a resumed attempt, candidate signature verification and comparison against the receipt must pass for the current execution, installed failure/image, and candidate; changed inputs require a newly reviewed receipt
+- **AND** this is not an automatic fallback for authentication, connectivity, unknown runtime identity, or inconsistent fleet authority
+- **AND** fresh Substrate, provisioner, and Kubernetes observations must still reconcile before deployment; failed output or cleanup blocks the upgrade
+- **AND** after the repaired provisioner is deployed, the ordinary installed-command path must pass without the bootstrap-image option
+
 #### Scenario: Destroyed operation history names an older runtime
 
 - **WHEN** a finalized destroy or discard removes the last desired, unfinished, and cluster dependency on an older reviewed runtime


### PR DESCRIPTION
Allow the isolated signed-candidate observer Job when a regression-tested history-reading defect blocks the installed observer. Bind each attempt to a private receipt containing the trusted execution hash, installed failure and exact repaired candidate. Require ordinary installed observation after deployment.

Verification: changed OpenSpec validates; 59 fleet and runtime-upgrade tests pass; public-artifact privacy and whitespace checks pass; independent review is clear.