### PR TITLE
fix(service): preserve queued request cancellation on Python 3.11

### DIFF
--- a/src/exomem/service_ingress.py
+++ b/src/exomem/service_ingress.py
@@ -285,7 +285,10 @@ class ServiceIngress:
                     await _undispatched(send, 408, "body read timed out")
                     return None, b""
                 try:
-                    message = await asyncio.wait_for(receive(), remaining)
+                    # Keep cancellation on this task: Python 3.11 wait_for can
+                    # swallow it when the child finishes in the same turn.
+                    async with asyncio.timeout(remaining):
+                        message = await receive()
                 except TimeoutError:
                     await _undispatched(send, 408, "body read timed out")
                     return None, b""
@@ -310,7 +313,8 @@ class ServiceIngress:
                 await _undispatched(send, 503, "queue wait timed out", bytes(body))
                 return None, b""
             try:
-                await asyncio.wait_for(self._ready.wait(), remaining)
+                async with asyncio.timeout(remaining):
+                    await self._ready.wait()
             except TimeoutError:
                 await _undispatched(send, 503, "queue wait timed out", bytes(body))
                 return None, b""

--- a/tests/test_corpus_context_flight_join.py
+++ b/tests/test_corpus_context_flight_join.py
@@ -438,7 +438,7 @@ _DECLARED_UNBOUNDED_JOINS = {
         "service_ingress.py",
         "ServiceIngress._queue",
         "self._ready.wait",
-    ): "enclosed by asyncio.wait_for with the remaining 45-second admission budget",
+    ): "enclosed by asyncio.timeout with the remaining 45-second admission budget",
     (
         "service_ingress.py",
         "ServiceIngress.detach_streams",

--- a/tests/test_service_ingress.py
+++ b/tests/test_service_ingress.py
@@ -497,6 +497,56 @@ def test_cancelled_queued_get_releases_stream_slot() -> None:
     asyncio.run(scenario())
 
 
+@pytest.mark.parametrize("method", ["GET", "POST"])
+@pytest.mark.parametrize("phase", ["body", "ready"])
+def test_queue_cancellation_wins_when_wait_completes(method: str, phase: str) -> None:
+    async def scenario() -> None:
+        calls: list[str] = []
+        sent: list[dict] = []
+        waiting = asyncio.Event()
+
+        class ObservedReady(asyncio.Event):
+            async def wait(self) -> bool:
+                waiting.set()
+                return await super().wait()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.method)
+            return httpx.Response(204)
+
+        async def receive() -> dict:
+            if phase == "body":
+                # Cancel the outer request in the same event-loop turn as
+                # body completion, before its completed wait resumes.
+                asyncio.get_running_loop().call_soon(first.cancel)
+            return {"type": "http.request", "body": b"payload", "more_body": False}
+
+        async def send(message: dict) -> None:
+            sent.append(message)
+
+        async with _client(handler) as client:
+            ingress = ServiceIngress(IngressLimits(stream_requests=1, queue_timeout=0.1))
+            ingress._ready = ObservedReady()
+            ingress.resume(client)
+            ingress.pause()
+            first = asyncio.create_task(ingress(_scope(method), receive, send))
+            if phase == "ready":
+                await waiting.wait()
+                ingress.resume()
+                first.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+            assert calls == []
+            assert sent == []
+            assert ingress.stats["queued"] == ingress.stats["queued_bytes"] == 0
+            ingress.resume()
+            assert (await _call(ingress, scope=_scope(method)))[0]["status"] == 204
+            assert calls == [method]
+            await ingress.aclose()
+
+    asyncio.run(scenario())
+
+
 def test_upstream_redirect_is_not_followed_even_if_client_default_is_enabled() -> None:
     async def scenario() -> None:
         calls: list[str] = []


### PR DESCRIPTION
Cancelling a queued HTTP request while its body read or worker-ready wait completed could be swallowed on Python 3.11, retaining its admission slot or forwarding the cancelled request. Use task-local timeout scopes so cancellation propagates and releases queued bytes and stream capacity.

Four deterministic GET/POST race cases failed before the fix. The ingress, manager, upgrade and wait-inventory tests now pass on Python 3.11 and 3.13: 60 tests per version. Independent review, lint and the public-artifact privacy check passed.
