### PR TITLE
test(e2e): await each relation profile graph snapshot

### DIFF
--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -595,8 +595,8 @@ async def _await_graph_convergence(
             reason = graph.get("reason") if isinstance(graph, dict) else "no graph in response"
             raise RuntimeError(
                 f"graph did not converge within {_GRAPH_CONVERGENCE_SECONDS:.0f}s of "
-                f"the write that changed it for {traversal_profile!r} ({reason!r}) -- a rebuild that never "
-                f"lands is exactly what this waits for. Server-side state: "
+                f"the write that changed it for {traversal_profile!r} ({reason!r}) -- "
+                "a rebuild that never lands is exactly what this waits for. Server-side state: "
                 f"{_server_side_graph_state()}. Response: {context!r}"
             )
         await asyncio.sleep(_GRAPH_POLL_SECONDS)

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -561,7 +561,8 @@ async def _await_graph_convergence(
     *,
     relation_ref: str,
     timeout: float,
-) -> None:
+    traversal_profile: str = "epistemic",
+) -> dict[str, Any]:
     """Poll a relation context until its graph is published, or fail saying so.
 
     Before the graph came off the write path, the write's own join meant the
@@ -583,18 +584,18 @@ async def _await_graph_convergence(
                 "operation": "context",
                 "path": relation_ref,
                 "depth": 1,
-                "traversal_profile": "epistemic",
+                "traversal_profile": traversal_profile,
             },
             timeout,
         )
         graph = context.get("graph")
         if isinstance(graph, dict) and graph.get("available") is True:
-            return
+            return context
         if time.monotonic() >= deadline:
             reason = graph.get("reason") if isinstance(graph, dict) else "no graph in response"
             raise RuntimeError(
                 f"graph did not converge within {_GRAPH_CONVERGENCE_SECONDS:.0f}s of "
-                f"the write that changed it ({reason!r}) -- a rebuild that never "
+                f"the write that changed it for {traversal_profile!r} ({reason!r}) -- a rebuild that never "
                 f"lands is exactly what this waits for. Server-side state: "
                 f"{_server_side_graph_state()}. Response: {context!r}"
             )
@@ -607,29 +608,23 @@ async def _assert_relation_contexts(
     relation_ref: str,
     timeout: float,
 ) -> None:
-    await _await_graph_convergence(client, relation_ref=relation_ref, timeout=timeout)
     expected = {
         "epistemic": ("science.replicates", "supports"),
         "provenance": ("records.traces_to", "derived_from"),
         "causal": ("systems.triggers", "causes"),
     }
     for profile, (canonical, parent) in expected.items():
-        context = await _call(
+        # A later drain can invalidate the graph between profile reads. Assert
+        # the same ready response we waited for, without another read race.
+        context = await _await_graph_convergence(
             client,
-            "connect_memory",
-            {
-                "operation": "context",
-                "path": relation_ref,
-                "depth": 1,
-                "traversal_profile": profile,
-            },
-            timeout,
+            relation_ref=relation_ref,
+            timeout=timeout,
+            traversal_profile=profile,
         )
         graph = context.get("graph", {})
         if not isinstance(graph, dict):
-            raise RuntimeError(
-                f"installed context returned no graph for {profile!r}: {context!r}"
-            )
+            raise RuntimeError(f"installed context returned no graph for {profile!r}: {context!r}")
         profile_data = graph.get("profile", {})
         if not isinstance(profile_data, dict) or profile_data.get("name") != profile:
             raise RuntimeError(

--- a/tests/test_product_e2e_helpers.py
+++ b/tests/test_product_e2e_helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import json
 import socket
@@ -12,6 +13,93 @@ SPEC = importlib.util.spec_from_file_location("e2e_product_loop_under_test", SCR
 assert SPEC is not None and SPEC.loader is not None
 e2e_product_loop = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(e2e_product_loop)
+
+
+@pytest.mark.parametrize("interrupted_profile", ["epistemic", "provenance", "causal"])
+def test_relation_contexts_wait_for_each_profile_snapshot(monkeypatch, interrupted_profile):
+    calls = []
+    unavailable_sent = False
+    expected = {
+        "epistemic": ("science.replicates", "supports"),
+        "provenance": ("records.traces_to", "derived_from"),
+        "causal": ("systems.triggers", "causes"),
+    }
+
+    async def call(_client, _tool, arguments, _timeout):
+        nonlocal unavailable_sent
+        profile = arguments["traversal_profile"]
+        calls.append(profile)
+        # The first graph can be ready before a later drain starts.
+        if profile == interrupted_profile and not unavailable_sent:
+            unavailable_sent = True
+            return {"graph": {"available": False, "reason": "graph sidecar unavailable"}}
+        canonical, parent = expected[profile]
+        return {
+            "graph": {
+                "available": True,
+                "profile": {"name": profile},
+                "edges": [
+                    {
+                        "relation_type": canonical,
+                        "parent_relation": parent,
+                        "registry_status": "extension",
+                        "raw_relation": canonical,
+                    }
+                ],
+            }
+        }
+
+    monkeypatch.setattr(e2e_product_loop, "_call", call)
+    monkeypatch.setattr(e2e_product_loop, "_GRAPH_POLL_SECONDS", 0)
+    asyncio.run(
+        e2e_product_loop._assert_relation_contexts(
+            object(),
+            relation_ref="example",
+            timeout=1,
+        )
+    )
+    assert calls.count(interrupted_profile) >= 2
+    assert set(calls) == set(expected)
+
+
+def test_relation_contexts_still_fail_when_a_profile_never_recovers(monkeypatch):
+    async def call(_client, _tool, arguments, _timeout):
+        return {"graph": {"available": False, "reason": "graph sidecar unavailable"}}
+
+    monkeypatch.setattr(e2e_product_loop, "_call", call)
+    monkeypatch.setattr(e2e_product_loop, "_GRAPH_CONVERGENCE_SECONDS", 0)
+    monkeypatch.setattr(e2e_product_loop, "_server_side_graph_state", lambda: "isolated fixture")
+    with pytest.raises(RuntimeError, match="graph did not converge"):
+        asyncio.run(
+            e2e_product_loop._assert_relation_contexts(
+                object(),
+                relation_ref="example",
+                timeout=1,
+            )
+        )
+
+
+def test_relation_contexts_do_not_retry_an_available_graph_with_wrong_edges(monkeypatch):
+    async def call(_client, _tool, arguments, _timeout):
+        return {
+            "graph": {
+                "available": True,
+                "profile": {
+                    "name": arguments["traversal_profile"],
+                },
+                "edges": [],
+            }
+        }
+
+    monkeypatch.setattr(e2e_product_loop, "_call", call)
+    with pytest.raises(RuntimeError, match="omitted science.replicates"):
+        asyncio.run(
+            e2e_product_loop._assert_relation_contexts(
+                object(),
+                relation_ref="example",
+                timeout=1,
+            )
+        )
 
 
 class _Hit(RootModel[dict[str, object]]):


### PR DESCRIPTION
The installed-wheel E2E journey could fail when the background graph drain began between relation-profile checks. Wait for each profile's graph response and assert that same response, preserving the convergence deadline and strict relation checks.

Validation: 46 E2E helper and Records tests passed; the installed-wheel stdio, HTTP and two-replica journey passed in 93 seconds. Regression cases cover temporary unavailability for each profile, permanent unavailability and incorrect edges. Ruff and the repository privacy gate passed.
